### PR TITLE
feat: add shell completion for flags

### DIFF
--- a/src/cmd/flag.go
+++ b/src/cmd/flag.go
@@ -1,0 +1,37 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/colonel-byte/cargoship/src/cmd/flags"
+	"github.com/colonel-byte/cargoship/src/config/lang"
+	"github.com/colonel-byte/cargoship/src/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// registerFlagOCIConcurrency adds the OCI concurrency flag to cmd, with its default sourced
+// from config and shell completion suggestions provided by flags.RegisterOCIConcurrency.
+func registerFlagOCIConcurrency(cmd *cobra.Command, con *int) error {
+	cmd.Flags().IntVar(con, PackageOCIConcurrency, v.GetInt(types.DistroOCIConcurrency), lang.CmdPackageFlagConcurrency)
+	return cmd.RegisterFlagCompletionFunc(PackageOCIConcurrency, flags.RegisterOCIConcurrency)
+}
+
+// registerFlagOutputFormat adds the output format flag to cmd, backed by format, with shell
+// completion suggestions provided by flags.RegisterOutputFormat.
+func registerFlagOutputFormat(cmd *cobra.Command, format pflag.Value) error {
+	cmd.Flags().VarP(format, MiscOutput, "o", lang.CmdVersionOutputFromat)
+	return cmd.RegisterFlagCompletionFunc(MiscOutput, flags.RegisterOutputFormat)
+}

--- a/src/cmd/flags/misc.go
+++ b/src/cmd/flags/misc.go
@@ -1,0 +1,40 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package flags provides shell completion functions for cargoship CLI flags.
+package flags
+
+import (
+	"fmt"
+
+	"github.com/colonel-byte/cargoship/src/config"
+	"github.com/spf13/cobra"
+)
+
+// RegisterOutputFormat provides shell completion suggestions for the output format flag.
+func RegisterOutputFormat(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return getOutputFormat(), cobra.ShellCompDirectiveNoFileComp
+}
+
+const (
+	outputFormatJSONDescription = "output as JSON"
+	outputFormatYAMLDescription = "output as YAML"
+)
+
+func getOutputFormat() []string {
+	return []string{
+		fmt.Sprintf("%s\t%s", string(config.OutputFromatJSON), outputFormatJSONDescription),
+		fmt.Sprintf("%s\t%s", string(config.OutputFromatYAML), outputFormatYAMLDescription),
+	}
+}

--- a/src/cmd/flags/package.go
+++ b/src/cmd/flags/package.go
@@ -1,0 +1,40 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// RegisterOCIConcurrency provides shell completion suggestions for the OCI concurrency flag.
+func RegisterOCIConcurrency(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return getOCIConcurrency(), cobra.ShellCompDirectiveNoFileComp
+}
+
+const (
+	ociConcurrencyMinimumDescription = "minimum: safest for rate-limited or unstable registries"
+	ociConcurrencyDefaultDescription = "default: balanced for most registries"
+	ociConcurrencyMaximumDescription = "recommended upper limit: risks registry throttling above this"
+)
+
+func getOCIConcurrency() []string {
+	return []string{
+		fmt.Sprintf("%d\t%s", 1, ociConcurrencyMinimumDescription),
+		fmt.Sprintf("%d\t%s", 6, ociConcurrencyDefaultDescription),
+		fmt.Sprintf("%d\t%s", 10, ociConcurrencyMaximumDescription),
+	}
+}

--- a/src/cmd/flags/root.go
+++ b/src/cmd/flags/root.go
@@ -1,0 +1,64 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"fmt"
+
+	"github.com/colonel-byte/cargoship/src/config"
+	"github.com/spf13/cobra"
+)
+
+// RegisterLogLevel provides shell completion suggestions for the log-level flag.
+func RegisterLogLevel(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return getLogLevel(), cobra.ShellCompDirectiveNoFileComp
+}
+
+const (
+	logLevelTraceDescription = "most verbose: every step, including internals"
+	logLevelDebugDescription = "verbose: detailed diagnostic information"
+	logLevelInfoDescription  = "default: high-level progress messages"
+	logLevelWarnDescription  = "quiet: only warnings and errors"
+	logLevelErrorDescription = "quietest: only errors"
+)
+
+func getLogLevel() []string {
+	return []string{
+		fmt.Sprintf("%s\t%s", config.RootFlagLogLevelTrace, logLevelTraceDescription),
+		fmt.Sprintf("%s\t%s", config.RootFlagLogLevelDebug, logLevelDebugDescription),
+		fmt.Sprintf("%s\t%s", config.RootFlagLogLevelInfo, logLevelInfoDescription),
+		fmt.Sprintf("%s\t%s", config.RootFlagLogLevelWarn, logLevelWarnDescription),
+		fmt.Sprintf("%s\t%s", config.RootFlagLogLevelError, logLevelErrorDescription),
+	}
+}
+
+// RegisterLogFormat provides shell completion suggestions for the log-format flag.
+func RegisterLogFormat(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return getLogFormat(), cobra.ShellCompDirectiveNoFileComp
+}
+
+const (
+	logFormatConsoleDescription = "default: colorful, human-readable console output"
+	logFormatJSONDescription    = "structured JSON, one object per line"
+	logFormatDevDescription     = "verbose, pretty-printed output for local development"
+)
+
+func getLogFormat() []string {
+	return []string{
+		fmt.Sprintf("%s\t%s", config.RootFlagLogFormatConsole, logFormatConsoleDescription),
+		fmt.Sprintf("%s\t%s", config.RootFlagLogFormatJSON, logFormatJSONDescription),
+		fmt.Sprintf("%s\t%s", config.RootFlagLogFormatDev, logFormatDevDescription),
+	}
+}

--- a/src/cmd/misc_version.go
+++ b/src/cmd/misc_version.go
@@ -30,6 +30,7 @@ import (
 	"github.com/colonel-byte/cargoship/src/config/lang"
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
 )
 
 type versionOptions struct {
@@ -40,21 +41,18 @@ func newVersionCommand() *cobra.Command {
 	o := versionOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "version",
-		Aliases:           []string{"v"},
-		Short:             lang.CmdVersionShort,
-		Long:              lang.CmdVersionLong,
-		RunE:              o.run,
-		PersistentPreRunE: o.perprerun,
+		Use:     "version",
+		Aliases: []string{"v"},
+		Short:   lang.CmdVersionShort,
+		Long:    lang.CmdVersionLong,
+		RunE:    o.run,
 	}
 
-	cmd.Flags().VarP(&o.outputFormat, "output", "o", "output format (yaml|json)")
+	if err := registerFlagOutputFormat(cmd, &o.outputFormat); err != nil {
+		logger.From(cmd.Context()).Debug("error when trying add shell completion", "error", err)
+	}
 
 	return cmd
-}
-
-func (o *versionOptions) perprerun(_ *cobra.Command, _ []string) error {
-	return nil
 }
 
 func (o *versionOptions) run(_ *cobra.Command, _ []string) error {

--- a/src/cmd/package_create.go
+++ b/src/cmd/package_create.go
@@ -63,10 +63,13 @@ func newPackageCreateCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&o.confirm, "confirm", "c", false, zlang.CmdPackagePublishFlagConfirm)
-	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(types.DistroOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().StringVarP(&o.output, "output", "o", output, lang.CmdPackageCreateFlagOutput)
 	cmd.Flags().StringSliceVar(&o.registryOverrides, "registry-override", GetStringSlice(v, types.DistroCreateRegistryOverride), zlang.CmdPackageCreateFlagRegistryOverride)
 	cmd.Flags().BoolVar(&o.skipSBOM, "skip-sbom", v.GetBool(types.DistroCreateSkipSbom), zlang.CmdPackageCreateFlagSkipSbom)
+
+	if err := registerFlagOCIConcurrency(cmd, &o.ociConcurrency); err != nil {
+		logger.From(cmd.Context()).Debug("error when trying add shell completion", "error", err)
+	}
 
 	v.SetDefault(types.DistroOutput, ".")
 

--- a/src/cmd/package_publish.go
+++ b/src/cmd/package_publish.go
@@ -63,11 +63,14 @@ func newPackagePublishCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&o.confirm, "confirm", "c", false, zlang.CmdPackagePublishFlagConfirm)
-	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(types.DistroOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().IntVar(&o.retries, "retries", v.GetInt(types.DistroRetry), lang.CmdPackageFlagRetries)
 	cmd.Flags().StringVar(&o.signingKeyPath, "signing-key", v.GetString(types.DistroPublishSigningKey), zlang.CmdPackagePublishFlagSigningKey)
 	cmd.Flags().StringVar(&o.signingKeyPassword, "signing-key-pass", v.GetString(types.DistroPublishSigningKeyPassword), zlang.CmdPackagePublishFlagSigningKeyPassword)
 	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
+
+	if err := registerFlagOCIConcurrency(cmd, &o.ociConcurrency); err != nil {
+		logger.From(cmd.Context()).Debug("error when trying add shell completion", "error", err)
+	}
 
 	return cmd
 }

--- a/src/cmd/package_pull.go
+++ b/src/cmd/package_pull.go
@@ -59,10 +59,13 @@ func newPackagePullCommand() *cobra.Command {
 		output = v.GetString(types.DistroOutput)
 	}
 
-	cmd.Flags().IntVar(&o.ociConcurrency, "oci-concurrency", v.GetInt(types.DistroOCIConcurrency), lang.CmdPackageFlagConcurrency)
 	cmd.Flags().StringVar(&o.shasum, "shasum", "", lang.CmdPackagePullFlagShasum)
 	cmd.Flags().StringVarP(&o.outputDirectory, "output", "o", output, lang.CmdPackageCreateFlagOutput)
 	addVerifyFlags(cmd, v, &o.packageVerifyFlags)
+
+	if err := registerFlagOCIConcurrency(cmd, &o.ociConcurrency); err != nil {
+		logger.From(cmd.Context()).Debug("error when trying add shell completion", "error", err)
+	}
 
 	return cmd
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/colonel-byte/cargoship/src/cmd/flags"
 	"github.com/colonel-byte/cargoship/src/config"
 	"github.com/colonel-byte/cargoship/src/config/lang"
 	"github.com/colonel-byte/cargoship/src/pkg/utils"
@@ -71,6 +72,16 @@ const (
 	InstallUpdateFAPolicyD = "update-fapolicyd"
 )
 
+const (
+	// PackageOCIConcurrency flag
+	PackageOCIConcurrency = "oci-concurrency"
+)
+
+const (
+	// MiscOutput flag
+	MiscOutput = "output"
+)
+
 var (
 	// IsColorDisabled whether to show the colored output
 	IsColorDisabled bool
@@ -110,11 +121,8 @@ func NewCargoshipCommand() *cobra.Command {
 		Short:         lang.RootCmdShort,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				_, _ = fmt.Fprintln(os.Stderr, err)
-			}
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
 		},
 		PersistentPreRunE: preRun,
 	}
@@ -137,7 +145,13 @@ func NewCargoshipCommand() *cobra.Command {
 	rootCmd.AddCommand(newSha256SumCommand())
 
 	rootCmd.PersistentFlags().StringVarP(&LogLevelCLI, RootLoggingLevel, "l", v.GetString(types.LogLevel), lang.RootCmdFlagLogLevel)
+	if err := rootCmd.RegisterFlagCompletionFunc(RootLoggingLevel, flags.RegisterLogLevel); err != nil {
+		fmt.Printf("failed to register %s flag completion: %v", RootLoggingLevel, err)
+	}
 	rootCmd.PersistentFlags().StringVarP(&LogFormat, RootLoggingFormat, "L", v.GetString(types.LogFormat), lang.RootCmdFlagLogFormat)
+	if err := rootCmd.RegisterFlagCompletionFunc(RootLoggingFormat, flags.RegisterLogFormat); err != nil {
+		fmt.Printf("failed to register %s flag completion: %v", RootLoggingFormat, err)
+	}
 	rootCmd.PersistentFlags().StringVar(&Timeout, RootTimeout, v.GetString(RootTimeout), lang.CmdInstallFlagTimeout)
 	rootCmd.PersistentFlags().BoolVar(&IsColorDisabled, "no-color", v.GetBool(types.NoColor), lang.RootCmdFlagNoColor)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, RootZarfCache, parsePath(rootCmd.Context(), types.ZarfCache), zlang.RootCmdFlagCachePath)

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -52,7 +52,6 @@ func initViper() error {
 		v.AddConfigPath("$HOME/.zarf")
 		v.SetConfigName("cargoship-config")
 		v.SetConfigType("yaml")
-		v.SetConfigType("yml")
 	}
 
 	v.SetEnvPrefix("distro")
@@ -73,9 +72,13 @@ func initViper() error {
 
 	vConfigError = v.ReadInConfig()
 	if vConfigError != nil {
-		// Config file not found; ignore
-		if pathError, ok := errors.AsType[*viper.ConfigFileNotFoundError](vConfigError); ok {
-			log.Warn(lang.CmdViperErrLoadingConfigFile, "error", pathError)
+		// A missing config file is expected when running on flags/env/defaults alone; ignore it.
+		// Any other error (e.g. malformed YAML, permission denied) means a config file was found
+		// but couldn't be used, so surface it instead of silently falling back to defaults.
+		if notFoundErr, ok := errors.AsType[viper.ConfigFileNotFoundError](vConfigError); !ok {
+			log.Warn(lang.CmdViperErrLoadingConfigFile, "error", vConfigError)
+		} else {
+			log.Debug(lang.CmdViperErrLoadingConfigFile, "error", notFoundErr)
 		}
 	}
 	return nil

--- a/src/config/constant.go
+++ b/src/config/constant.go
@@ -44,3 +44,12 @@ const (
 	// EngineTLS string key
 	EngineTLS = "tls"
 )
+
+const (
+	// OutputFromatJSON json output format
+	OutputFromatJSON = "json"
+	// OutputFromatYAML yaml output format
+	OutputFromatYAML = "yaml"
+	// OutputFromatTable table output format
+	OutputFromatTable = "table"
+)

--- a/src/config/flags.go
+++ b/src/config/flags.go
@@ -1,0 +1,37 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+const (
+	// RootFlagLogLevelTrace trace log level
+	RootFlagLogLevelTrace = "trace"
+	// RootFlagLogLevelDebug debug log level
+	RootFlagLogLevelDebug = "debug"
+	// RootFlagLogLevelInfo info log level
+	RootFlagLogLevelInfo = "info"
+	// RootFlagLogLevelWarn warn log level
+	RootFlagLogLevelWarn = "warn"
+	// RootFlagLogLevelError error log level
+	RootFlagLogLevelError = "error"
+)
+
+const (
+	// RootFlagLogFormatConsole console log format
+	RootFlagLogFormatConsole = "console"
+	// RootFlagLogFormatJSON json log format
+	RootFlagLogFormatJSON = "json"
+	// RootFlagLogFormatDev dev log format
+	RootFlagLogFormatDev = "dev"
+)

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -68,6 +68,8 @@ const (
 	CmdVersionLong = "Displays the version of the release that the current binary was built from."
 	// CmdVersionShort version short
 	CmdVersionShort = "Shows the version of the running binary"
+	// CmdVersionOutputFromat version flag output format
+	CmdVersionOutputFromat = "output format (yaml|json)"
 	// CmdSha256SumShort sha256sum short
 	CmdSha256SumShort = "Generates a SHA256SUM for the given file"
 	// CmdSha256SumFlagExtractPath flag description


### PR DESCRIPTION
## Description

Adds shell completion suggestions (value + description) for CLI flags that previously had none, and fixes a few correctness bugs found while wiring that up:

**Shell completion**
- `--oci-concurrency`: suggests min/default/recommended-upper-limit values with explanations of the registry-throttling tradeoff at each.
- `--output` (version cmd): suggests `json`/`yaml` with descriptions.
- `--log-level` (root, persistent): suggests `trace`/`debug`/`info`/`warn`/`error` with descriptions.
- `--log-format` (root, persistent): suggests `console`/`json`/`dev` with descriptions.

New `src/cmd/flags` package holds the `RegisterFlagCompletionFunc` callbacks; `src/config/flags.go` holds the shared flag-value constants they complete against.

**Bug fixes found along the way**
- `version` subcommand defined its own no-op `PersistentPreRunE`, which silently overrode the root command's `PersistentPreRunE` (cobra does not chain these — a child's hook fully replaces the parent's). This meant `cargoship version` ignored `--log-level`, `--no-color`, and never printed the "using config file" notice, unlike every other subcommand. Removed the no-op override so cobra falls through to the root's hook as intended.
- Root command used `Run` instead of `RunE`, manually writing `cmd.Help()`'s error to `os.Stderr` instead of returning it through cobra's normal error path (bypassing the centralized logger-based error handling in `Execute`). Switched to `RunE`.
- `initViper()`'s config-file error handling was broken in two ways:
  - `errors.AsType[*viper.ConfigFileNotFoundError]` used a pointer type, but viper always returns this error by value, so the "ignore missing config file" check could never match — a missing config file (the common, expected case) always logged a spurious warning.
  - The branch logic was inverted: it warned on the not-found case and stayed silent on real errors (malformed YAML, permission denied), so a broken config file would silently fall back to defaults with zero indication anything was wrong.
  - Both fixed: missing config file is now silent (debug-only), and a present-but-unusable config file now logs a warning.
- Removed a redundant `v.SetConfigType("yml")` call that immediately overwrote the preceding `SetConfigType("yaml")` and had no effect.

Also fixed a handful of typos in newly-touched constants (`RootFlagLogLevelTarce` → `RootFlagLogLevelTrace`, `minmumOCIConcurrancy` → proper spelling, etc.) and added missing doc comments on exported identifiers to satisfy `golangci-lint` (revive/staticcheck).

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
