### PR TITLE
feat: change sysctl to create a file

### DIFF
--- a/schema/zarf-v1alpha1-cluster-schema.json
+++ b/schema/zarf-v1alpha1-cluster-schema.json
@@ -174,7 +174,10 @@
       "required": [
         "address",
         "user",
-        "port"
+        "port",
+        "useHttps",
+        "insecure",
+        "useNtlm"
       ],
       "type": "object"
     },

--- a/schema/zarf-v1alpha1-distro-package-schema.json
+++ b/schema/zarf-v1alpha1-distro-package-schema.json
@@ -473,7 +473,14 @@
         },
         "sysctl": {
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "type": "object"
         }

--- a/src/api/zarf.dev/v1alpha1/cluster/host.go
+++ b/src/api/zarf.dev/v1alpha1/cluster/host.go
@@ -66,7 +66,7 @@ type ZarfHost struct {
 	PrivateAddress   string             `json:"privateAddress,omitempty"`
 	PrivateInterface string             `json:"privateInterface,omitempty"`
 	Profile          string             `json:"profile,omitempty"`
-	Role             string             `json:"role" jsonschema:"enum=controller,enum=controller+worker,enum=single,enum=worker"`
+	Role             string             `json:"role" jsonschema:"required,enum=controller,enum=controller+worker,enum=single,enum=worker"`
 	//keep-sorted end
 	Configurer os.Configurer    `json:"-"`
 	Metadata   ZarfHostMetadata `json:"-"`

--- a/src/internal/gendocs/main.go
+++ b/src/internal/gendocs/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package main is used to generate the markdown docs for the cli
+// Package main is used to generate the markdown docs for the cli
 package main
 
 import (

--- a/src/internal/schema/generate.go
+++ b/src/internal/schema/generate.go
@@ -45,6 +45,14 @@ type schema struct {
 	keyNamer     func(string) string
 }
 
+type t struct {
+	T string `json:"type"`
+}
+
+type o struct {
+	O []t `json:"oneOf"`
+}
+
 func main() {
 	var sch = []schema{
 		{
@@ -150,16 +158,20 @@ func generateV1Alpha1Schema(v any, path []string, key func(string) string) ([]by
 
 	// clean up the rig.OpenSSH properties for schema
 	if defObj, ok := schemaMap["$defs"].(map[string]any); ok {
-		if sshObj, ok := defObj["WinRM"].(map[string]any); ok {
-			sshObj["required"] = []string{
-				"address",
-				"user",
-				"port",
-			}
-		}
-		if sshObj, ok := defObj["ZarfHost"].(map[string]any); ok {
-			sshObj["required"] = []string{
-				"role",
+		if obj, ok := defObj["ZarfDistroOS"].(map[string]any); ok {
+			if obj, ok := obj["properties"].(map[string]any); ok {
+				if obj, ok := obj["sysctl"].(map[string]any); ok {
+					obj["additionalProperties"] = o{
+						O: []t{
+							{
+								T: "string",
+							},
+							{
+								T: "number",
+							},
+						},
+					}
+				}
 			}
 		}
 	}

--- a/src/pkg/phase/00_generic_phase.go
+++ b/src/pkg/phase/00_generic_phase.go
@@ -19,7 +19,7 @@
 // limitations under the License.
 
 // Package phase is all the various phases used for bootstrapping a cluster.
-// The phase files are named in a rough order used during and install;
+// The phase files are named in a rough order used during an install;
 // - 0x are for preconnection resources, along with ssh-ing into the node
 // - 1x are used to gather information and start the prep-work for the cluster
 // - 2x are for installing files for the distro engine, e.i. rpm's, apt's, or binary files

--- a/src/pkg/phase/13_prepare_host.go
+++ b/src/pkg/phase/13_prepare_host.go
@@ -26,11 +26,13 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1/cluster"
 	"github.com/colonel-byte/cargoship/src/pkg/retry"
 	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/exec"
 	"github.com/k0sproject/rig/os"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
 )
@@ -75,8 +77,11 @@ func (p *PrepareHosts) prepareHost(ctx context.Context, h *cluster.ZarfHost) err
 
 	if len(p.manager.Distro.Spec.Config.OS.Sysctl) > 0 {
 		logger.From(ctx).Info("updating sysctls", "host", h)
-		if err := p.updateSysctls(ctx, h); err != nil {
-			return fmt.Errorf("failed to updated sysctls: %w", err)
+		if err := p.updateSysctlConfig(ctx, h); err != nil {
+			return fmt.Errorf("failed to create sysctls config: %w", err)
+		}
+		if err := h.Exec("sysctl --system", exec.Sudo(h)); err != nil {
+			return fmt.Errorf("failed apply the new sysctls: %w", err)
 		}
 	}
 
@@ -110,21 +115,23 @@ func (p *PrepareHosts) updateEnvironment(ctx context.Context, h *cluster.ZarfHos
 	})
 }
 
-func (p *PrepareHosts) updateSysctls(ctx context.Context, h *cluster.ZarfHost) error {
+func (p *PrepareHosts) updateSysctlConfig(ctx context.Context, h *cluster.ZarfHost) error {
+	var sb strings.Builder
+
 	keys := make([]string, 0, len(p.GetDistro().Spec.Config.OS.Sysctl))
 	for k := range p.GetDistro().Spec.Config.OS.Sysctl {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+	w := tabwriter.NewWriter(&sb, 1, 1, 1, ' ', 0)
+	fmt.Fprintln(w, "# sysctl generated from cargoship")
 
-	for k := range keys {
-		err := h.Configurer.SetSysctlValue(h, keys[k], p.GetDistro().Spec.Config.OS.Sysctl[keys[k]])
-		if err != nil {
-			logger.From(ctx).Warn("got error when setting sysctl value", "host", h, "key", keys[k], "error", err)
-		} else {
-			logger.From(ctx).Debug("updating sysctls", "host", h, "key", keys[k])
-		}
+	for _, key := range keys {
+		fmt.Fprintf(w, "%s\t=\t%s\n", key, p.GetDistro().Spec.Config.OS.Sysctl[key])
+	}
+	if err := w.Flush(); err != nil {
+		logger.From(ctx).Warn("failed to render sysctl tables")
 	}
 
-	return nil
+	return h.WriteFile("/etc/sysctl.d/99-cargoship.conf", sb.String(), "0644")
 }

--- a/src/types/os/interface.go
+++ b/src/types/os/interface.go
@@ -48,7 +48,6 @@ type Configurer interface {
 	FileContains(os.Host, string, string) bool
 	FileExist(os.Host, string) bool
 	GetDistroService(string) (string, error)
-	GetSysctlValue(os.Host, string) (string, error)
 	HTTPStatus(os.Host, string) (int, error)
 	HostPath(string) string
 	Hostname(os.Host) string
@@ -68,7 +67,6 @@ type Configurer interface {
 	ServiceIsRunning(os.Host, string) bool
 	ServiceScriptPath(os.Host, string) (string, error)
 	SetPath(string, string)
-	SetSysctlValue(os.Host, string, string) error
 	Sha256sum(h os.Host, path string, opts ...exec.Option) (string, error)
 	StartService(os.Host, string) error
 	Stat(os.Host, string, ...exec.Option) (*os.FileInfo, error)

--- a/src/types/os/linux.go
+++ b/src/types/os/linux.go
@@ -307,22 +307,3 @@ func (l *Linux) GetDistroService(key string) (string, error) {
 func (l *Linux) SetPath(key, value string) {
 	l.paths[key] = value
 }
-
-// SetSysctlValue sets the sysctl key with the given value, will return if any errors are set
-func (l *Linux) SetSysctlValue(h os.Host, key string, value string) error {
-	return h.Execf(`sysctl -w %s=%s`, key, value, exec.Sudo(h))
-}
-
-// GetSysctlValue get the current value of a sysctl value, will return an error if the key does not exist
-func (l *Linux) GetSysctlValue(h os.Host, key string) (string, error) {
-	output, err := h.ExecOutputf(`sysctl "%s"`, key)
-	if err != nil {
-		return "", err
-	}
-	sp := strings.Split(output, "=")
-	if len(sp) > 1 {
-		return strings.TrimSpace(sp[1]), nil
-	}
-
-	return "", nil
-}


### PR DESCRIPTION
Instead of using the `sysctl` command to update the system, we now create a sysctl config file:

`/etc/sysctl.d/99-cargoship.conf`

This allows the sysctl to persist across reboots
