### PR TITLE
feat!: add registry overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/otiai10/copy v1.14.1
+	github.com/pb33f/ordered-map/v2 v2.3.1
 	github.com/pterm/pterm v0.12.83
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -306,7 +307,6 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
 	github.com/open-policy-agent/opa v1.19.1 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
-	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/schema/zarf-config-distro-schema.json
+++ b/schema/zarf-config-distro-schema.json
@@ -17,11 +17,8 @@
       },
       "properties": {
         "registry_override": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "maps a source registry to the registry cargoship uses instead\nwhen pulling images, for example {\"docker.io\": \"mirror.example.com\"}",
-          "type": "object"
+          "$ref": "#/$defs/RegistryOverrideMap",
+          "description": "maps a source registry to the registry cargoship uses instead\nwhen pulling images, for example {\"docker.io\": \"mirror.example.com\"}"
         },
         "skip_sbom": {
           "description": "whether we will scan the images or files",
@@ -180,6 +177,36 @@
         },
         "signing_key_password": {
           "description": "the password for the private key used for signing",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "RegistryOverrideMap": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "maps a source registry to the registry cargoship uses instead.",
+      "patternProperties": {
+        "^x-": {}
+      },
+      "properties": {
+        "docker.io": {
+          "type": "string"
+        },
+        "gcr.io": {
+          "type": "string"
+        },
+        "ghcr.io": {
+          "type": "string"
+        },
+        "public.ecr.aws": {
+          "type": "string"
+        },
+        "quay.io": {
+          "type": "string"
+        },
+        "registry.k8s.io": {
           "type": "string"
         }
       },

--- a/schema/zarf-config-distro-schema.json
+++ b/schema/zarf-config-distro-schema.json
@@ -17,11 +17,11 @@
       },
       "properties": {
         "registry_override": {
-          "description": "remaps references from one registry to another",
-          "items": {
+          "additionalProperties": {
             "type": "string"
           },
-          "type": "array"
+          "description": "maps a source registry to the registry cargoship uses instead\nwhen pulling images, for example {\"docker.io\": \"mirror.example.com\"}",
+          "type": "object"
         },
         "skip_sbom": {
           "description": "whether we will scan the images or files",

--- a/src/cmd/package_create.go
+++ b/src/cmd/package_create.go
@@ -24,9 +24,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/colonel-byte/cargoship/src/config/lang"
 	"github.com/colonel-byte/cargoship/src/pkg/distro"
+	"github.com/colonel-byte/cargoship/src/pkg/images"
 	"github.com/colonel-byte/cargoship/src/pkg/lint"
 	"github.com/spf13/cobra"
 	zconfig "github.com/zarf-dev/zarf/src/config"
@@ -71,9 +74,15 @@ func newPackageCreateCommand() *cobra.Command {
 		output = v.GetString(distroOutputKey)
 	}
 
+	registryOverrideDefaults := make([]string, 0, len(resolvedConfig.DistroOpts.CreateOpts.RegistryOverride))
+	for source, override := range resolvedConfig.DistroOpts.CreateOpts.RegistryOverride {
+		registryOverrideDefaults = append(registryOverrideDefaults, source+"="+override)
+	}
+	slices.Sort(registryOverrideDefaults)
+
 	cmd.Flags().BoolVarP(&o.confirm, "confirm", "c", false, zlang.CmdPackagePublishFlagConfirm)
 	cmd.Flags().StringVarP(&o.output, "output", "o", output, lang.CmdPackageCreateFlagOutput)
-	cmd.Flags().StringSliceVar(&o.registryOverrides, "registry-override", resolvedConfig.DistroOpts.CreateOpts.RegistryOverride, zlang.CmdPackageCreateFlagRegistryOverride)
+	cmd.Flags().StringSliceVar(&o.registryOverrides, "registry-override", registryOverrideDefaults, zlang.CmdPackageCreateFlagRegistryOverride)
 	cmd.Flags().BoolVar(&o.skipSBOM, "skip-sbom", resolvedConfig.DistroOpts.CreateOpts.SkipSBOM, zlang.CmdPackageCreateFlagSkipSbom)
 	cmd.Flags().BoolVar(&o.reproducible, "reproducible", false, lang.CmdPackageCreateFlagReproducible)
 	cmd.Flags().StringVar(&o.signingKeyPath, "signing-key", resolvedConfig.DistroOpts.PublishOpts.SigningKey, zlang.CmdPackageCreateFlagSigningKey)
@@ -88,6 +97,42 @@ func newPackageCreateCommand() *cobra.Command {
 	return cmd
 }
 
+// parseRegistryOverrides converts registry overrides to a structured type.
+// The result is sorted in descending order by Source, which guarantees the
+// longest prefix will be sorted toward the beginning -- so that e.g.
+// docker.io/library overrides win over a broader docker.io override.
+//
+// Input is of the following form:
+// []string{"docker.io/library=docker.example.com", "docker.io=docker.example.com"}
+func parseRegistryOverrides(overrides []string) ([]images.RegistryOverride, error) {
+	result := make([]images.RegistryOverride, len(overrides))
+	for i, mapping := range overrides {
+		source, override, found := strings.Cut(mapping, "=")
+		if !found {
+			return nil, fmt.Errorf("registry override missing '=': %s", mapping)
+		}
+		if source == "" {
+			return nil, fmt.Errorf("registry override missing source: %s", mapping)
+		}
+		if override == "" {
+			return nil, fmt.Errorf("registry override missing value: %s", mapping)
+		}
+		if index := slices.IndexFunc(result, func(existing images.RegistryOverride) bool {
+			return existing.Source == source
+		}); index >= 0 {
+			return nil, fmt.Errorf("registry override has duplicate source: existing index %d, new index %d, source %s", index, i, source)
+		}
+		result[i].Source = source
+		result[i].Override = override
+	}
+
+	slices.SortFunc(result, func(a images.RegistryOverride, b images.RegistryOverride) int {
+		return -strings.Compare(a.Source, b.Source)
+	})
+
+	return result, nil
+}
+
 func (o *packageCreateOptions) run(ctx context.Context, args []string) error {
 	l := logger.From(ctx)
 	basePath := setBaseDirectory(args)
@@ -96,10 +141,17 @@ func (o *packageCreateOptions) run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	registryOverrides, err := parseRegistryOverrides(o.registryOverrides)
+	if err != nil {
+		return fmt.Errorf("error parsing registry override: %w", err)
+	}
+	l.Debug("parsed registry overrides", "overrides", registryOverrides)
+
 	opt := distro.CreateOptions{
 		CachePath:          cachePath,
 		IsInteractive:      !o.confirm,
 		OCIConcurrency:     o.ociConcurrency,
+		RegistryOverrides:  registryOverrides,
 		RemoteOptions:      defaultRemoteOptions(),
 		Reproducible:       o.reproducible,
 		SigningKeyPath:     o.signingKeyPath,

--- a/src/cmd/package_create_test.go
+++ b/src/cmd/package_create_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/colonel-byte/cargoship/src/pkg/images"
+)
+
+func TestParseRegistryOverridesSortsLongestPrefixFirst(t *testing.T) {
+	got, err := parseRegistryOverrides([]string{
+		"docker.io=docker.example.com",
+		"docker.io/library=library.example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []images.RegistryOverride{
+		{Source: "docker.io/library", Override: "library.example.com"},
+		{Source: "docker.io", Override: "docker.example.com"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseRegistryOverrides() = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseRegistryOverridesEmpty(t *testing.T) {
+	got, err := parseRegistryOverrides(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("parseRegistryOverrides(nil) = %+v, want empty", got)
+	}
+}
+
+func TestParseRegistryOverridesErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+	}{
+		{"missing equals", []string{"docker.io"}},
+		{"missing source", []string{"=docker.example.com"}},
+		{"missing value", []string{"docker.io="}},
+		{"duplicate source", []string{"docker.io=a.example.com", "docker.io=b.example.com"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseRegistryOverrides(tt.input); err == nil {
+				t.Fatalf("parseRegistryOverrides(%v) = nil error, want error", tt.input)
+			}
+		})
+	}
+}

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/colonel-byte/cargoship/src/config"
 	"github.com/colonel-byte/cargoship/src/config/lang"
 	"github.com/colonel-byte/cargoship/src/types"
+	goyaml "github.com/goccy/go-yaml"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -103,7 +104,37 @@ func initViper() error {
 		log.Warn(lang.CmdViperErrLoadingConfigFile, "error", err)
 	}
 
+	// RegistryOverride is mapstructure:"-" (see types.DistroConfig) and must be read
+	// directly from the config file, bypassing viper's Unmarshal above: its map keys
+	// are registry domains like "docker.io", and viper always treats "." as a
+	// nested-key delimiter when merging its settings tree, silently corrupting any
+	// such key into a nested map. Never fatal, same reasoning as the Unmarshal above.
+	if cfgPath := v.ConfigFileUsed(); cfgPath != "" {
+		overrides, err := loadRegistryOverrides(cfgPath)
+		if err != nil {
+			log.Warn(lang.CmdViperErrLoadingConfigFile, "error", err)
+		} else {
+			resolvedConfig.DistroOpts.CreateOpts.RegistryOverride = overrides
+		}
+	}
+
 	return nil
+}
+
+// loadRegistryOverrides reads DistroOpts.CreateOpts.RegistryOverride directly out of
+// the config file at cfgPath. It exists because that field is mapstructure:"-" -- see
+// the comment where it's called in initViper for why viper's Unmarshal can't be trusted
+// with it.
+func loadRegistryOverrides(cfgPath string) (map[string]string, error) {
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+	var fileConfig types.DistroConfig
+	if err := goyaml.UnmarshalWithOptions(raw, &fileConfig); err != nil {
+		return nil, err
+	}
+	return fileConfig.DistroOpts.CreateOpts.RegistryOverride, nil
 }
 
 // configPath derives a viper dot-path key for a field in types.DistroConfig by
@@ -162,7 +193,6 @@ func setDefaults() {
 	// an env-only key on its own. Confirmed via a standalone reproduction before adding
 	// these -- omitting any of them silently drops that key's env-var support.
 	v.SetDefault(configPath("Architecture"), "")
-	v.SetDefault(configPath("DistroOpts", "CreateOpts", "RegistryOverride"), []string{})
 	v.SetDefault(configPath("DistroOpts", "FAPolicyd"), false)
 	v.SetDefault(configPath("DistroOpts", "WorkerConcurrency"), 0)
 	v.SetDefault(configPath("DistroOpts", "Type"), "")

--- a/src/cmd/viper_test.go
+++ b/src/cmd/viper_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadRegistryOverridesDottedKeys(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "cargoship-config.yaml")
+	writeFile(t, cfgPath, `
+distro:
+  create:
+    registry_override:
+      docker.io: mirror.example.com
+      docker.io/library: library-mirror.example.com
+`)
+
+	got, err := loadRegistryOverrides(cfgPath)
+	if err != nil {
+		t.Fatalf("loadRegistryOverrides failed: %v", err)
+	}
+
+	want := map[string]string{
+		"docker.io":         "mirror.example.com",
+		"docker.io/library": "library-mirror.example.com",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("loadRegistryOverrides() = %+v, want %+v", got, want)
+	}
+}
+
+func TestLoadRegistryOverridesEmpty(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "cargoship-config.yaml")
+	writeFile(t, cfgPath, "log_level: info\n")
+
+	got, err := loadRegistryOverrides(cfgPath)
+	if err != nil {
+		t.Fatalf("loadRegistryOverrides failed: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("loadRegistryOverrides() = %+v, want empty", got)
+	}
+}
+
+func TestLoadRegistryOverridesMissingFile(t *testing.T) {
+	if _, err := loadRegistryOverrides(filepath.Join(t.TempDir(), "does-not-exist.yaml")); err == nil {
+		t.Fatalf("loadRegistryOverrides() = nil error, want error")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeFile failed: %v", err)
+	}
+}

--- a/src/pkg/distro/create.go
+++ b/src/pkg/distro/create.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/colonel-byte/cargoship/src/pkg/images"
 	"github.com/colonel-byte/cargoship/src/pkg/packager/assemble"
 	"github.com/colonel-byte/cargoship/src/pkg/packager/layout"
 	"github.com/colonel-byte/cargoship/src/pkg/packager/load"
@@ -42,7 +43,8 @@ type CreateOptions struct {
 	// Reproducible pins Build.Timestamp to config.Timestamp instead of the
 	// current time, and is recorded on Build.Reproducible, so identical package
 	// inputs produce byte-identical output.
-	Reproducible bool
+	Reproducible      bool
+	RegistryOverrides []images.RegistryOverride
 	// SigningKeyPath and SigningKeyPassword sign the package as part of creation
 	// when set. Empty values are a no-op -- see DistroLayout.SignPackage.
 	SigningKeyPath     string
@@ -71,6 +73,7 @@ func Create(ctx context.Context, distroPath string, output string, opts CreateOp
 		OCIConcurrency:     opts.OCIConcurrency,
 		CachePath:          opts.CachePath,
 		Reproducible:       opts.Reproducible,
+		RegistryOverrides:  opts.RegistryOverrides,
 		SigningKeyPath:     opts.SigningKeyPath,
 		SigningKeyPassword: opts.SigningKeyPassword,
 		// Don't have sbom logic yet....

--- a/src/types/config.go
+++ b/src/types/config.go
@@ -15,6 +15,11 @@
 // Package types is a little bit of a hacky way to generate the cargo-ship-config jsonschema
 package types
 
+import (
+	"github.com/invopop/jsonschema"
+	orderedmap "github.com/pb33f/ordered-map/v2"
+)
+
 // DistroConfig holds the values for the `.`, or root, section of the config file
 type DistroConfig struct {
 	// CachePath is the folder where oras artifacts are stored
@@ -91,7 +96,7 @@ type DistroCreateOptions struct {
 	SkipSBOM bool `json:"skip_sbom,omitempty" mapstructure:"skip_sbom"`
 	// RegistryOverride maps a source registry to the registry cargoship uses instead
 	// when pulling images, for example {"docker.io": "mirror.example.com"}
-	RegistryOverride map[string]string `json:"registry_override,omitempty" mapstructure:"-"` // mapstructure:"-": viper always splits a map key on "." when merging its settings tree, so a domain key like "docker.io" gets silently corrupted into a nested map; read directly from the config file instead (see initViper in cmd/viper.go)
+	RegistryOverride RegistryOverrideMap `json:"registry_override,omitempty" mapstructure:"-"` // mapstructure:"-": viper always splits a map key on "." when merging its settings tree, so a domain key like "docker.io" gets silently corrupted into a nested map; read directly from the config file instead (see initViper in cmd/viper.go)
 }
 
 // DistroPublishOptions holds the values for the `.distro.publish` section of the config file
@@ -113,3 +118,32 @@ type ApplyOptions struct{}
 
 // ResetOptions holds the values for the `.distro.reset` section of the config file
 type ResetOptions struct{}
+
+// RegistryOverrideMap maps a source registry to the registry cargoship uses instead.
+// It's a named type (rather than a bare map[string]string) solely so it can implement
+// JSONSchemaExtend below and suggest common registries in the generated schema; the
+// config file is not restricted to those.
+type RegistryOverrideMap map[string]string
+
+// commonRegistries are suggested, non-exhaustive property names for RegistryOverrideMap's
+// generated schema -- editors with YAML/JSON schema support (e.g. the redhat.vscode-yaml
+// extension) offer them as autocomplete for registry_override keys.
+var commonRegistries = []string{
+	"docker.io",
+	"ghcr.io",
+	"quay.io",
+	"gcr.io",
+	"registry.k8s.io",
+	"public.ecr.aws",
+}
+
+// JSONSchemaExtend adds commonRegistries to the schema's properties, alongside the
+// additionalProperties the reflector already set for the map[string]string element
+// type, so the suggestions are additive and don't restrict which keys are allowed.
+func (RegistryOverrideMap) JSONSchemaExtend(s *jsonschema.Schema) {
+	suggestions := orderedmap.New[string, *jsonschema.Schema]()
+	for _, registry := range commonRegistries {
+		suggestions.Set(registry, &jsonschema.Schema{Type: "string"})
+	}
+	s.Properties = suggestions
+}

--- a/src/types/config.go
+++ b/src/types/config.go
@@ -89,8 +89,9 @@ type DistroOptions struct {
 type DistroCreateOptions struct {
 	// SkipSBOM whether we will scan the images or files
 	SkipSBOM bool `json:"skip_sbom,omitempty" mapstructure:"skip_sbom"`
-	// RegistryOverride remaps references from one registry to another
-	RegistryOverride []string `json:"registry_override,omitempty" mapstructure:"registry_override"`
+	// RegistryOverride maps a source registry to the registry cargoship uses instead
+	// when pulling images, for example {"docker.io": "mirror.example.com"}
+	RegistryOverride map[string]string `json:"registry_override,omitempty" mapstructure:"-"` // mapstructure:"-": viper always splits a map key on "." when merging its settings tree, so a domain key like "docker.io" gets silently corrupted into a nested map; read directly from the config file instead (see initViper in cmd/viper.go)
 }
 
 // DistroPublishOptions holds the values for the `.distro.publish` section of the config file


### PR DESCRIPTION
## Description

Makes registry overrides actually work on `cargoship create`, in both the CLI flag and the config file, and matches zarf's own conventions for both.

`--registry-override` (`docker.io=mirror.example.com`) was previously collected into a flag but never converted or passed anywhere -- a dead flag. Added `parseRegistryOverrides`, ported directly from zarf's `cmd/package.go`: validates each `source=override` pair, rejects duplicate sources, and sorts results longest-prefix-first so a `docker.io/library` override wins over a broader `docker.io` one. Wired the result through `distro.CreateOptions` -> `assemble.AssembleOptions` -> the image puller, which already had this sorting-dependent "first match wins" logic but was never actually being fed any overrides.

`cargoship-config.yaml` now accepts overrides as a real YAML map instead of a list of `key=value` strings:

```yaml
distro:
  create:
    registry_override:
      docker.io: mirror.example.com
```

This needed more than a type change. Viper always treats `.` as a nested-key delimiter when merging its settings tree, so a domain key like `docker.io` was silently corrupted into `{docker: {io: ...}}` and dropped. `RegistryOverride` is now `mapstructure:"-"` and read directly from the config file with a plain YAML decode, the same way `Verify`/`InsecureIgnoreTLog` already bypass viper's `Unmarshal` for their own reasons.

Also added suggested registry names (`docker.io`, `ghcr.io`, `quay.io`, `gcr.io`, `registry.k8s.io`, `public.ecr.aws`) to the generated config schema, so editors with YAML/JSON schema support (e.g. redhat.vscode-yaml, which this repo's config files already reference) offer them as autocomplete for `registry_override` keys, without restricting the field to only those registries.

Along the way, found that `utils.ReadByteStrict`'s `&destConfig any` pattern never actually populates the caller's struct (confirmed with a standalone repro), so the new config-file read path doesn't use it.

Verified end to end: config-file overrides apply on `create`, a CLI-provided `--registry-override` correctly takes precedence over the config-file default, and `--help` shows the config-sourced default. Added unit tests for `parseRegistryOverrides` and the new config-file read path.

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
