### PR TITLE
feat: add logging to file

### DIFF
--- a/docs/commands/cargoship.md
+++ b/docs/commands/cargoship.md
@@ -14,6 +14,7 @@ cargoship COMMAND [flags]
   -a, --architecture string        Architecture for OCI images and Zarf packages
   -h, --help                       help for cargoship
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_apply.md
+++ b/docs/commands/cargoship_apply.md
@@ -26,6 +26,7 @@ cargoship apply [Distro Package] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_create.md
+++ b/docs/commands/cargoship_create.md
@@ -27,6 +27,7 @@ cargoship create [Dir] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_kube-config.md
+++ b/docs/commands/cargoship_kube-config.md
@@ -21,6 +21,7 @@ cargoship kube-config [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_prepare.md
+++ b/docs/commands/cargoship_prepare.md
@@ -26,6 +26,7 @@ cargoship prepare [Distro Package] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_publish.md
+++ b/docs/commands/cargoship_publish.md
@@ -33,6 +33,7 @@ cargoship publish [Package] [REPOSITORY] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_pull.md
+++ b/docs/commands/cargoship_pull.md
@@ -31,6 +31,7 @@ cargoship pull [Package] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_reset.md
+++ b/docs/commands/cargoship_reset.md
@@ -27,6 +27,7 @@ cargoship reset [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_sha256sum.md
+++ b/docs/commands/cargoship_sha256sum.md
@@ -20,6 +20,7 @@ cargoship sha256sum [ FILE | URL ] [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_sign.md
+++ b/docs/commands/cargoship_sign.md
@@ -69,6 +69,7 @@ $ cargoship sign cargoship-rancher-rke2-amd64-1.0.0.tar.zst --signing-key awskms
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/docs/commands/cargoship_version.md
+++ b/docs/commands/cargoship_version.md
@@ -24,6 +24,7 @@ cargoship version [flags]
 ```
   -a, --architecture string        Architecture for OCI images and Zarf packages
       --insecure-skip-tls-verify   Skip checking server's certificate for validity. This flag should only be used if you have a specific reason and accept the reduced security posture.
+      --log-file                   Always write a full-verbosity debug log to a file, regardless of --log-level.
   -L, --log-format string          Select a logging format. Defaults to 'console'. Valid options are: 'console', 'json', 'dev'. (default "console")
   -l, --log-level string           Log level when running cargoship. Valid options are: warn, info, debug, trace (default "info")
       --no-color                   Disable terminal color codes in logging and stdout prints.

--- a/schema/zarf-config-distro-schema.json
+++ b/schema/zarf-config-distro-schema.json
@@ -238,6 +238,10 @@
       "$ref": "#/$defs/DistroOptions",
       "description": "are various options used by the command"
     },
+    "log_file": {
+      "description": "enables always writing a full-verbosity debug log to a file, regardless of LogLevel",
+      "type": "boolean"
+    },
     "log_format": {
       "default": "console",
       "description": "how the logs are displayed well running",

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -273,10 +273,6 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	ctx := logger.WithContext(cmd.Context(), l)
 	cmd.SetContext(ctx)
 
-	if f != nil {
-		l.Info("writing full-verbosity debug log to file, regardless of --log-level", "path", f.Name())
-	}
-
 	// if --no-color is set, disable PTerm color in message prints
 	if IsColorDisabled {
 		pterm.DisableColor()
@@ -286,6 +282,10 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	err = PrintViperConfigUsed(cmd.Context())
 	if err != nil {
 		return err
+	}
+
+	if f != nil {
+		l.Info("logging debug to", "path", f.Name())
 	}
 
 	l.Debug("using temporary directory", "tmpDir", config.CommonOptions.TempDirectory)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -335,13 +335,14 @@ func setupLogger(level, format string, isColor bool, logFilePath string) (*slog.
 }
 
 // defaultLogFilePath returns where the always-on debug log file is written: under the same
-// cache directory cargoship already uses for OCI artifacts, one file per invocation so
-// concurrent runs don't clobber each other's logs.
+// cache directory cargoship already uses for OCI artifacts, named to the second. Invocations
+// started within the same second share/append to the same file since the name carries no PID
+// or other disambiguator.
 func defaultLogFilePath() string {
 	cacheDir, err := config.GetAbsCachePath()
 	if err != nil || cacheDir == "" {
 		cacheDir = config.DefaultCachePath
 	}
-	name := fmt.Sprintf("cargoship-%s-%d.log", time.Now().Format("20060102-150405"), os.Getpid())
+	name := fmt.Sprintf("cargoship-%s.log", time.Now().Format(config.TimeFormat))
 	return filepath.Join(cacheDir, "logs", name)
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -26,10 +26,13 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/colonel-byte/cargoship/src/cmd/flags"
 	"github.com/colonel-byte/cargoship/src/config"
 	"github.com/colonel-byte/cargoship/src/config/lang"
+	"github.com/colonel-byte/cargoship/src/internal/logging"
 	"github.com/colonel-byte/cargoship/src/pkg/utils"
 	"github.com/colonel-byte/cargoship/src/types"
 	"github.com/pterm/pterm"
@@ -92,8 +95,13 @@ var (
 	LogFormat string
 	// LogLevelCLI log level
 	LogLevelCLI string
+	// LogFile enables always writing a full-verbosity debug log to a file
+	LogFile bool
 	// Timeout for how long a task runs
-	Timeout   string
+	Timeout string
+	// logFile is the file handle backing the always-on debug log, if enabled. Held here so
+	// Execute can close it once the command has finished running.
+	logFile   *os.File
 	distroCfg = types.DistroConfig{}
 )
 
@@ -158,6 +166,7 @@ func NewCargoshipCommand() *cobra.Command {
 	}
 	rootCmd.PersistentFlags().StringVar(&Timeout, RootTimeout, v.GetString(RootTimeout), lang.CmdInstallFlagTimeout)
 	rootCmd.PersistentFlags().BoolVar(&IsColorDisabled, "no-color", resolvedConfig.NoColor, lang.RootCmdFlagNoColor)
+	rootCmd.PersistentFlags().BoolVar(&LogFile, "log-file", resolvedConfig.LogFile, lang.RootCmdFlagLogFile)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, RootZarfCache, parsePath(rootCmd.Context(), resolvedConfig.CachePath), zlang.RootCmdFlagCachePath)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.TempDirectory, "tmpdir", parsePath(rootCmd.Context(), resolvedConfig.TempDirectory), zlang.RootCmdFlagTempDir)
 	rootCmd.PersistentFlags().StringVarP(&config.CLIArch, RootArchitecture, "a", resolvedConfig.Architecture, zlang.RootCmdFlagArch)
@@ -174,6 +183,12 @@ func NewCargoshipCommand() *cobra.Command {
 
 // Execute is the root execute logic
 func Execute(ctx context.Context) error {
+	defer func() {
+		if logFile != nil {
+			_ = logFile.Close() //nolint:errcheck
+		}
+	}()
+
 	_, err := rootCmd.ExecuteContextC(ctx)
 	if err == nil {
 		return nil
@@ -244,13 +259,23 @@ func unmarshalAndValidateConfig(configFile []byte, distroCfg *types.DistroConfig
 }
 
 func preRun(cmd *cobra.Command, _ []string) error {
+	logFilePath := ""
+	if LogFile {
+		logFilePath = defaultLogFilePath()
+	}
+
 	// Configure logger and add it to cmd context. We flip NoColor because setLogger wants "isColor"
-	l, err := setupLogger(LogLevelCLI, LogFormat, !IsColorDisabled)
+	l, f, err := setupLogger(LogLevelCLI, LogFormat, !IsColorDisabled, logFilePath)
 	if err != nil {
 		return err
 	}
+	logFile = f
 	ctx := logger.WithContext(cmd.Context(), l)
 	cmd.SetContext(ctx)
+
+	if f != nil {
+		l.Debug("writing full-verbosity debug log to file, regardless of --log-level", "path", f.Name())
+	}
 
 	// if --no-color is set, disable PTerm color in message prints
 	if IsColorDisabled {
@@ -267,15 +292,18 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// setupLogger handles creating a logger and setting it as the global default.
-func setupLogger(level, format string, isColor bool) (*slog.Logger, error) {
+// setupLogger handles creating a logger and setting it as the global default. When logFilePath
+// is non-empty, every log level is additionally written to that file as JSON, regardless of
+// what level is configured for the console -- the returned *os.File is the caller's to close
+// once logging is done.
+func setupLogger(level, format string, isColor bool, logFilePath string) (*slog.Logger, *os.File, error) {
 	// If we didn't get a level from config, fallback to "info"
 	if level == "" {
 		level = "info"
 	}
 	sLevel, err := logger.ParseLevel(level)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	cfg := logger.Config{
 		Level:       sLevel,
@@ -285,9 +313,35 @@ func setupLogger(level, format string, isColor bool) (*slog.Logger, error) {
 	}
 	l, err := logger.New(cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	var f *os.File
+	if logFilePath != "" {
+		fileHandler, opened, err := logging.OpenFileHandler(logFilePath)
+		if err != nil {
+			// A log file we can't open shouldn't block the CLI from running; fall back to
+			// console-only logging.
+			l.Warn("failed to open log file, continuing without one", "path", logFilePath, "error", err)
+		} else {
+			f = opened
+			l = slog.New(logging.NewMultiHandler(l.Handler(), fileHandler))
+		}
+	}
+
 	logger.SetDefault(l)
-	l.Debug("logger successfully initialized", "cfg", cfg)
-	return l, nil
+	l.Debug("logger successfully initialized", "cfg", cfg, "logFile", logFilePath)
+	return l, f, nil
+}
+
+// defaultLogFilePath returns where the always-on debug log file is written: under the same
+// cache directory cargoship already uses for OCI artifacts, one file per invocation so
+// concurrent runs don't clobber each other's logs.
+func defaultLogFilePath() string {
+	cacheDir, err := config.GetAbsCachePath()
+	if err != nil || cacheDir == "" {
+		cacheDir = config.DefaultCachePath
+	}
+	name := fmt.Sprintf("cargoship-%s-%d.log", time.Now().Format("20060102-150405"), os.Getpid())
+	return filepath.Join(cacheDir, "logs", name)
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -274,7 +274,7 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	cmd.SetContext(ctx)
 
 	if f != nil {
-		l.Debug("writing full-verbosity debug log to file, regardless of --log-level", "path", f.Name())
+		l.Info("writing full-verbosity debug log to file, regardless of --log-level", "path", f.Name())
 	}
 
 	// if --no-color is set, disable PTerm color in message prints

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -177,6 +177,7 @@ func setDefaults() {
 	v.SetDefault(configPath("LogFormat"), string(logger.FormatConsole))
 	v.SetDefault(configPath("TempDirectory"), "/tmp")
 	v.SetDefault(configPath("NoColor"), false)
+	v.SetDefault(configPath("LogFile"), false)
 
 	v.SetDefault(configPath("DistroOpts", "OCIConcurrency"), 6)
 	v.SetDefault(configPath("DistroOpts", "CreateOpts", "SkipSBOM"), false)

--- a/src/config/constant.go
+++ b/src/config/constant.go
@@ -53,3 +53,8 @@ const (
 	// OutputFromatTable table output format
 	OutputFromatTable = "table"
 )
+
+const (
+	// TimeFormat is the time.Time layout used for timestamps embedded in generated log file names.
+	TimeFormat = "2006.01.02-15.04.05"
+)

--- a/src/config/constant.go
+++ b/src/config/constant.go
@@ -56,5 +56,5 @@ const (
 
 const (
 	// TimeFormat is the time.Time layout used for timestamps embedded in generated log file names.
-	TimeFormat = "2006.01.02-15.04.05"
+	TimeFormat = "2006.01.02-15.04.05.00"
 )

--- a/src/config/lang/eng-core.go
+++ b/src/config/lang/eng-core.go
@@ -82,6 +82,8 @@ const (
 	RootCmdFlagLogLevel = "Log level when running cargoship. Valid options are: warn, info, debug, trace"
 	// RootCmdFlagNoColor no color
 	RootCmdFlagNoColor = "Disable terminal color codes in logging and stdout prints."
+	// RootCmdFlagLogFile log file
+	RootCmdFlagLogFile = "Always write a full-verbosity debug log to a file, regardless of --log-level."
 	// RootCmdShort root short
 	RootCmdShort = "CLI for cargoship installs"
 	// RootCmdUse root use

--- a/src/internal/logging/file_handler.go
+++ b/src/internal/logging/file_handler.go
@@ -1,0 +1,42 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// OpenFileHandler opens (creating if needed) the file at path and returns an slog.Handler that
+// writes every level -- Debug and up, i.e. all of them -- to it as JSON. The caller owns the
+// returned file and must close it once logging is done.
+func OpenFileHandler(path string) (slog.Handler, *os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, nil, fmt.Errorf("failed to create log file directory: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open log file: %w", err)
+	}
+
+	handler := slog.NewJSONHandler(f, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+
+	return handler, f, nil
+}

--- a/src/internal/logging/multi_handler.go
+++ b/src/internal/logging/multi_handler.go
@@ -1,0 +1,84 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logging provides an slog.Handler that fans a record out to several handlers, each
+// with its own independent level filter. It exists so cargoship can write every log level to a
+// file for later debugging while the terminal keeps showing only what the user's configured
+// --log-level asks for.
+package logging
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// MultiHandler dispatches each log record to every handler that wants it. Unlike wrapping a
+// single slog.Logger, each handler keeps its own Enabled check: one handler can be silent at
+// Info while another still records everything down to Debug.
+type MultiHandler struct {
+	handlers []slog.Handler
+}
+
+// NewMultiHandler returns a MultiHandler that fans records out to handlers.
+func NewMultiHandler(handlers ...slog.Handler) *MultiHandler {
+	return &MultiHandler{handlers: handlers}
+}
+
+// Enabled reports whether at least one handler wants records at level. This must stay a
+// logical OR: the top-level slog.Logger calls Enabled before Handle, so if this returned false
+// whenever any single handler would refuse the level, that handler would silence every other
+// handler in the group along with it -- including a file handler meant to catch everything.
+func (m *MultiHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, h := range m.handlers {
+		if h.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+// Handle passes r to every handler whose own Enabled check accepts r.Level.
+func (m *MultiHandler) Handle(ctx context.Context, r slog.Record) error {
+	var errs []error
+	for _, h := range m.handlers {
+		if !h.Enabled(ctx, r.Level) {
+			continue
+		}
+		// Record.Clone is required here: slog.Record's Attrs iterator can only be walked
+		// once safely, and each handler in the group walks it independently.
+		if err := h.Handle(ctx, r.Clone()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// WithAttrs returns a MultiHandler whose children each have attrs added.
+func (m *MultiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Handler, len(m.handlers))
+	for i, h := range m.handlers {
+		next[i] = h.WithAttrs(attrs)
+	}
+	return &MultiHandler{handlers: next}
+}
+
+// WithGroup returns a MultiHandler whose children each have the group added.
+func (m *MultiHandler) WithGroup(name string) slog.Handler {
+	next := make([]slog.Handler, len(m.handlers))
+	for i, h := range m.handlers {
+		next[i] = h.WithGroup(name)
+	}
+	return &MultiHandler{handlers: next}
+}

--- a/src/internal/logging/multi_handler_test.go
+++ b/src/internal/logging/multi_handler_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiHandlerWritesEveryLevelToFileRegardlessOfConsoleLevel(t *testing.T) {
+	var console, file bytes.Buffer
+
+	// Console only shows Warn and above, file (like the log-file handler) keeps everything.
+	consoleHandler := slog.NewTextHandler(&console, &slog.HandlerOptions{Level: slog.LevelWarn})
+	fileHandler := slog.NewTextHandler(&file, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	logger := slog.New(NewMultiHandler(consoleHandler, fileHandler))
+
+	logger.Debug("debug message")
+	logger.Info("info message")
+	logger.Warn("warn message")
+
+	require.NotContains(t, console.String(), "debug message")
+	require.NotContains(t, console.String(), "info message")
+	require.Contains(t, console.String(), "warn message")
+
+	require.Contains(t, file.String(), "debug message")
+	require.Contains(t, file.String(), "info message")
+	require.Contains(t, file.String(), "warn message")
+}
+
+func TestMultiHandlerEnabledIsTrueIfAnyChildWants(t *testing.T) {
+	quiet := slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelError})
+	verbose := slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	m := NewMultiHandler(quiet, verbose)
+
+	require.True(t, m.Enabled(t.Context(), slog.LevelDebug))
+	require.False(t, NewMultiHandler(quiet).Enabled(t.Context(), slog.LevelDebug))
+}
+
+func TestMultiHandlerWithAttrsAppliesToEveryChild(t *testing.T) {
+	var a, b bytes.Buffer
+	m := NewMultiHandler(
+		slog.NewTextHandler(&a, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		slog.NewTextHandler(&b, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+
+	logger := slog.New(m).With("requestId", "abc123")
+	logger.Info("hello")
+
+	require.Contains(t, a.String(), "request_id=abc123")
+	require.Contains(t, b.String(), "request_id=abc123")
+}
+
+func TestMultiHandlerWithGroupAppliesToEveryChild(t *testing.T) {
+	var a, b bytes.Buffer
+	m := NewMultiHandler(
+		slog.NewTextHandler(&a, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		slog.NewTextHandler(&b, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+
+	logger := slog.New(m).WithGroup("upload").With("file", "k3s")
+	logger.Info("hello")
+
+	for _, out := range []string{a.String(), b.String()} {
+		require.Contains(t, out, "upload.file=k3s")
+	}
+}

--- a/src/internal/logging/multi_handler_test.go
+++ b/src/internal/logging/multi_handler_test.go
@@ -64,8 +64,8 @@ func TestMultiHandlerWithAttrsAppliesToEveryChild(t *testing.T) {
 	logger := slog.New(m).With("requestId", "abc123")
 	logger.Info("hello")
 
-	require.Contains(t, a.String(), "request_id=abc123")
-	require.Contains(t, b.String(), "request_id=abc123")
+	require.Contains(t, a.String(), "requestId=abc123")
+	require.Contains(t, b.String(), "requestId=abc123")
 }
 
 func TestMultiHandlerWithGroupAppliesToEveryChild(t *testing.T) {

--- a/src/internal/riglogger/core.go
+++ b/src/internal/riglogger/core.go
@@ -30,27 +30,38 @@ type rigLogger struct {
 
 // Debugf implements log.Logger.
 func (l rigLogger) Debugf(msg string, args ...any) {
-	logger.From(l.ctx).Debug(fmt.Sprintf(msg, args...))
+	logger.From(l.ctx).Debug(fmt.Sprintf(msg, args...), argAttrs(args)...)
 }
 
 // Errorf implements log.Logger.
 func (l rigLogger) Errorf(msg string, args ...any) {
-	logger.From(l.ctx).Error(fmt.Sprintf(msg, args...))
+	logger.From(l.ctx).Error(fmt.Sprintf(msg, args...), argAttrs(args)...)
 }
 
 // Infof implements log.Logger.
 func (l rigLogger) Infof(msg string, args ...any) {
-	logger.From(l.ctx).Info(fmt.Sprintf(msg, args...))
+	logger.From(l.ctx).Info(fmt.Sprintf(msg, args...), argAttrs(args)...)
 }
 
 // Tracef implements log.Logger.
 func (l rigLogger) Tracef(msg string, args ...any) {
-	logger.From(l.ctx).Debug(fmt.Sprintf(msg, args...))
+	logger.From(l.ctx).Debug(fmt.Sprintf(msg, args...), argAttrs(args)...)
 }
 
 // Warnf implements log.Logger.
 func (l rigLogger) Warnf(msg string, args ...any) {
-	logger.From(l.ctx).Warn(fmt.Sprintf(msg, args...))
+	logger.From(l.ctx).Warn(fmt.Sprintf(msg, args...), argAttrs(args)...)
+}
+
+// argAttrs turns rig's positional printf args into their own slog key-value pairs (key, value)
+// so structured sinks like the JSON file handler retain each raw value instead of only the
+// single flattened message string that fmt.Sprintf produces.
+func argAttrs(args []any) []any {
+	attrs := make([]any, 0, len(args)*2)
+	for i, arg := range args {
+		attrs = append(attrs, fmt.Sprint(args[i]), arg)
+	}
+	return attrs
 }
 
 // RigLogger overrides the rig.Log with our custom logger

--- a/src/internal/riglogger/core.go
+++ b/src/internal/riglogger/core.go
@@ -18,6 +18,7 @@ package riglogger
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/k0sproject/rig/log"
 	"github.com/zarf-dev/zarf/src/pkg/logger"
@@ -30,38 +31,39 @@ type rigLogger struct {
 
 // Debugf implements log.Logger.
 func (l rigLogger) Debugf(msg string, args ...any) {
-	logger.From(l.ctx).Debug(fmt.Sprintf(msg, args...), argAttrs(args)...)
+	logger.From(l.ctx).Debug(fmt.Sprintf(msg, args...), argAttrs(args))
 }
 
 // Errorf implements log.Logger.
 func (l rigLogger) Errorf(msg string, args ...any) {
-	logger.From(l.ctx).Error(fmt.Sprintf(msg, args...), argAttrs(args)...)
+	logger.From(l.ctx).Error(fmt.Sprintf(msg, args...), argAttrs(args))
 }
 
 // Infof implements log.Logger.
 func (l rigLogger) Infof(msg string, args ...any) {
-	logger.From(l.ctx).Info(fmt.Sprintf(msg, args...), argAttrs(args)...)
+	logger.From(l.ctx).Info(fmt.Sprintf(msg, args...), argAttrs(args))
 }
 
 // Tracef implements log.Logger.
 func (l rigLogger) Tracef(msg string, args ...any) {
-	logger.From(l.ctx).Debug(fmt.Sprintf(msg, args...), argAttrs(args)...)
+	logger.From(l.ctx).Debug(fmt.Sprintf(msg, args...), argAttrs(args))
 }
 
 // Warnf implements log.Logger.
 func (l rigLogger) Warnf(msg string, args ...any) {
-	logger.From(l.ctx).Warn(fmt.Sprintf(msg, args...), argAttrs(args)...)
+	logger.From(l.ctx).Warn(fmt.Sprintf(msg, args...), argAttrs(args))
 }
 
-// argAttrs turns rig's positional printf args into their own slog key-value pairs (key, value)
-// so structured sinks like the JSON file handler retain each raw value instead of only the
-// single flattened message string that fmt.Sprintf produces.
-func argAttrs(args []any) []any {
-	attrs := make([]any, 0, len(args)*2)
+// argAttrs turns rig's positional printf args into an "args" group of slog key-value pairs so
+// structured sinks like the JSON file handler retain each raw value instead of only the single
+// flattened message string that fmt.Sprintf produces. When args is empty, slog.Group returns a
+// zero Attr that handlers skip, so no empty "args" object is logged.
+func argAttrs(args []any) slog.Attr {
+	pairs := make([]any, 0, len(args)*2)
 	for i, arg := range args {
-		attrs = append(attrs, fmt.Sprint(args[i]), arg)
+		pairs = append(pairs, fmt.Sprint(args[i]), arg)
 	}
-	return attrs
+	return slog.Group("args", pairs...)
 }
 
 // RigLogger overrides the rig.Log with our custom logger

--- a/src/pkg/phase/06_service_logs.go
+++ b/src/pkg/phase/06_service_logs.go
@@ -1,0 +1,88 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phase
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1/cluster"
+	"github.com/colonel-byte/cargoship/src/config"
+	"github.com/k0sproject/rig/exec"
+	"github.com/zarf-dev/zarf/src/pkg/logger"
+)
+
+var serviceLogFilenameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9.-]+`)
+
+// captureServiceLogsOnFailure is a no-op when waitErr is nil. Otherwise it best-effort fetches
+// h's systemd journal for service, covering the window since startedAt, and writes it to a
+// local file -- so a service that never became ready leaves behind more to debug than just a
+// timeout error. It always returns waitErr unchanged: a failure to capture logs must never mask
+// or replace the real error that made the wait fail.
+func (p *GenericPhase) captureServiceLogsOnFailure(ctx context.Context, h *cluster.ZarfHost, service string, startedAt time.Time, waitErr error) error {
+	if waitErr == nil {
+		return nil
+	}
+
+	l := logger.From(ctx)
+
+	// "@<unix-seconds>" is journalctl's locale/timezone-independent form for --since.
+	cmd := fmt.Sprintf("journalctl -u %s --no-pager --since=@%d", service, startedAt.Unix())
+	output, err := h.ExecOutput(cmd, exec.Sudo(h))
+	if err != nil {
+		l.Warn("failed to collect remote service logs for debugging", "host", h, "service", service, "error", err)
+		return waitErr
+	}
+
+	path, err := writeServiceLogFile(h, service, output)
+	if err != nil {
+		l.Warn("failed to save remote service logs for debugging", "host", h, "service", service, "error", err)
+		return waitErr
+	}
+
+	l.Warn("service did not become ready in time, saved its logs for debugging", "host", h, "service", service, "path", path)
+	return waitErr
+}
+
+// writeServiceLogFile saves content under the same cache/logs directory cargoship's own
+// --log-file debug log uses, named so repeated failures for the same host/service don't
+// clobber each other.
+func writeServiceLogFile(h *cluster.ZarfHost, service, content string) (string, error) {
+	cacheDir, err := config.GetAbsCachePath()
+	if err != nil || cacheDir == "" {
+		cacheDir = config.DefaultCachePath
+	}
+	logsDir := filepath.Join(cacheDir, "logs")
+	if err := os.MkdirAll(logsDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create log directory: %w", err)
+	}
+
+	name := fmt.Sprintf(
+		"%s-%s-%s.log",
+		serviceLogFilenameSanitizer.ReplaceAllString(h.String(), "_"),
+		serviceLogFilenameSanitizer.ReplaceAllString(service, "_"),
+		time.Now().Format("20060102-150405"),
+	)
+	path := filepath.Join(logsDir, name)
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return "", fmt.Errorf("failed to write log file: %w", err)
+	}
+	return path, nil
+}

--- a/src/pkg/phase/06_service_logs.go
+++ b/src/pkg/phase/06_service_logs.go
@@ -77,7 +77,7 @@ func writeServiceLogFile(h *cluster.ZarfHost, service, content string) (string, 
 		"%s-%s-%s.log",
 		serviceLogFilenameSanitizer.ReplaceAllString(h.String(), "_"),
 		serviceLogFilenameSanitizer.ReplaceAllString(service, "_"),
-		time.Now().Format("20060102-150405"),
+		time.Now().Format(config.TimeFormat),
 	)
 	path := filepath.Join(logsDir, name)
 

--- a/src/pkg/phase/06_service_logs_test.go
+++ b/src/pkg/phase/06_service_logs_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phase
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1/cluster"
+	"github.com/colonel-byte/cargoship/src/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureServiceLogsOnFailureNoOpWhenWaitSucceeded(t *testing.T) {
+	config.CommonOptions.CachePath = t.TempDir()
+
+	p := &GenericPhase{}
+	h := &cluster.ZarfHost{}
+
+	err := p.captureServiceLogsOnFailure(context.Background(), h, "k3s", time.Now(), nil)
+
+	require.NoError(t, err)
+	require.NoDirExists(t, filepath.Join(config.CommonOptions.CachePath, "logs"))
+}
+
+func TestWriteServiceLogFileSanitizesNameAndWritesContent(t *testing.T) {
+	config.CommonOptions.CachePath = t.TempDir()
+	h := &cluster.ZarfHost{}
+
+	path, err := writeServiceLogFile(h, "k3s agent", "journal output here")
+	require.NoError(t, err)
+
+	require.FileExists(t, path)
+	require.Equal(t, filepath.Join(config.CommonOptions.CachePath, "logs"), filepath.Dir(path))
+
+	// service name with a space must not survive into the filename unsanitized
+	require.Contains(t, filepath.Base(path), "k3s_agent")
+	require.NotContains(t, filepath.Base(path), " ")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "journal output here", string(content))
+}
+
+func TestWriteServiceLogFileDoesNotClobberConcurrentCalls(t *testing.T) {
+	config.CommonOptions.CachePath = t.TempDir()
+	h := &cluster.ZarfHost{}
+
+	pathA, err := writeServiceLogFile(h, "k3s", "first attempt")
+	require.NoError(t, err)
+	time.Sleep(time.Second) // filenames are second-resolution timestamps
+	pathB, err := writeServiceLogFile(h, "k3s", "second attempt")
+	require.NoError(t, err)
+
+	require.NotEqual(t, pathA, pathB)
+
+	first, err := os.ReadFile(pathA)
+	require.NoError(t, err)
+	require.Equal(t, "first attempt", string(first))
+
+	second, err := os.ReadFile(pathB)
+	require.NoError(t, err)
+	require.Equal(t, "second attempt", string(second))
+}
+
+func TestCaptureServiceLogsOnFailureReturnsOriginalErrorEvenWhenCaptureFails(t *testing.T) {
+	// An unresolved host (no connection configured) makes h.ExecOutput fail; the capture
+	// helper must still hand back the real wait error rather than swallowing or replacing it.
+	config.CommonOptions.CachePath = t.TempDir()
+
+	p := &GenericPhase{}
+	h := &cluster.ZarfHost{}
+	waitErr := errors.New("service k3s is not running")
+
+	err := p.captureServiceLogsOnFailure(context.Background(), h, "k3s", time.Now(), waitErr)
+
+	require.ErrorIs(t, err, waitErr)
+}

--- a/src/pkg/phase/61_initialize_controller.go
+++ b/src/pkg/phase/61_initialize_controller.go
@@ -94,18 +94,20 @@ func (p *InitializeControllers) installDistro(ctx context.Context, h *cluster.Za
 }
 
 func (p *InitializeControllers) startService(ctx context.Context, h *cluster.ZarfHost) error {
-	logger.From(ctx).Info("waiting for the controller service to start", "service", p.Distro.GetControllerService(), "host", h)
+	service := p.Distro.GetControllerService()
+	logger.From(ctx).Info("waiting for the controller service to start", "service", service, "host", h)
 
+	startedAt := time.Now()
 	go func() {
-		err := h.Configurer.StartService(h, p.Distro.GetControllerService())
+		err := h.Configurer.StartService(h, service)
 		if err != nil {
-			logger.From(ctx).Warn("failed to start", "service", p.Distro.GetControllerService(), "host", h)
+			logger.From(ctx).Warn("failed to start", "service", service, "host", h)
 		}
 	}()
 
-	if err := p.manager.RetryTimeout(ctx, node.ServiceRunningFunc(h, p.Distro.GetControllerService())); err != nil {
-		return err
+	if err := p.manager.RetryTimeout(ctx, node.ServiceRunningFunc(h, service)); err != nil {
+		return p.captureServiceLogsOnFailure(ctx, h, service, startedAt, err)
 	}
 
-	return h.Configurer.EnableService(h, p.Distro.GetControllerService())
+	return h.Configurer.EnableService(h, service)
 }

--- a/src/pkg/phase/62_initialize_worker.go
+++ b/src/pkg/phase/62_initialize_worker.go
@@ -102,18 +102,20 @@ func (p *InitializeWorkers) installDistro(ctx context.Context, h *cluster.ZarfHo
 }
 
 func (p *InitializeWorkers) startService(ctx context.Context, h *cluster.ZarfHost) error {
-	logger.From(ctx).Info("waiting for the worker service to start", "service", p.Distro.GetWorkerService(), "host", h)
+	service := p.Distro.GetWorkerService()
+	logger.From(ctx).Info("waiting for the worker service to start", "service", service, "host", h)
 
+	startedAt := time.Now()
 	go func() {
-		err := h.Configurer.StartService(h, p.Distro.GetWorkerService())
+		err := h.Configurer.StartService(h, service)
 		if err != nil {
-			logger.From(ctx).Warn("failed to start", "service", p.Distro.GetWorkerService(), "host", h)
+			logger.From(ctx).Warn("failed to start", "service", service, "host", h)
 		}
 	}()
 
-	if err := p.manager.RetryTimeout(ctx, node.ServiceRunningFunc(h, p.Distro.GetWorkerService())); err != nil {
-		return err
+	if err := p.manager.RetryTimeout(ctx, node.ServiceRunningFunc(h, service)); err != nil {
+		return p.captureServiceLogsOnFailure(ctx, h, service, startedAt, err)
 	}
 
-	return h.Configurer.EnableService(h, p.Distro.GetWorkerService())
+	return h.Configurer.EnableService(h, service)
 }

--- a/src/pkg/phase/65_upgrade_common.go
+++ b/src/pkg/phase/65_upgrade_common.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1/cluster"
 	"github.com/colonel-byte/cargoship/src/pkg/node"
@@ -64,6 +65,7 @@ func (p *UpgradeHosts) installDistro(ctx context.Context, h *cluster.ZarfHost) e
 func (p *UpgradeHosts) startService(ctx context.Context, h *cluster.ZarfHost) error {
 	logger.From(ctx).Info("waiting for the service to start", "service", p.service, "host", h)
 
+	startedAt := time.Now()
 	go func() {
 		err := h.Configurer.StartService(h, p.service)
 		if err != nil {
@@ -72,7 +74,7 @@ func (p *UpgradeHosts) startService(ctx context.Context, h *cluster.ZarfHost) er
 	}()
 
 	if err := p.manager.RetryTimeout(ctx, node.ServiceRunningFunc(h, p.service)); err != nil {
-		return err
+		return p.captureServiceLogsOnFailure(ctx, h, p.service, startedAt, err)
 	}
 
 	return h.Configurer.EnableService(h, p.service)

--- a/src/types/config.go
+++ b/src/types/config.go
@@ -32,6 +32,8 @@ type DistroConfig struct {
 	LogLevel string `json:"log_level,omitempty" mapstructure:"log_level" jsonschema:"enum=warn,enum=info,enum=debug,enum=trace,default=info"`
 	// NoColor whether to disable terminal color codes in logging and stdout prints
 	NoColor bool `json:"no_color,omitempty" mapstructure:"no_color"`
+	// LogFile enables always writing a full-verbosity debug log to a file, regardless of LogLevel
+	LogFile bool `json:"log_file,omitempty" mapstructure:"log_file"`
 	// Architecture the CPU architecture to use for OCI operations
 	Architecture string `json:"architecture,omitempty" mapstructure:"architecture"`
 	// TempDirectory the directory where we store stuff before deleting them


### PR DESCRIPTION
## Description

Adds a `--log-file` flag (config: `log_file`, default `false`). When set, cargoship always writes a full-verbosity debug log to `<cache-dir>/logs/cargoship-<timestamp>.log` as JSON, regardless of `--log-level`. Console output still respects `--log-level` as before.

Implementation:
- `src/internal/logging/multi_handler.go` (+tests): new `MultiHandler` (`slog.Handler`) that fans a record out to multiple handlers, each keeping its own independent level filter — so file gets everything while console stays at the configured level.
- `src/internal/logging/file_handler.go`: `OpenFileHandler` opens/creates the log file and wraps it in a `slog.JSONHandler` at Debug level.
- `src/cmd/root.go`: wires the flag through `setupLogger`, closes the file on `Execute` exit, warns and falls back to console-only if the file can't be opened.
- `src/config/constant.go`: adds shared `TimeFormat` used for log file timestamps.
- `src/internal/riglogger/core.go`: rig's printf-style log calls now pass their args through as a structured `args` group instead of only the flattened message string, so the JSON file log retains raw values.
- `src/types/config.go`, `src/cmd/viper.go`, `schema/zarf-config-distro-schema.json`, `docs/commands/*.md`: config field, default, schema, and generated CLI docs for the new flag.

Also adds systemd service log capture on failure: when `startService` (controller/worker/upgrade phases) times out waiting for a service to become ready, `captureServiceLogsOnFailure` (`src/pkg/phase/06_service_logs.go`, +tests) best-effort pulls `journalctl -u <service> --since=@<startedAt>` from the remote host and saves it under `<cache-dir>/logs/`. Capture failures are logged as warnings but never mask or replace the original wait error.

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
