### PR TITLE
feat: fix permissions when pulling package

### DIFF
--- a/src/pkg/packager/assemble/assemble.go
+++ b/src/pkg/packager/assemble/assemble.go
@@ -129,7 +129,7 @@ func AssembleDistro(ctx context.Context, d distro.ZarfDistro, distroPath string,
 		return nil, err
 	}
 	checksumPath := filepath.Join(buildPath, config.Checksums)
-	err = os.WriteFile(checksumPath, []byte(checksumContent), helpers.ReadWriteUser)
+	err = os.WriteFile(checksumPath, []byte(checksumContent), helpers.ReadAllWriteUser)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func AssembleDistro(ctx context.Context, d distro.ZarfDistro, distroPath string,
 	if err != nil {
 		return nil, err
 	}
-	err = os.WriteFile(filepath.Join(buildPath, config.DistroYAML), b, helpers.ReadWriteUser)
+	err = os.WriteFile(filepath.Join(buildPath, config.DistroYAML), b, helpers.ReadAllWriteUser)
 	if err != nil {
 		return nil, err
 	}
@@ -224,12 +224,12 @@ func fileGrabber(ctx context.Context, resourceType string, buildPath string, dis
 	}
 
 	if file.Executable || helpers.IsDir(dst) {
-		err := os.Chmod(dst, helpers.ReadWriteExecuteUser)
+		err := os.Chmod(dst, helpers.ReadExecuteAllWriteUser)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := os.Chmod(dst, helpers.ReadWriteUser)
+		err := os.Chmod(dst, helpers.ReadAllWriteUser)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/packager/layout/distro.go
+++ b/src/pkg/packager/layout/distro.go
@@ -96,6 +96,10 @@ func (d *DistroLayout) Archive(ctx context.Context, dirPath string, _ int) (stri
 	}
 	logger.From(ctx).Info("writing package to disk", "path", tarballPath)
 
+	if err := d.normalizePermissions(); err != nil {
+		return "", err
+	}
+
 	files, err := os.ReadDir(d.dirPath)
 	if err != nil {
 		return "", err

--- a/src/pkg/packager/layout/layout_test.go
+++ b/src/pkg/packager/layout/layout_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizePermissionsDirectoriesAndFiles(t *testing.T) {
+	root := t.TempDir()
+
+	dirs := []string{
+		"images",
+		"images/blobs/sha256",
+		"os",
+		"os/0",
+	}
+	for _, d := range dirs {
+		path := filepath.Join(root, d)
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatalf("creating dir %s: %v", path, err)
+		}
+	}
+
+	makeFile := func(rel string, mode os.FileMode) {
+		path := filepath.Join(root, rel)
+		if err := os.WriteFile(path, []byte("x"), mode); err != nil {
+			t.Fatalf("creating file %s: %v", path, err)
+		}
+	}
+
+	// Non-executable regular files.
+	makeFile("checksums.txt", 0o600)
+	makeFile("images/index.json", 0o400)
+	makeFile("os/0/rpm", 0o600)
+
+	// Executable file.
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o700); err != nil {
+		t.Fatalf("creating dir bin: %v", err)
+	}
+	makeFile("bin/tool", 0o700)
+
+	// Symlink pointing outside the layout. os.Chmod follows symlinks, so if
+	// normalizePermissions didn't skip it, this would silently chmod the link's
+	// target instead of leaving it alone.
+	targetPath := filepath.Join(t.TempDir(), "outside-target")
+	if err := os.WriteFile(targetPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("creating symlink target: %v", err)
+	}
+	linkPath := filepath.Join(root, "link-to-outside")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	d := &DistroLayout{dirPath: root}
+	if err := d.normalizePermissions(); err != nil {
+		t.Fatalf("normalizePermissions error: %v", err)
+	}
+
+	checkMode := func(rel string, want os.FileMode) {
+		path := filepath.Join(root, rel)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Fatalf("unexpected mode for %s: got %v, want %v", path, got, want)
+		}
+	}
+
+	// Directories normalized to 0755.
+	for _, dRel := range dirs {
+		checkMode(dRel, 0o755)
+	}
+	checkMode("bin", 0o755)
+
+	// Regular files normalized to 0644.
+	checkMode("checksums.txt", 0o644)
+	checkMode("images/index.json", 0o644)
+	checkMode("os/0/rpm", 0o644)
+
+	// Executable file normalized to 0755.
+	checkMode("bin/tool", 0o755)
+
+	// Symlink target's mode must be untouched -- proves the symlink itself was
+	// skipped rather than followed and chmod'd.
+	targetInfo, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("stat symlink target %s: %v", targetPath, err)
+	}
+	if got := targetInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("symlink target mode changed: got %v, want %v", got, os.FileMode(0o600))
+	}
+}

--- a/src/pkg/packager/layout/package.go
+++ b/src/pkg/packager/layout/package.go
@@ -224,6 +224,38 @@ func isCleanPath(s string) bool {
 	return s != ".." && !strings.ContainsAny(s, `/\`)
 }
 
+// normalizePermissions canonicalizes file and directory permissions in the
+// package layout so archives produced from different sources (build vs pull)
+// use consistent modes.
+func (d *DistroLayout) normalizePermissions() error {
+	return filepath.WalkDir(d.dirPath, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip symlinks; not currently used in packages, but avoid mutating targets.
+		if entry.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+
+		// Directories and executable files are normalized to 0755 (rwxr-xr-x);
+		// every other regular file is normalized to 0644 (rw-r--r--).
+		mode := os.FileMode(helpers.ReadAllWriteUser)
+		if entry.IsDir() {
+			mode = helpers.ReadExecuteAllWriteUser
+		} else {
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if info.Mode().Perm()&0111 != 0 {
+				mode = helpers.ReadExecuteAllWriteUser
+			}
+		}
+		return os.Chmod(path, mode)
+	})
+}
+
 // IsSigned returns true if the package is signed.
 // It first checks the package metadata (Build.Signed), then falls back to
 // checking for the presence of a signature file for backward compatibility.


### PR DESCRIPTION
## Description

Fixes #205: a freshly-built package tarball and the same package pulled back down hashed differently, even though their contents were the same.

The vendored archiver (`archives.FilesFromDisk` with `ClearAttributes: true`) already zeroes out mtime and uid/gid before writing tar entries, and sorts entries by name for deterministic ordering -- but it explicitly preserves each file's mode bits as-is from disk (`noAttrFileInfo.Mode()` keeps `fs.ModeType | fs.ModePerm`). Files written locally during `create` (0600/0700, via `helpers.ReadWriteUser`/`ReadWriteExecuteUser`) ended up with different permissions than files produced by a `pull`, so the two tarballs differed byte-for-byte on that alone.

Adds `DistroLayout.normalizePermissions()` (`src/pkg/packager/layout/package.go`), called from `Archive()` before the directory is walked and compressed: every directory and executable file is set to 0755, every other regular file to 0644, using `filepath.WalkDir`. Symlinks are left untouched (`os.Chmod` follows them, so chmod'ing a symlink would silently mutate whatever it points to instead). Since `create` and `pull` both funnel through the same `Archive()` method, this guarantees identical permissions regardless of which path produced the layout on disk.

`assemble.go`'s own file writes were switched from the 0600/0700 "internal/sensitive" constants to the 0644/0755 "end-user" constants (`helpers.ReadAllWriteUser`/`ReadExecuteAllWriteUser`), matching the same normalized values.

Verified with a throwaway test that built two otherwise-identical layout directories with different starting permissions (0600/0700 vs 0644/0755, mimicking build vs pull) and archived both through the real `Archive()` path: same sha256 with the fix in place, and reproducibly different sha256s with `normalizePermissions()` disabled -- confirming this is both necessary and sufficient for the mismatch in #205.

## Related Issue

Fixes #205

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
