### PR TITLE
feat(distro): update the upgrade logic for rancher

### DIFF
--- a/.dagger/build-local.go
+++ b/.dagger/build-local.go
@@ -57,10 +57,11 @@ func (m *Cargoship) BuildLocal(
 	gitCommit, _ := builder.WithExec([]string{"git", "rev-parse", "--short", "HEAD", "--always"}).Stdout(ctx)
 
 	ldflagsArgs := LDFlags(ctx, m.AppVersion, gitCommit)
+	gcflagsArgs := GCFLags(ctx)
 
 	builder = builder.WithExec([]string{
 		"sh", "-c",
-		fmt.Sprintf(`go build -v -ldflags "%s" -o /bin/%s /src/main.go`, ldflagsArgs, binName),
+		fmt.Sprintf(`go build -a -gcflags=all="%s" -ldflags "%s" -o /bin/%s /src/main.go`, gcflagsArgs, ldflagsArgs, binName),
 	})
 	return builder.File("/bin/" + binName)
 }

--- a/.dagger/utils.go
+++ b/.dagger/utils.go
@@ -25,13 +25,25 @@ import (
 	"strings"
 )
 
-func LDFlags(ctx context.Context, version string, commit string) string {
+func LDFlags(_ context.Context, version string, commit string) string {
 	return strings.TrimSpace(
 		fmt.Sprintf(
-			"-X github.com/colonel-byte/cargoship/src/config.CLIVersion=%s "+
+			"-s -w "+
+				"-X github.com/colonel-byte/cargoship/src/config.CLIVersion=%s "+
 				"-X github.com/colonel-byte/cargoship/src/config.CLICommit=%s ",
 			version,
 			commit,
 		),
+	)
+}
+
+func GCFLags(_ context.Context) string {
+	return strings.Join(
+		[]string{
+			"-l",
+			"-B",
+			"-C",
+		},
+		" ",
 	)
 }

--- a/src/types/distrocfg/rancher_common.go
+++ b/src/types/distrocfg/rancher_common.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1/cluster"
 	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1/distro"
@@ -234,8 +235,19 @@ func (d *RancherCommon) stopService(h *cluster.ZarfHost, ser string, killall str
 			return err
 		}
 	}
+	cache := false
+	cacheFile := fmt.Sprintf("%s/agent/images/.cache.json", d.Data)
+	if h.Configurer.FileExist(h, cacheFile) {
+		cache = true
+		if err := h.Configurer.DeleteFile(h, cacheFile); err != nil {
+			return err
+		}
+	}
 	if h.Configurer.CommandExist(h, killall) {
 		return h.Exec(killall, exec.Sudo(h))
+	}
+	if cache {
+		h.Configurer.Touch(h, cacheFile, time.Unix(0, 0)) //nolint:errcheck
 	}
 	return nil
 }


### PR DESCRIPTION
I have noticed that when trying to run upgrades on the rke2 packages, that sometimes containerd would not import the new images tar balls.
This PR deletes the cache file, if present, then recreates it so that the rke2 service can properly import the new images.

This pr also updates the dagger build to include some compile flags that help to reduce the size of the binary a good bit