### PR TITLE
refactor: widen sysctl schema via JSONSchemaExtend

### DIFF
--- a/magefiles/gen-schema.go
+++ b/magefiles/gen-schema.go
@@ -42,14 +42,6 @@ type schema struct {
 	keyNamer     func(string) string
 }
 
-type t struct {
-	T string `json:"type"`
-}
-
-type o struct {
-	O []t `json:"oneOf"`
-}
-
 // Schema creates the jsonschema files for a number of the yaml files
 func (Generate) Schema() error {
 	var sch = []schema{
@@ -141,26 +133,6 @@ func generateV1Alpha1Schema(v any, path []string, key func(string) string) ([]by
 	}
 
 	addYAMLExtensions(schemaMap)
-
-	// allow the sysctl object to use numbers along side strings
-	if defObj, ok := schemaMap["$defs"].(map[string]any); ok {
-		if obj, ok := defObj["ZarfDistroOS"].(map[string]any); ok {
-			if obj, ok := obj["properties"].(map[string]any); ok {
-				if obj, ok := obj["sysctl"].(map[string]any); ok {
-					obj["additionalProperties"] = o{
-						O: []t{
-							{
-								T: "string",
-							},
-							{
-								T: "number",
-							},
-						},
-					}
-				}
-			}
-		}
-	}
 
 	output, err := json.MarshalIndent(schemaMap, "", "  ")
 	if err != nil {

--- a/src/api/zarf.dev/v1alpha1/distro/spec.go
+++ b/src/api/zarf.dev/v1alpha1/distro/spec.go
@@ -17,6 +17,7 @@ package distro
 
 import (
 	"github.com/colonel-byte/cargoship/src/api/zarf.dev/v1alpha1"
+	"github.com/invopop/jsonschema"
 	"github.com/k0sproject/dig"
 	zarf "github.com/zarf-dev/zarf/src/api/v1alpha1"
 )
@@ -137,6 +138,21 @@ type ZarfDistroOS struct {
 	Kernel []string `json:"kernel,omitempty"`
 	// Environment maps environment variables cargoship sets on the host.
 	Environment map[string]string `json:"env,omitempty"`
+}
+
+// JSONSchemaExtend widens sysctl values to accept numbers alongside strings, so
+// unquoted numeric values in YAML validate.
+func (ZarfDistroOS) JSONSchemaExtend(s *jsonschema.Schema) {
+	sysctl, ok := s.Properties.Get("sysctl")
+	if !ok {
+		return
+	}
+	sysctl.AdditionalProperties = &jsonschema.Schema{
+		OneOf: []*jsonschema.Schema{
+			{Type: "string"},
+			{Type: "number"},
+		},
+	}
 }
 
 // IsSBOMAble reports whether cargoship can generate an SBOM for this distro package. It returns true if the config lists any images or files.


### PR DESCRIPTION
## Description

Split out of #216 (1 of 6). Independent of the rest of the series — mergeable in any order.

Replaces the hand-walked schema map in `magefiles/gen-schema.go` with a `JSONSchemaExtend` method on `ZarfDistroOS`. The reflector calls it while building the type, so the `sysctl` widening (accept numbers alongside strings) lives next to the field it describes instead of reaching into the marshalled map through a chain of string keys and type assertions that fail silently if any link changes.

Generated schema output is unchanged — the `generate-schemas` pre-commit hook passes with no diff.

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
