### PR TITLE
feat: add logic for keeping track of files uploaded

### DIFF
--- a/src/api/zarf.dev/v1alpha1/cluster/host.go
+++ b/src/api/zarf.dev/v1alpha1/cluster/host.go
@@ -201,6 +201,10 @@ type ZarfHostMetadata struct {
 	NewConfig string
 	// Ready indicates whether the distro service is up and running.
 	Ready bool
+	// UploadedFiles lists "category\tpath" entries cargoship uploaded to this host during the
+	// current run. It is used to detect files a previous version left behind that the current
+	// upload no longer produces, e.g. an engine binary renamed by a version bump.
+	UploadedFiles []string
 }
 
 // requireConfigurer returns the resolved configurer for h, or an error if none has been resolved yet.

--- a/src/api/zarf.dev/v1alpha1/file.go
+++ b/src/api/zarf.dev/v1alpha1/file.go
@@ -58,6 +58,8 @@ type ZarfFile struct {
 	User string `json:"user,omitempty"`
 	// Base is the local directory cargoship joins with LocalSource.Path to find the file. Cargoship resolves it at runtime; it is not read from the config.
 	Base string `json:"-"`
+	// Category labels why cargoship is uploading this file, e.g. "engine", "image", "file", or "data". Cargoship records it in the remote upload manifest; it is not read from the config.
+	Category string `json:"-"`
 	// PermString is the octal permission string cargoship applies to the file. Cargoship derives it from PermMode at runtime.
 	PermString string `json:"-"`
 	// DirPermString is the octal permission string cargoship applies to the file's parent directory.

--- a/src/pkg/phase/01_generic_phase_file.go
+++ b/src/pkg/phase/01_generic_phase_file.go
@@ -128,6 +128,15 @@ func (p *GenericPhase) uploadFile(ctx context.Context, h *cluster.ZarfHost, f *v
 		logger.From(ctx).Info("file already exists and hasn't been changed, skipping upload", "host", h, "file", target)
 	}
 
+	// f.Target may be a temporary staging path for executable files (see stageTempPath); the
+	// manifest should record where the file actually ends up, which OriginalTarget holds
+	// whenever staging is used.
+	manifestPath := target
+	if f.OriginalTarget != "" {
+		manifestPath = f.OriginalTarget
+	}
+	p.recordManifestEntry(ctx, h, f.Category, manifestPath)
+
 	modTime := time.Unix(0, 0)
 	return p.applyFileMetadata(ctx, h, f.Target, owner, f.LocalSource.PermMode, &modTime)
 }
@@ -165,6 +174,12 @@ func (p *GenericPhase) uploadData(ctx context.Context, h *cluster.ZarfHost, f *v
 	if err != nil {
 		return err
 	}
+
+	category := f.Category
+	if category == "" {
+		category = "data"
+	}
+	p.recordManifestEntry(ctx, h, category, dest)
 
 	return p.applyFileMetadata(ctx, h, dest, owner, "", nil)
 }

--- a/src/pkg/phase/50_uploadfiles.go
+++ b/src/pkg/phase/50_uploadfiles.go
@@ -131,6 +131,7 @@ func (p *UploadFiles) Prepare(ctx context.Context, c *cluster.ZarfCluster, d *di
 			Name:        tarBallName,
 			Target:      p.manager.Distro.Spec.Config.ImagesConfig.Path,
 			TargetIsDir: true,
+			Category:    "image",
 			LocalSource: v1alpha1.LocalFile{
 				Path: tarballPath,
 			},
@@ -210,6 +211,7 @@ func (p *UploadFiles) uploadDistroFiles(ctx context.Context, h *cluster.ZarfHost
 			Target:         target,
 			OriginalTarget: f.Target,
 			TargetIsDir:    f.TargetIsDir,
+			Category:       "file",
 			LocalSource: v1alpha1.LocalFile{
 				Path: filepath.Join(p.manager.TempDirectory, config.FilesDir, strconv.Itoa(i), filepath.Base(f.Target)),
 			},

--- a/src/pkg/phase/50_uploadfiles.go
+++ b/src/pkg/phase/50_uploadfiles.go
@@ -29,6 +29,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1"
@@ -50,6 +51,11 @@ type UploadFiles struct {
 	hosts    cluster.ZarfHosts
 	disFiles v1alpha1.ZarfFiles
 	imgFiles []v1alpha1.ZarfFile
+
+	// priorManifest holds each host's upload manifest as it was before this run touched it,
+	// captured in Prepare so Run can tell which images an upgrade no longer uploads (e.g. an
+	// image tag that was removed from the distro config, or renamed to a new version).
+	priorManifest map[*cluster.ZarfHost][]ManifestEntry
 }
 
 // Title for the phase
@@ -74,6 +80,11 @@ func (p *UploadFiles) Prepare(ctx context.Context, c *cluster.ZarfCluster, d *di
 		return (len(h.Files) + len(d.Spec.Config.Files) + len(p.manager.Distro.Spec.Config.ImagesConfig.Images)) > 0
 	})
 	p.disFiles = p.manager.Distro.Spec.Config.Files
+
+	p.priorManifest = make(map[*cluster.ZarfHost][]ManifestEntry, len(p.manager.Config.Spec.Hosts))
+	for _, h := range p.manager.Config.Spec.Hosts {
+		p.priorManifest[h] = p.readManifest(h)
+	}
 
 	err := os.MkdirAll(filepath.Join(p.manager.TempDirectory, config.TarBallDir), 0755)
 	if err != nil {
@@ -156,7 +167,21 @@ func (p *UploadFiles) Run(ctx context.Context) error {
 		p.manager.Config.Spec.Hosts,
 		p.cleanUpOldTmpFiles,
 		p.uploadDistroFiles,
+		p.cleanStaleUploads,
 	)
+}
+
+// cleanStaleUploads removes images this run's upload left in the manifest from a previous
+// version but didn't re-upload itself, e.g. an image tag bumped by a version upgrade. The diff
+// is scoped to the "image" category: the engine binary phases run after this one and haven't
+// recorded their own files into h.Metadata.UploadedFiles yet, so comparing the full manifest
+// here would misread their files as stale and delete a still-in-use engine binary.
+func (p *UploadFiles) cleanStaleUploads(ctx context.Context, h *cluster.ZarfHost) error {
+	current := parseManifest(strings.Join(h.Metadata.UploadedFiles, "\n"))
+	old := filterManifestByCategory(p.priorManifest[h], "image")
+	current = filterManifestByCategory(current, "image")
+	p.removeStaleManifestEntries(ctx, h, old, current)
+	return nil
 }
 
 func (p *UploadFiles) cleanUpOldTmpFiles(ctx context.Context, h *cluster.ZarfHost) error {

--- a/src/pkg/phase/55_files_common.go
+++ b/src/pkg/phase/55_files_common.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1"
@@ -49,6 +51,10 @@ type UploadFilesCommon struct {
 
 	filesWorkers []v1alpha1.ZarfFile
 	filesControl []v1alpha1.ZarfFile
+
+	// priorManifest holds each host's upload manifest as it was before this run touched it,
+	// captured in Prepare so Run can tell which of those files an upgrade no longer uploads.
+	priorManifest map[*cluster.ZarfHost][]ManifestEntry
 }
 
 // Prepare the phase
@@ -63,6 +69,11 @@ func (p *UploadFilesCommon) Prepare(_ context.Context, _ *cluster.ZarfCluster, _
 	p.control = hosts.Filter(func(h *cluster.ZarfHost) bool {
 		return !h.Metadata.EngineUploaded && h.IsController()
 	})
+
+	p.priorManifest = make(map[*cluster.ZarfHost][]ManifestEntry, len(p.control)+len(p.workers))
+	for _, h := range slices.Concat(p.control, p.workers) {
+		p.priorManifest[h] = p.readManifest(h)
+	}
 
 	return nil
 }
@@ -87,6 +98,15 @@ func (p *UploadFilesCommon) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+
+	return p.parallelDo(ctx, slices.Concat(p.control, p.workers), p.cleanStaleUploads)
+}
+
+// cleanStaleUploads removes files this run's upload left in the manifest from a previous
+// version but didn't re-upload itself, e.g. an engine binary a version bump renamed.
+func (p *UploadFilesCommon) cleanStaleUploads(ctx context.Context, h *cluster.ZarfHost) error {
+	current := parseManifest(strings.Join(h.Metadata.UploadedFiles, "\n"))
+	p.removeStaleManifestEntries(ctx, h, p.priorManifest[h], current)
 	return nil
 }
 
@@ -130,6 +150,7 @@ func (p *UploadFilesCommon) getProfileFiles(ctx context.Context, selector string
 					Name:           filepath.Base(f.Target),
 					Target:         target,
 					OriginalTarget: f.Target,
+					Category:       "engine",
 					LocalSource: v1alpha1.LocalFile{
 						Path: filePath,
 					},

--- a/src/pkg/phase/55_files_common.go
+++ b/src/pkg/phase/55_files_common.go
@@ -102,11 +102,15 @@ func (p *UploadFilesCommon) Run(ctx context.Context) (err error) {
 	return p.parallelDo(ctx, slices.Concat(p.control, p.workers), p.cleanStaleUploads)
 }
 
-// cleanStaleUploads removes files this run's upload left in the manifest from a previous
-// version but didn't re-upload itself, e.g. an engine binary a version bump renamed.
+// cleanStaleUploads removes engine files this run's upload left in the manifest from a previous
+// version but didn't re-upload itself, e.g. an engine binary a version bump renamed. The diff is
+// scoped to the "engine" category: other upload phases (e.g. images) record into the same
+// per-host UploadedFiles list, and their entries may not exist yet by the time this phase runs.
 func (p *UploadFilesCommon) cleanStaleUploads(ctx context.Context, h *cluster.ZarfHost) error {
 	current := parseManifest(strings.Join(h.Metadata.UploadedFiles, "\n"))
-	p.removeStaleManifestEntries(ctx, h, p.priorManifest[h], current)
+	old := filterManifestByCategory(p.priorManifest[h], "engine")
+	current = filterManifestByCategory(current, "engine")
+	p.removeStaleManifestEntries(ctx, h, old, current)
 	return nil
 }
 

--- a/src/pkg/phase/88_uninstall_engine.go
+++ b/src/pkg/phase/88_uninstall_engine.go
@@ -145,7 +145,7 @@ func (p *UninstallEngine) uninstallNode(ctx context.Context, h *cluster.ZarfHost
 			logger.From(ctx).Warn("failed to remove engine config dir", "path", confPath, "error", err)
 		}
 	}
-	// TODO: remove binaries......
-	// need to sort and unique the results
+	p.cleanUploadManifest(ctx, h)
+
 	return nil
 }

--- a/src/pkg/phase/manifest.go
+++ b/src/pkg/phase/manifest.go
@@ -103,6 +103,20 @@ func diffManifest(old, current []ManifestEntry) []ManifestEntry {
 	return stale
 }
 
+// filterManifestByCategory returns only the entries matching category. Stale-file diffing must
+// be scoped to a single category: an upload phase for one category (e.g. images) can run before
+// another phase (e.g. the engine binary) has re-recorded its own files for the current run, and
+// an unscoped diff would misread the other category's not-yet-uploaded files as stale.
+func filterManifestByCategory(entries []ManifestEntry, category string) []ManifestEntry {
+	filtered := make([]ManifestEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.Category == category {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
 // readManifest reads and parses the manifest from h. It returns nil if the manifest doesn't
 // exist or can't be read.
 func (p *GenericPhase) readManifest(h *cluster.ZarfHost) []ManifestEntry {

--- a/src/pkg/phase/manifest.go
+++ b/src/pkg/phase/manifest.go
@@ -1,0 +1,171 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phase
+
+import (
+	"context"
+	"strings"
+
+	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1/cluster"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+)
+
+const (
+	// manifestDir is the remote directory cargoship uses to track files it uploaded to a host,
+	// kept outside the distro's own data/config directories so it survives long enough to drive
+	// cleanup of paths an uninstall wouldn't otherwise know about (e.g. a binary install target).
+	manifestDir = "/var/lib/cargoship"
+	// manifestFile is the remote path of the upload manifest.
+	manifestFile = manifestDir + "/manifest.txt"
+	// manifestSep separates the category from the path on each manifest line.
+	manifestSep = "\t"
+)
+
+// ManifestEntry is a single file cargoship uploaded to a host, recorded so it can be found
+// and removed later during an upgrade or uninstall.
+type ManifestEntry struct {
+	// Category labels why the file was uploaded, e.g. "engine", "image", "file", "data".
+	Category string
+	// Path is the absolute path of the file on the remote host.
+	Path string
+}
+
+// encodeManifest renders entries as manifest file content, one "category\tpath" line each.
+func encodeManifest(entries []ManifestEntry) string {
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, e.Category+manifestSep+e.Path)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// parseManifest reads manifest file content back into entries. Malformed lines are skipped.
+func parseManifest(content string) []ManifestEntry {
+	entries := []ManifestEntry{}
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, manifestSep, 2)
+		if len(parts) != 2 {
+			continue
+		}
+		entries = append(entries, ManifestEntry{Category: parts[0], Path: parts[1]})
+	}
+	return entries
+}
+
+// mergeManifest dedupes entries by Path, keeping insertion order and the last Category seen
+// for a given Path.
+func mergeManifest(entries []ManifestEntry) []ManifestEntry {
+	order := make([]string, 0, len(entries))
+	byPath := make(map[string]ManifestEntry, len(entries))
+	for _, e := range entries {
+		if _, exists := byPath[e.Path]; !exists {
+			order = append(order, e.Path)
+		}
+		byPath[e.Path] = e
+	}
+	merged := make([]ManifestEntry, 0, len(order))
+	for _, path := range order {
+		merged = append(merged, byPath[path])
+	}
+	return merged
+}
+
+// diffManifest returns entries present in old but missing from current, keyed by Path. This is
+// how a stale file from a previous version (e.g. a renamed engine binary) is found after an
+// upgrade uploads its replacement.
+func diffManifest(old, current []ManifestEntry) []ManifestEntry {
+	keep := make(map[string]bool, len(current))
+	for _, e := range current {
+		keep[e.Path] = true
+	}
+	stale := []ManifestEntry{}
+	for _, e := range old {
+		if !keep[e.Path] {
+			stale = append(stale, e)
+		}
+	}
+	return stale
+}
+
+// readManifest reads and parses the manifest from h. It returns nil if the manifest doesn't
+// exist or can't be read.
+func (p *GenericPhase) readManifest(h *cluster.ZarfHost) []ManifestEntry {
+	if !h.FileExist(manifestFile) {
+		return nil
+	}
+	content, err := h.ReadFile(manifestFile)
+	if err != nil {
+		return nil
+	}
+	return parseManifest(content)
+}
+
+// recordManifestEntry appends path to h's on-disk manifest and to h's in-memory record of what
+// was uploaded during the current run (used by removeStaleManifestEntries to find files an
+// upgrade no longer needs). Failures are logged and swallowed: a missed manifest entry should
+// never fail an upload.
+func (p *GenericPhase) recordManifestEntry(ctx context.Context, h *cluster.ZarfHost, category, path string) {
+	if category == "" {
+		category = "file"
+	}
+
+	h.Metadata.UploadedFiles = append(h.Metadata.UploadedFiles, category+manifestSep+path)
+
+	entries := mergeManifest(append(p.readManifest(h), ManifestEntry{Category: category, Path: path}))
+
+	if err := p.ensureDir(ctx, h, manifestDir, "0755", ""); err != nil {
+		logger.From(ctx).Warn("failed to create upload manifest directory", "host", h, "error", err)
+		return
+	}
+	if err := h.WriteFile(manifestFile, encodeManifest(entries), "0644"); err != nil {
+		logger.From(ctx).Warn("failed to record upload manifest entry", "host", h, "path", path, "error", err)
+	}
+}
+
+// removeStaleManifestEntries deletes files on h that appear in old but not in current, e.g. an
+// engine binary left behind after a version bump renamed it.
+func (p *GenericPhase) removeStaleManifestEntries(ctx context.Context, h *cluster.ZarfHost, old, current []ManifestEntry) {
+	for _, e := range diffManifest(old, current) {
+		logger.From(ctx).Info("removing stale upload from previous install", "host", h, "category", e.Category, "path", e.Path)
+		if err := h.DeleteFile(e.Path); err != nil {
+			logger.From(ctx).Warn("failed to remove stale upload", "host", h, "path", e.Path, "error", err)
+		}
+	}
+}
+
+// cleanUploadManifest deletes every file listed in h's upload manifest, then the manifest
+// itself. Used during uninstall to remove files an engine's own data/config directories don't
+// cover, such as binaries staged outside the distro's data dir.
+func (p *GenericPhase) cleanUploadManifest(ctx context.Context, h *cluster.ZarfHost) {
+	entries := p.readManifest(h)
+	if len(entries) == 0 {
+		return
+	}
+
+	for _, e := range entries {
+		logger.From(ctx).Info("removing uploaded file", "host", h, "category", e.Category, "path", e.Path)
+		if err := h.DeleteFile(e.Path); err != nil {
+			logger.From(ctx).Warn("failed to remove uploaded file", "host", h, "path", e.Path, "error", err)
+		}
+	}
+
+	if err := h.DeleteFile(manifestFile); err != nil {
+		logger.From(ctx).Warn("failed to remove upload manifest", "host", h, "error", err)
+	}
+}

--- a/src/pkg/phase/manifest_test.go
+++ b/src/pkg/phase/manifest_test.go
@@ -89,3 +89,40 @@ func TestDiffManifestEmptyWhenNothingChanged(t *testing.T) {
 	require.Empty(t, diffManifest(entries, entries))
 	require.Empty(t, diffManifest(nil, entries))
 }
+
+func TestFilterManifestByCategory(t *testing.T) {
+	entries := []ManifestEntry{
+		{Category: "engine", Path: "/usr/local/bin/k3s"},
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v1.tar"},
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/other_v1.tar"},
+		{Category: "file", Path: "/etc/rancher/k3s/config.yaml"},
+	}
+
+	require.Equal(t, []ManifestEntry{
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v1.tar"},
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/other_v1.tar"},
+	}, filterManifestByCategory(entries, "image"))
+
+	require.Empty(t, filterManifestByCategory(entries, "data"))
+}
+
+func TestDiffManifestIsScopedByCategory(t *testing.T) {
+	// Regression check for the bug the image-cleanup phase must avoid: the engine binary phase
+	// hasn't re-recorded its file yet when the image phase's own stale-check runs, so an
+	// unscoped diff would misread the engine binary as stale and delete a file still in use.
+	old := []ManifestEntry{
+		{Category: "engine", Path: "/usr/local/bin/k3s"},
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v1.tar"},
+	}
+	// Simulates mid-run state: the image phase re-recorded its file, the engine phase hasn't run yet.
+	current := []ManifestEntry{
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v2.tar"},
+	}
+
+	oldImages := filterManifestByCategory(old, "image")
+	currentImages := filterManifestByCategory(current, "image")
+
+	require.Equal(t, []ManifestEntry{
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v1.tar"},
+	}, diffManifest(oldImages, currentImages))
+}

--- a/src/pkg/phase/manifest_test.go
+++ b/src/pkg/phase/manifest_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeParseManifestRoundTrip(t *testing.T) {
+	entries := []ManifestEntry{
+		{Category: "engine", Path: "/usr/local/bin/k3s"},
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v1.tar"},
+	}
+
+	content := encodeManifest(entries)
+	require.Equal(t, "engine\t/usr/local/bin/k3s\nimage\t/var/lib/rancher/k3s/agent/images/app_v1.tar\n", content)
+
+	parsed := parseManifest(content)
+	require.Equal(t, entries, parsed)
+}
+
+func TestParseManifestSkipsMalformedLines(t *testing.T) {
+	content := "engine\t/usr/local/bin/k3s\n\nnoseparatorhere\n  \nimage\t/tmp/app.tar\n"
+
+	parsed := parseManifest(content)
+
+	require.Equal(t, []ManifestEntry{
+		{Category: "engine", Path: "/usr/local/bin/k3s"},
+		{Category: "image", Path: "/tmp/app.tar"},
+	}, parsed)
+}
+
+func TestMergeManifestDedupesByPathKeepingOrderAndLatestCategory(t *testing.T) {
+	entries := []ManifestEntry{
+		{Category: "file", Path: "/etc/rancher/k3s/config.yaml"},
+		{Category: "engine", Path: "/usr/local/bin/k3s"},
+		{Category: "engine-updated", Path: "/usr/local/bin/k3s"},
+	}
+
+	merged := mergeManifest(entries)
+
+	require.Equal(t, []ManifestEntry{
+		{Category: "file", Path: "/etc/rancher/k3s/config.yaml"},
+		{Category: "engine-updated", Path: "/usr/local/bin/k3s"},
+	}, merged)
+}
+
+func TestDiffManifestFindsFilesAPreviousVersionLeftBehind(t *testing.T) {
+	// Simulates an upgrade: v1 uploaded a binary named for its version, v2's upload no longer
+	// produces that path because the new binary is named differently.
+	old := []ManifestEntry{
+		{Category: "engine", Path: "/usr/local/bin/k3s-v1"},
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v1.tar"},
+		{Category: "file", Path: "/etc/rancher/k3s/config.yaml"},
+	}
+	current := []ManifestEntry{
+		{Category: "engine", Path: "/usr/local/bin/k3s-v2"},
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v2.tar"},
+		{Category: "file", Path: "/etc/rancher/k3s/config.yaml"},
+	}
+
+	stale := diffManifest(old, current)
+
+	require.Equal(t, []ManifestEntry{
+		{Category: "engine", Path: "/usr/local/bin/k3s-v1"},
+		{Category: "image", Path: "/var/lib/rancher/k3s/agent/images/app_v1.tar"},
+	}, stale)
+}
+
+func TestDiffManifestEmptyWhenNothingChanged(t *testing.T) {
+	entries := []ManifestEntry{
+		{Category: "engine", Path: "/usr/local/bin/k3s"},
+	}
+
+	require.Empty(t, diffManifest(entries, entries))
+	require.Empty(t, diffManifest(nil, entries))
+}


### PR DESCRIPTION
## Description

Adds a remote-side manifest of every file cargoship uploads to a host, so upgrades and uninstalls can find and remove files they otherwise wouldn't know about. `UninstallEngine.uninstallNode` had a literal `// TODO: remove binaries......` -- it already `rm -rf`s the engine's data and config directories, but a BIN-installed engine binary (or anything else uploaded outside those directories) was never tracked and never cleaned up.

`src/pkg/phase/manifest.go` is new and holds the core logic as small, pure functions: `encodeManifest`/`parseManifest` read and write `category\tpath` lines, `mergeManifest` dedupes by path, and `diffManifest` finds entries a previous run wrote that the current run didn't reproduce -- e.g. an engine binary or image tag renamed by a version bump. The manifest itself lives at `/var/lib/cargoship/manifest.txt` on each host, deliberately outside the distro's own data/config directories so it survives long enough to drive cleanup of paths an uninstall wouldn't otherwise touch.

Recording is wired into the single choke point every upload already goes through, `GenericPhase.uploadFile`/`uploadData` in `01_generic_phase_file.go`, so every upload path (images, distro files, inline host data, RPM/APT/BIN engine files) is covered without touching each call site's logic. Added a `Category` field to `ZarfFile` (`engine`, `image`, `file`, `data`) so the manifest records *why* a file was uploaded, not just where. One subtlety: executable files upload to a temporary staged path (see `stageTempPath`) before being moved into place, so `uploadFile` records `f.OriginalTarget` -- the real final path -- rather than the staged one.

`UploadFiles` (images) and `UploadFilesCommon` (RPM/APT/BIN engine files) each snapshot a host's manifest in `Prepare`, then after uploading diff that snapshot against what got recorded this run and delete anything left over from a previous version. This diff has to be scoped per-category: `UploadFiles` runs before the engine-binary phases, so at the point its own stale-check runs, the engine phase hasn't re-recorded its file into `h.Metadata.UploadedFiles` yet. An unscoped diff would misread the live, not-yet-re-uploaded engine binary as stale and delete it out from under a running service. `filterManifestByCategory` plus `TestDiffManifestIsScopedByCategory` cover exactly this.

`UninstallEngine.uninstallNode` now calls `cleanUploadManifest`, which reads the manifest, deletes every listed file, and removes the manifest itself -- replacing the old TODO.

Verified with `go build`, `go vet`, and `go test ./src/...`, all clean. Added 7 unit tests in `manifest_test.go` covering encode/parse round-tripping, malformed-line handling, dedup/merge, stale-file detection, and the category-scoping fix above.

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
