### PR TITLE
feat: pull pinned k3s and rke2 source into thirdparty-src

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+docs/commands/**/*.md linguist-generated
+docs/phases/**/*.md linguist-generated
+thirdparty-src/** linguist-vendored

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,11 @@ repos:
     rev: v1.2.0
     hooks:
       - id: addlicense
-        exclude: vendor/.*
+        exclude: |-
+          (?x)^(
+              vendor/.*|
+              thirdparty-src/.*
+          )$
         exclude_types:
           - yaml
         args:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,7 @@
     "-tags=mage"
   ],
   "git.ignoreLimitWarning": true,
+  "gopls": {
+    "directoryFilters": ["-thirdparty-src"]
+  },
 }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -48,6 +48,7 @@
 - [build-flags](dev/build-flags.md)
 - [dagger](dev/dagger.md)
 - [mage](dev/mage.md)
+- [thirdparty-src](dev/thirdparty-src.md)
 - [vault-library-choice](dev/vault-library-choice.md)
 
 

--- a/docs/dev/mage.md
+++ b/docs/dev/mage.md
@@ -83,10 +83,25 @@ The `Generate` namespace handles code-generation and repository asset updates:
 
 *   `Document` — Automatically generates command documentation from Cobra structures, parses cluster operational phase descriptors, and formats the mdBook `docs/SUMMARY.md` structure.
 *   `Schema` — Generates YAML-compatible JSON schemas in `schema/` from Go structs using reflection, facilitating IDE autocomplete and validation for cluster config, distro packages, and runtime configs.
+*   `PullEngineSource` — Fetches raw k3s/RKE2 source at the tags pinned in `thirdparty-src/pins.json` into `thirdparty-src/` (see [thirdparty-src](thirdparty-src.md)). Touches the network.
+*   `LatestTag <distro> <vMAJOR.MINOR>` — Resolves the newest non-RC upstream tag for that minor line, pins it in `thirdparty-src/pins.json`, and re-pulls that version's source if the pin moved. Touches the network.
+*   `UpdatePins` — Runs `LatestTag` over every minor line already pinned in `thirdparty-src/pins.json`, refreshing each to its newest patch release. Touches the network.
 
 ```sh
 mage generate:document                  # regenerate docs/commands, docs/phases, and docs/SUMMARY.md
 mage generate:schema                    # regenerate schema/*.json from the Go API types
+
+mage generate:pullEngineSource          # re-pull every tag already pinned in thirdparty-src/pins.json
+mage generate:latestTag rke2 v1.36      # pin rke2's newest v1.36.x, and pull it if the pin moved
+mage generate:latestTag k3s v1.31       # same, for a k3s minor line
+mage generate:updatePins                # bump every pinned minor line, both distros, to its newest patch
+```
+
+`LatestTag` is also how a *new* minor line is added: pass a prefix that `thirdparty-src/pins.json` does not yet pin and it appends that line rather than replacing one. Adding an rke2 minor means adding the matching k3s minor too, because rke2's config is composed against k3s's flags at the same version:
+
+```sh
+mage generate:latestTag k3s v1.37
+mage generate:latestTag rke2 v1.37
 ```
 
 ---
@@ -99,6 +114,10 @@ mage generate:schema                    # regenerate schema/*.json from the Go A
 *   **`dev.go`:** Defines convenience tasks under the `Dev` and `Test` namespaces.
 *   **`gen-docs.go`:** Performs Cobra command extraction and phase parser generation to update everything inside the `docs/` tree.
 *   **`gen-schema.go`:** Maps Go types to JSON schemas under `schema/`.
+*   **`gen-engine-source.go`:** Holds `Generate.PullEngineSource` and the clone-and-copy logic behind it.
+*   **`gen-engine-latest-tag.go`:** Holds `Generate.LatestTag`.
+*   **`gen-engine-update-pins.go`:** Holds `Generate.UpdatePins`.
+*   **`engine-pins.go`:** Shared, target-free layer over `thirdparty-src/pins.json`: reading, writing, tag parsing, and tag resolution used by the `gen-engine-*.go` targets.
 *   **`utils.go`:** Implements low-level helper functions for file cleanup, Dagger CLI execution, and compiler flag construction. See [build-flags](build-flags.md) for what each flag/env var does and why.
 *   **`binary.go`:** Includes non-exported validation functions to verify binary existences within `GOPATH`.
 
@@ -115,6 +134,8 @@ Running various Mage tasks maintains and updates the following filesystem artifa
 | `docs/phases/*` | Auto-generated cluster phase descriptors | `Generate.Document` |
 | `docs/SUMMARY.md` | Compiled table of contents for mdBook | `Generate.Document` |
 | `schema/*.json` | JSON schemas for YAML validations | `Generate.Schema` |
+| `thirdparty-src/<distro>/<minor>/*` | Raw pinned upstream k3s/RKE2 source | `Generate.PullEngineSource` / `Generate.LatestTag` |
+| `thirdparty-src/pins.json` | Pinned upstream tags | `Generate.LatestTag` / `Generate.UpdatePins` |
 
 ---
 

--- a/docs/dev/mage.md
+++ b/docs/dev/mage.md
@@ -15,7 +15,7 @@ The entry point of the automation layer is `magefiles/core/core.go`, which boots
 
 ## Namespace Architecture
 
-Mage targets are organized into logical Go namespaces to group related operations together.
+Mage targets are organized into logical Go namespaces to group related operations together. Every target is invoked as `mage <namespace>:<target>`, and target names are case-insensitive, so `mage generate:document` and `mage generate:Document` are the same command. Run `mage -l` for the authoritative list on your checkout.
 
 ### `Dagger` Namespace
 
@@ -27,11 +27,29 @@ The `Dagger` namespace is the default target and the primary build path. It mana
 *   `Macamd64` / `Macarm64` — Compiles macOS binaries.
 *   `All` — Compiles and exports all release binaries to `build/` concurrently.
 
-Running `mage` without arguments defaults to `Dagger.All`.
+```sh
+mage dagger:toolchain     # update the dagger build environment (run once, or after a dagger upgrade)
+mage dagger:binary        # build for this host's OS/arch
+mage dagger:linuxamd64    # build build/cargoship_linux_amd64
+mage dagger:linuxarm64    # build build/cargoship_linux_arm64
+mage dagger:macamd64      # build build/cargoship_darwin_amd64
+mage dagger:macarm64      # build build/cargoship_darwin_arm64
+mage dagger:all           # build every release binary into build/
+mage                      # same as `mage dagger:all` -- it is the default target
+```
 
 ### `Build` Namespace
 
-The `Build` namespace mirrors the compilation targets of the `Dagger` namespace but bypasses containerization, executing compilation natively on the host's Go toolchain. This path is intended for quick, local development.
+The `Build` namespace mirrors the compilation targets of the `Dagger` namespace but bypasses containerization, executing compilation natively on the host's Go toolchain. This path is intended for quick, local development, and it is the one to use when Docker or Dagger is not available.
+
+```sh
+mage build:binary         # build for this host's OS/arch, no container
+mage build:linuxamd64
+mage build:linuxarm64
+mage build:macamd64
+mage build:macarm64
+mage build:all            # build every release binary into build/
+```
 
 ### `Dev` Namespace
 
@@ -39,13 +57,25 @@ The `Dev` namespace aggregates convenience tasks for day-to-day development:
 
 *   `Clean` — Deletes local compilation artifacts and cleans the `build/` directory.
 *   `Tidy` — Runs `go mod tidy` inside the workspace.
-*   `ResolveImageDigest` — Resolves and logs specific container digests for validation.
+*   `Vendor` — Runs `Tidy`, then `go mod vendor`. Use this rather than a bare `go mod vendor` after changing dependencies, so `go.mod`, `go.sum`, and `vendor/` are updated in one step.
+*   `Digest` — Resolves `docker.io/library/alpine:latest` through the host's Docker credentials and prints its digest. This is a connectivity and auth smoke test, not part of a build.
+
+```sh
+mage dev:clean            # rm the build/ artifacts
+mage dev:tidy             # go mod tidy
+mage dev:vendor           # go mod tidy, then go mod vendor
+mage dev:digest           # print the alpine:latest digest, to check registry auth works
+```
 
 ### `Test` Namespace
 
 The `Test` namespace hosts the integration and validation suites:
 
-*   `E2E` — Automatically compiles Cargoship via Dagger and executes the complete Go-based end-to-end test suite in verbose mode.
+*   `EndToEnd` — Builds Cargoship for the host via Dagger, then runs the full Go end-to-end suite in verbose mode. It builds first every time, so there is no separate build step to remember.
+
+```sh
+mage test:endToEnd        # build via dagger, then run the e2e suite
+```
 
 ### `Generate` Namespace
 
@@ -53,6 +83,11 @@ The `Generate` namespace handles code-generation and repository asset updates:
 
 *   `Document` — Automatically generates command documentation from Cobra structures, parses cluster operational phase descriptors, and formats the mdBook `docs/SUMMARY.md` structure.
 *   `Schema` — Generates YAML-compatible JSON schemas in `schema/` from Go structs using reflection, facilitating IDE autocomplete and validation for cluster config, distro packages, and runtime configs.
+
+```sh
+mage generate:document                  # regenerate docs/commands, docs/phases, and docs/SUMMARY.md
+mage generate:schema                    # regenerate schema/*.json from the Go API types
+```
 
 ---
 

--- a/docs/dev/thirdparty-src.md
+++ b/docs/dev/thirdparty-src.md
@@ -1,0 +1,89 @@
+# Third-Party Engine Source (`thirdparty-src/`)
+
+This document explains what lives under `thirdparty-src/` and why it's handled differently from the rest of the repository.
+
+## What it is
+
+`thirdparty-src/<distro>/<version>/` holds raw, unmodified source files pulled from an upstream engine repo (k3s and RKE2) at an exact tag — e.g. `thirdparty-src/k3s/v1_35/{zz_server.go,zz_agent.go}`, pulled from k3s-io/k3s at tag `v1.35.3+k3s1`. `version` is truncated to the minor version (`v1_35`, not the full `v1.35.3-k3s1` patch tag): patch releases are assumed not to change the flag set, so one pull/generate covers every patch in that minor line. RKE2 additionally pulls `zz_root.go` and `zz_k3sopts.go` — see "RKE2's flag composition" below. The `zz_` prefix marks these as pulled/tool-managed rather than hand-authored, the same convention used for the generated structs under `src/pkg/engineconfig/gen`.
+
+These files exist so `src/pkg/engineconfig/extract` can statically parse them with `go/ast` to recover the `urfave/cli` flag declarations k3s/RKE2 ships for a given version. That, in turn, lets `mage generate:engineConfig` (see `magefiles/gen-engine-config.go`) generate a typed Go struct describing the valid `config.yaml` keys for that version — see `docs/agent/design-config-codegen.md` for the full design rationale.
+
+## Why source files instead of a module dependency
+
+k3s and RKE2 are not safe to `go get`/import as library dependencies: their `go.mod` files carry `replace` directives that would leak into (and corrupt) this module's own dependency graph (see golang/go#30354). Statically parsing their source text with `go/parser` sidesteps that entirely — the files are never compiled, never imported, and never linked into any Cargoship binary. They exist purely as text for the extractor to read.
+
+## Why `thirdparty-src/` has its own `go.mod`
+
+Because these files reference packages (`github.com/urfave/cli/v2`, `github.com/k3s-io/k3s/pkg/version`, ...) that this repository does not vendor, letting the main module's tooling discover them causes real breakage: `go build ./...`, `go vet`, and IDE tooling (gopls) all try to resolve those imports and fail.
+
+`thirdparty-src/go.mod` declares a separate, empty module so the Go toolchain treats `thirdparty-src/` as outside the main module boundary. `go build ./...`/`go vet` from the repo root no longer descend into it. IDEs still open a second module context for it, which can surface unresolved-import diagnostics on the files themselves; the workspace's `.vscode/settings.json` sets `gopls.directoryFilters` to `-thirdparty-src` to stop gopls from loading that module at all.
+
+## Layout
+
+```
+thirdparty-src/
+  <distro>/                  # k3s or rke2
+    <version>/                # e.g. v1_35 (minor version only, see above)
+      zz_server.go             # verbatim upstream source
+      zz_agent.go
+      zz_root.go               # rke2 only -- commonFlag, shared by server/agent
+      zz_k3sopts.go            # rke2 only -- K3SFlagOption/copyFlag/dropFlag/hideFlag
+      SOURCE.txt               # repo, tag, resolved commit, and pulled file list
+  pins.json                    # the pinned tags and file lists, see below
+  go.mod                       # module boundary marker, see above
+```
+
+## RKE2's flag composition
+
+RKE2 doesn't declare its `config.yaml` flags outright the way k3s does. `zz_server.go`/`zz_agent.go` import k3s's own command and wrap it at runtime via `mustCmdFromK3S(cmd, K3SFlagSet{...})` (defined in `zz_k3sopts.go`): a map, keyed by k3s flag name, of `copyFlag`/`dropFlag`/`hideFlag` (or an inline `{Usage: "...", Hide: true}`-style literal) saying whether that k3s flag survives into RKE2 at all, and whether it's hidden. RKE2 then appends a small literal of its own additions (`serverFlag`/`deprecatedFlags`) and a shared `commonFlag` literal declared in `zz_root.go`.
+
+`mage generate:engineConfig` reproduces this: for each RKE2 target it extracts the sibling k3s manifest (`thirdparty-src/k3s/<version>/`), applies the `K3SFlagSet` transform parsed from RKE2's `zz_server.go`/`zz_agent.go`, then appends RKE2's own additions and `commonFlag`. This is why an RKE2 version's pull must always be paired with a k3s pull at the same minor version.
+
+Some of `commonFlag`'s entries have a computed `Name` (a package constant, e.g. `images.KubeAPIServer`, or a concatenation like `podtemplate.KubeAPIServer + "-extra-mount"`) rather than a string literal. Those aren't statically resolvable to a flag name without also pulling and evaluating `pkg/images`/`pkg/podtemplate`, so they're listed in the generated file's "not resolvable" comment block instead of silently guessed at or dropped.
+
+## Pulling a new version
+
+`thirdparty-src/pins.json` is the single source of truth for what gets pulled: one entry per upstream repo, listing the files to copy and every tag to copy them at.
+
+```json
+{
+  "distros": [
+    {
+      "name": "k3s",
+      "repo": "https://github.com/k3s-io/k3s",
+      "files": ["pkg/cli/cmds/server.go", "pkg/cli/cmds/agent.go"],
+      "tags": ["v1.36.4+k3s1", "v1.35.8+k3s1"]
+    },
+    {
+      "name": "rke2",
+      "repo": "https://github.com/rancher/rke2",
+      "files": [
+        "pkg/cli/cmds/server.go",
+        "pkg/cli/cmds/agent.go",
+        "pkg/cli/cmds/root.go",
+        "pkg/cli/cmds/k3sopts.go"
+      ],
+      "tags": ["v1.36.3+rke2r1", "v1.35.7+rke2r1"]
+    }
+  ]
+}
+```
+
+There is no destination path in the manifest: it is derived from `name` plus the tag's major.minor, so `k3s` at `v1.35.8+k3s1` always lands in `thirdparty-src/k3s/v1_35/`. That keeps the truncation rule described above from drifting out of sync with the tag it was truncated from. A tag that does not start with `vMAJOR.MINOR.PATCH` is rejected rather than guessed at.
+
+`mage generate:pullEngineSource` reads the manifest and, for each pinned tag, clones `repo`@`tag` to a throwaway temp directory, copies out `files` verbatim into the derived directory (prefixed `zz_`), and writes `SOURCE.txt` recording the repo, tag, and resolved commit for traceability. It never runs `go get` or touches this repo's module graph.
+
+You rarely need to edit `pins.json` by hand. `mage generate:latestTag <distro> <vMAJOR.MINOR>` resolves the newest non-RC tag upstream publishes for that minor line, pins it — replacing whatever that line held, or adding the line newest-first if it is new — and re-pulls that version's source if the pin moved, so the manifest and the committed files can never disagree. When nothing moved it prints `unchanged` and writes nothing.
+
+```sh
+mage generate:latestTag k3s v1.37   # start tracking a new minor line
+mage generate:updatePins            # refresh every line already pinned
+```
+
+`generate:updatePins` runs that same cycle over every minor line in the manifest, which is the usual way to answer "are we behind upstream?". Both targets touch the network, and both leave struct generation to you: follow with `mage generate:engineConfig` for any version that moved. The version directory name is sanitized into a valid Go package name (dots become underscores) since it becomes the generated package's directory and name directly.
+
+## Consuming it
+
+`mage generate:engineConfig` walks every `thirdparty-src/<distro>/<version>/` directory and writes generated structs to `src/pkg/engineconfig/gen/<distro>/<version>/`. For k3s (and any distro that declares its flags outright) it parses whichever of `zz_server.go`/`zz_agent.go` it finds directly; for RKE2 it composes as described above. See `docs/dev/mage.md` for the broader `Generate` namespace.
+
+It also (re)writes `src/pkg/engineconfig/gen/zz_registry.go`, wiring every distro/version it just generated into `gen.Registry` so nothing needs hand-maintaining as new versions are pulled. `src/types/distrocfg` (`RancherCommon.ConfigureEngine`) uses `gen.Lookup` to find the struct matching a node's distro and minor version, and drops (with a warning) any `config.yaml` key that isn't a real flag for it -- falling back to the previous unvalidated, pass-everything-through behavior with a warning if that distro/version was never pulled/generated. See "Consumption: wired into `src/types/distrocfg`" in `docs/agent/design-config-codegen.md` for the full picture.

--- a/magefiles/engine-pins.go
+++ b/magefiles/engine-pins.go
@@ -1,0 +1,299 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file holds the shared thirdparty-src/pins.json manifest layer. The mage targets that
+// read or rewrite it each live in their own gen-engine-*.go file.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// thirdpartySrcDir is the root the pinned upstream source is pulled into and generated from.
+const thirdpartySrcDir = "thirdparty-src"
+
+// engineSourcePull describes one upstream file set to pull verbatim into thirdparty-src/ for
+// src/pkg/engineconfig/extract to statically parse. See docs/dev/thirdparty-src.md.
+type engineSourcePull struct {
+	repoURL string
+	tag     string
+	destDir string
+	files   []string
+}
+
+// enginePins is the on-disk form of thirdparty-src/pins.json, the single source of truth
+// for which upstream files this repo pulls and at which tags.
+type enginePins struct {
+	Distros []enginePinDistro `json:"distros"`
+}
+
+// enginePinDistro pins one upstream repo. Every tag pulls the same file set into
+// thirdparty-src/<name>/<minor>, where <minor> is derived from the tag (v1.35.8+k3s1 -> v1_35).
+type enginePinDistro struct {
+	Name  string   `json:"name"`
+	Repo  string   `json:"repo"`
+	Files []string `json:"files"`
+	Tags  []string `json:"tags"`
+}
+
+const enginePinsPath = "thirdparty-src/pins.json"
+
+var tagVersionPattern = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)`)
+
+// readEnginePins loads and parses thirdparty-src/pins.json.
+func readEnginePins() (enginePins, error) {
+	var pins enginePins
+
+	data, err := os.ReadFile(enginePinsPath)
+	if err != nil {
+		return pins, fmt.Errorf("reading %s: %w", enginePinsPath, err)
+	}
+	if err := json.Unmarshal(data, &pins); err != nil {
+		return pins, fmt.Errorf("parsing %s: %w", enginePinsPath, err)
+	}
+	return pins, nil
+}
+
+// write rewrites thirdparty-src/pins.json from the in-memory pins.
+func (p enginePins) write() error {
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", enginePinsPath, err)
+	}
+	return os.WriteFile(enginePinsPath, append(data, '\n'), 0o644)
+}
+
+// distro returns the pinned entry for a distro name.
+func (p *enginePins) distro(name string) (*enginePinDistro, error) {
+	var known []string
+	for i := range p.Distros {
+		if p.Distros[i].Name == name {
+			return &p.Distros[i], nil
+		}
+		known = append(known, p.Distros[i].Name)
+	}
+	return nil, fmt.Errorf("unknown distro %q, expected one of: %s", name, strings.Join(known, ", "))
+}
+
+// pulls flattens the pins into one pull per pinned tag.
+func (p enginePins) pulls() ([]engineSourcePull, error) {
+	var pulls []engineSourcePull
+	for _, d := range p.Distros {
+		for _, tag := range d.Tags {
+			pull, err := d.pull(tag)
+			if err != nil {
+				return nil, err
+			}
+			pulls = append(pulls, pull)
+		}
+	}
+	return pulls, nil
+}
+
+// pull describes what pulling one of this distro's tags copies, and to where.
+func (d enginePinDistro) pull(tag string) (engineSourcePull, error) {
+	minor, err := tagMinor(tag)
+	if err != nil {
+		return engineSourcePull{}, fmt.Errorf("%s: %s: %w", enginePinsPath, d.Name, err)
+	}
+	return engineSourcePull{
+		repoURL: d.Repo,
+		tag:     tag,
+		destDir: filepath.Join(thirdpartySrcDir, d.Name, minor),
+		files:   d.Files,
+	}, nil
+}
+
+// setTag pins tag for its minor line, replacing whatever that line held. It reports the tag
+// previously pinned there ("" when the minor line is new) and whether anything changed.
+func (d *enginePinDistro) setTag(tag string) (prev string, changed bool, err error) {
+	minor, err := tagMinor(tag)
+	if err != nil {
+		return "", false, err
+	}
+
+	for i, existing := range d.Tags {
+		existingMinor, err := tagMinor(existing)
+		if err != nil {
+			return "", false, fmt.Errorf("%s: %s: %w", enginePinsPath, d.Name, err)
+		}
+		if existingMinor != minor {
+			continue
+		}
+		if existing == tag {
+			return existing, false, nil
+		}
+		d.Tags[i] = tag
+		return existing, true, nil
+	}
+
+	d.Tags = append(d.Tags, tag)
+	return "", true, d.sortTags()
+}
+
+// sortTags orders the pinned tags newest first, so a freshly pinned minor line lands where a
+// reader expects it rather than at the end of the list.
+func (d *enginePinDistro) sortTags() error {
+	var sortErr error
+	slices.SortFunc(d.Tags, func(a, b string) int {
+		va, err := tagVersion(a)
+		if err != nil {
+			sortErr = err
+		}
+		vb, err := tagVersion(b)
+		if err != nil {
+			sortErr = err
+		}
+		return slices.Compare(vb[:], va[:])
+	})
+	return sortErr
+}
+
+// tagVersion parses the leading major.minor.patch of an upstream tag ("v1.35.8+k3s1").
+func tagVersion(tag string) ([3]int, error) {
+	m := tagVersionPattern.FindStringSubmatch(tag)
+	if m == nil {
+		return [3]int{}, fmt.Errorf("tag %q does not start with vMAJOR.MINOR.PATCH", tag)
+	}
+
+	var v [3]int
+	for i := range v {
+		n, err := strconv.Atoi(m[i+1])
+		if err != nil {
+			return [3]int{}, fmt.Errorf("tag %q: %w", tag, err)
+		}
+		v[i] = n
+	}
+	return v, nil
+}
+
+// tagMinor is the thirdparty-src directory name for a tag's minor line ("v1.35.8+k3s1" -> "v1_35").
+func tagMinor(tag string) (string, error) {
+	v, err := tagVersion(tag)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("v%d_%d", v[0], v[1]), nil
+}
+
+// pinTag resolves the newest non-RC tag matching prefix, pins it in thirdparty-src/pins.json,
+// and re-pulls that version's source when the pin moved. Returns the resolved tag.
+func pinTag(pins *enginePins, distro, prefix string) (string, error) {
+	d, err := pins.distro(distro)
+	if err != nil {
+		return "", err
+	}
+
+	tag, err := latestTag(d.Repo, prefix)
+	if err != nil {
+		return "", err
+	}
+
+	prev, changed, err := d.setTag(tag)
+	if err != nil {
+		return "", err
+	}
+
+	minor, err := tagMinor(tag)
+	if err != nil {
+		return "", err
+	}
+	switch {
+	case !changed:
+		fmt.Printf("%s: %s %s unchanged\n", enginePinsPath, distro, minor)
+		return tag, nil
+	case prev == "":
+		fmt.Printf("%s: %s %s added at %s\n", enginePinsPath, distro, minor, tag)
+	default:
+		fmt.Printf("%s: %s %s %s -> %s\n", enginePinsPath, distro, minor, prev, tag)
+	}
+
+	if err := pins.write(); err != nil {
+		return "", err
+	}
+
+	pull, err := d.pull(tag)
+	if err != nil {
+		return "", err
+	}
+	if err := pullEngineSource(pull); err != nil {
+		return "", fmt.Errorf("pulling %s@%s: %w", pull.repoURL, pull.tag, err)
+	}
+	return tag, nil
+}
+
+// remoteTags lists every non-RC upstream tag on a minor line ("v1.36"), in the order git
+// ls-remote returned them. Touches the network.
+func remoteTags(repoURL, prefix string) ([]string, error) {
+	lsRemoteCmd := exec.Command("git", "ls-remote", "--tags", "--refs", repoURL)
+	out, err := lsRemoteCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-remote: %w", err)
+	}
+
+	var tags []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		_, tag, ok := strings.Cut(line, "refs/tags/")
+		if !ok || !strings.HasPrefix(tag, prefix+".") {
+			continue
+		}
+		if strings.Contains(strings.ToLower(tag), "rc") {
+			continue
+		}
+		if _, err := tagVersion(tag); err != nil {
+			continue
+		}
+		tags = append(tags, tag)
+	}
+
+	if len(tags) == 0 {
+		return nil, fmt.Errorf("no non-RC tag matching prefix %q found for %s", prefix, repoURL)
+	}
+	return tags, nil
+}
+
+// latestTag is the highest-versioned of those tags. Ties on version (the same patch
+// released twice, v1.36.1+rke2r1 and +rke2r2) keep the first one ls-remote listed.
+func latestTag(repoURL, prefix string) (string, error) {
+	tags, err := remoteTags(repoURL, prefix)
+	if err != nil {
+		return "", err
+	}
+
+	var best string
+	var bestVer [3]int
+	for _, tag := range tags {
+		ver, err := tagVersion(tag)
+		if err != nil {
+			continue
+		}
+		if best == "" || slices.Compare(ver[:], bestVer[:]) > 0 {
+			best = tag
+			bestVer = ver
+		}
+	}
+	return best, nil
+}

--- a/magefiles/gen-engine-latest-tag.go
+++ b/magefiles/gen-engine-latest-tag.go
@@ -1,0 +1,43 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+)
+
+// LatestTag pins the newest non-RC tag for a distro ("k3s" or "rke2") matching a
+// major.minor prefix (e.g. "v1.35")
+//
+// Resolves the tag, prints it, and writes it into thirdparty-src/pins.json -- replacing
+// whatever that minor line held, or adding the line if it is new. When the pin moves it
+// re-pulls that version's source so pins.json and thirdparty-src/ never disagree. Touches
+// the network.
+//
+//	mage generate:latestTag rke2 v1.35
+func (Generate) LatestTag(distro, prefix string) error {
+	pins, err := readEnginePins()
+	if err != nil {
+		return err
+	}
+
+	tag, err := pinTag(&pins, distro, prefix)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(tag)
+	return nil
+}

--- a/magefiles/gen-engine-source.go
+++ b/magefiles/gen-engine-source.go
@@ -1,0 +1,92 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// PullEngineSource fetches pinned k3s/RKE2 source files
+//
+// Fetches the raw files pinned in thirdparty-src/pins.json at their exact tags and
+// commits them under thirdparty-src/ as plain text -- never as a Go module dependency
+// (their go.mod replace directives make that unsafe). This is the only step in the
+// engine-config codegen pipeline that touches the network; Generate.EngineConfig runs
+// fully offline against what this writes.
+func (Generate) PullEngineSource() error {
+	pins, err := readEnginePins()
+	if err != nil {
+		return err
+	}
+
+	pulls, err := pins.pulls()
+	if err != nil {
+		return err
+	}
+
+	for _, p := range pulls {
+		if err := pullEngineSource(p); err != nil {
+			return fmt.Errorf("pulling %s@%s: %w", p.repoURL, p.tag, err)
+		}
+	}
+	return nil
+}
+
+func pullEngineSource(p engineSourcePull) error {
+	tmp, err := os.MkdirTemp("", "engine-src-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+
+	srcDir := filepath.Join(tmp, "src")
+	cloneCmd := exec.Command("git", "clone", "--quiet", "--depth", "1", "--branch", p.tag, p.repoURL, srcDir)
+	if out, err := cloneCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone: %w: %s", err, out)
+	}
+
+	revParseCmd := exec.Command("git", "-C", srcDir, "rev-parse", "HEAD")
+	commitOut, err := revParseCmd.Output()
+	if err != nil {
+		return fmt.Errorf("git rev-parse: %w", err)
+	}
+	commit := strings.TrimSpace(string(commitOut))
+
+	if err := os.MkdirAll(p.destDir, 0o755); err != nil {
+		return err
+	}
+	for _, f := range p.files {
+		data, err := os.ReadFile(filepath.Join(srcDir, f))
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(p.destDir, "zz_"+filepath.Base(f)), data, 0o644); err != nil {
+			return err
+		}
+	}
+
+	sourceTxt := fmt.Sprintf("repo:   %s\ntag:    %s\ncommit: %s\nfiles:  %s\n",
+		p.repoURL, p.tag, commit, strings.Join(p.files, " "))
+	if err := os.WriteFile(filepath.Join(p.destDir, "SOURCE.txt"), []byte(sourceTxt), 0o644); err != nil {
+		return err
+	}
+
+	fmt.Printf("Pulled %d file(s) from %s@%s into %s\n", len(p.files), p.repoURL, p.tag, p.destDir)
+	return nil
+}

--- a/magefiles/gen-engine-update-pins.go
+++ b/magefiles/gen-engine-update-pins.go
@@ -1,0 +1,53 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+)
+
+// UpdatePins refreshes every pinned minor line to its newest non-RC patch release
+//
+// Runs the same resolve-pin-pull cycle as Generate.LatestTag over every minor line already
+// in thirdparty-src/pins.json, so a routine "are we behind upstream?" pass is one command
+// rather than twelve. Touches the network.
+func (Generate) UpdatePins() error {
+	pins, err := readEnginePins()
+	if err != nil {
+		return err
+	}
+
+	// Snapshot the pinned minor lines first: pinTag rewrites Tags as it goes.
+	type pinnedLine struct{ distro, prefix string }
+	var lines []pinnedLine
+	for _, d := range pins.Distros {
+		for _, tag := range d.Tags {
+			v, err := tagVersion(tag)
+			if err != nil {
+				return fmt.Errorf("%s: %s: %w", enginePinsPath, d.Name, err)
+			}
+			lines = append(lines, pinnedLine{d.Name, fmt.Sprintf("v%d.%d", v[0], v[1])})
+		}
+	}
+
+	for _, l := range lines {
+		if _, err := pinTag(&pins, l.distro, l.prefix); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("Run mage generate:engineConfig to regenerate structs for any version that moved.")
+	return nil
+}

--- a/thirdparty-src/go.mod
+++ b/thirdparty-src/go.mod
@@ -1,0 +1,7 @@
+// This file intentionally makes thirdparty-src its own Go module boundary. The .go files under
+// it are raw upstream source pulled by `mage generate:pullEngineSource` for static go/ast
+// parsing only -- they are never meant to compile or be imported, so the main module's
+// build/vet/lint tooling must not descend into them. See docs/dev/thirdparty-src.md.
+module thirdpartysrc
+
+go 1.21

--- a/thirdparty-src/k3s/v1_31/SOURCE.txt
+++ b/thirdparty-src/k3s/v1_31/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/k3s-io/k3s
+tag:    v1.31.14+k3s1
+commit: a2ef79f53538e58982857c1820469792d582e470
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go

--- a/thirdparty-src/k3s/v1_31/zz_agent.go
+++ b/thirdparty-src/k3s/v1_31/zz_agent.go
@@ -1,0 +1,343 @@
+package cmds
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+type Agent struct {
+	Token                    string
+	TokenFile                string
+	ClusterSecret            string
+	ServerURL                string
+	APIAddressCh             chan []string
+	DisableLoadBalancer      bool
+	DisableServiceLB         bool
+	ETCDAgent                bool
+	LBServerPort             int
+	ResolvConf               string
+	DataDir                  string
+	BindAddress              string
+	NodeIP                   cli.StringSlice
+	NodeExternalIP           cli.StringSlice
+	NodeInternalDNS          cli.StringSlice
+	NodeExternalDNS          cli.StringSlice
+	NodeName                 string
+	PauseImage               string
+	Snapshotter              string
+	Docker                   bool
+	ContainerdNoDefault      bool
+	ContainerdNonrootDevices bool
+	ContainerRuntimeEndpoint string
+	DefaultRuntime           string
+	ImageServiceEndpoint     string
+	FlannelIface             string
+	FlannelConf              string
+	FlannelCniConfFile       string
+	VPNAuth                  string
+	VPNAuthFile              string
+	Debug                    bool
+	EnablePProf              bool
+	Rootless                 bool
+	RootlessAlreadyUnshared  bool
+	WithNodeID               bool
+	EnableSELinux            bool
+	ProtectKernelDefaults    bool
+	ClusterReset             bool
+	PrivateRegistry          string
+	SystemDefaultRegistry    string
+	AirgapExtraRegistry      cli.StringSlice
+	ExtraKubeletArgs         cli.StringSlice
+	ExtraKubeProxyArgs       cli.StringSlice
+	Labels                   cli.StringSlice
+	Taints                   cli.StringSlice
+	ImageCredProvBinDir      string
+	ImageCredProvConfig      string
+	AgentShared
+}
+
+type AgentShared struct {
+	NodeIP string
+}
+
+var (
+	appName        = filepath.Base(os.Args[0])
+	AgentConfig    Agent
+	AgentTokenFlag = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Token to use for authentication",
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+		Destination: &AgentConfig.Token,
+	}
+	NodeIPFlag = &cli.StringSliceFlag{
+		Name:        "node-ip",
+		Aliases:     []string{"i"},
+		Usage:       "(agent/networking) IPv4/IPv6 addresses to advertise for node",
+		Destination: &AgentConfig.NodeIP,
+	}
+	NodeExternalIPFlag = &cli.StringSliceFlag{
+		Name:        "node-external-ip",
+		Usage:       "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalIP,
+	}
+	NodeInternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-internal-dns",
+		Usage:       "(agent/networking) internal DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeInternalDNS,
+	}
+	NodeExternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-external-dns",
+		Usage:       "(agent/networking) external DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalDNS,
+	}
+	NodeNameFlag = &cli.StringFlag{
+		Name:        "node-name",
+		Usage:       "(agent/node) Node name",
+		EnvVars:     []string{version.ProgramUpper + "_NODE_NAME"},
+		Destination: &AgentConfig.NodeName,
+	}
+	WithNodeIDFlag = &cli.BoolFlag{
+		Name:        "with-node-id",
+		Usage:       "(agent/node) Append id to node name",
+		Destination: &AgentConfig.WithNodeID,
+	}
+	ProtectKernelDefaultsFlag = &cli.BoolFlag{
+		Name:        "protect-kernel-defaults",
+		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
+		Destination: &AgentConfig.ProtectKernelDefaults,
+	}
+	SELinuxFlag = &cli.BoolFlag{
+		Name:        "selinux",
+		Usage:       "(agent/node) Enable SELinux in containerd",
+		Destination: &AgentConfig.EnableSELinux,
+		EnvVars:     []string{version.ProgramUpper + "_SELINUX"},
+	}
+	LBServerPortFlag = &cli.IntFlag{
+		Name:        "lb-server-port",
+		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
+		Destination: &AgentConfig.LBServerPort,
+		EnvVars:     []string{version.ProgramUpper + "_LB_SERVER_PORT"},
+		Value:       6444,
+	}
+	DockerFlag = &cli.BoolFlag{
+		Name:        "docker",
+		Usage:       "(agent/runtime) (experimental) Use cri-dockerd instead of containerd",
+		Destination: &AgentConfig.Docker,
+	}
+	CRIEndpointFlag = &cli.StringFlag{
+		Name:        "container-runtime-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
+		Destination: &AgentConfig.ContainerRuntimeEndpoint,
+	}
+	DefaultRuntimeFlag = &cli.StringFlag{
+		Name:        "default-runtime",
+		Usage:       "(agent/runtime) Set the default runtime in containerd",
+		Destination: &AgentConfig.DefaultRuntime,
+	}
+	ImageServiceEndpointFlag = &cli.StringFlag{
+		Name:        "image-service-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd image service and use remote image service socket at the given path. If not specified, defaults to --container-runtime-endpoint.",
+		Destination: &AgentConfig.ImageServiceEndpoint,
+	}
+	PrivateRegistryFlag = &cli.StringFlag{
+		Name:        "private-registry",
+		Usage:       "(agent/runtime) Private registry configuration file",
+		Destination: &AgentConfig.PrivateRegistry,
+		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
+	}
+	AirgapExtraRegistryFlag = &cli.StringSliceFlag{
+		Name:   "airgap-extra-registry",
+		Usage:  "(agent/runtime) Additional registry to tag airgap images as being sourced from",
+		Value:  &AgentConfig.AirgapExtraRegistry,
+		Hidden: true,
+	}
+	PauseImageFlag = &cli.StringFlag{
+		Name:        "pause-image",
+		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
+		Destination: &AgentConfig.PauseImage,
+		Value:       "rancher/mirrored-pause:3.6",
+	}
+	SnapshotterFlag = &cli.StringFlag{
+		Name:        "snapshotter",
+		Usage:       "(agent/runtime) Override default containerd snapshotter",
+		Destination: &AgentConfig.Snapshotter,
+		Value:       DefaultSnapshotter,
+	}
+	FlannelIfaceFlag = &cli.StringFlag{
+		Name:        "flannel-iface",
+		Usage:       "(agent/networking) Override default flannel interface",
+		Destination: &AgentConfig.FlannelIface,
+	}
+	FlannelConfFlag = &cli.StringFlag{
+		Name:        "flannel-conf",
+		Usage:       "(agent/networking) Override default flannel config file",
+		Destination: &AgentConfig.FlannelConf,
+	}
+	FlannelCniConfFileFlag = &cli.StringFlag{
+		Name:        "flannel-cni-conf",
+		Usage:       "(agent/networking) Override default flannel cni config file",
+		Destination: &AgentConfig.FlannelCniConfFile,
+	}
+	VPNAuth = &cli.StringFlag{
+		Name:        "vpn-auth",
+		Usage:       "(agent/networking) (experimental) Credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH"},
+		Destination: &AgentConfig.VPNAuth,
+	}
+	VPNAuthFile = &cli.StringFlag{
+		Name:        "vpn-auth-file",
+		Usage:       "(agent/networking) (experimental) File containing credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH_FILE"},
+		Destination: &AgentConfig.VPNAuthFile,
+	}
+	ResolvConfFlag = &cli.StringFlag{
+		Name:        "resolv-conf",
+		Usage:       "(agent/networking) Kubelet resolv.conf file",
+		EnvVars:     []string{version.ProgramUpper + "_RESOLV_CONF"},
+		Destination: &AgentConfig.ResolvConf,
+	}
+	ExtraKubeletArgs = &cli.StringSliceFlag{
+		Name:        "kubelet-arg",
+		Usage:       "(agent/flags) Customized flag for kubelet process",
+		Destination: &AgentConfig.ExtraKubeletArgs,
+	}
+	ExtraKubeProxyArgs = &cli.StringSliceFlag{
+		Name:        "kube-proxy-arg",
+		Usage:       "(agent/flags) Customized flag for kube-proxy process",
+		Destination: &AgentConfig.ExtraKubeProxyArgs,
+	}
+	NodeTaints = &cli.StringSliceFlag{
+		Name:        "node-taint",
+		Usage:       "(agent/node) Registering kubelet with set of taints",
+		Destination: &AgentConfig.Taints,
+	}
+	NodeLabels = &cli.StringSliceFlag{
+		Name:        "node-label",
+		Usage:       "(agent/node) Registering and starting kubelet with set of labels",
+		Destination: &AgentConfig.Labels,
+	}
+	ImageCredProvBinDirFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-bin-dir",
+		Usage:       "(agent/node) The path to the directory where credential provider plugin binaries are located",
+		Destination: &AgentConfig.ImageCredProvBinDir,
+		Value:       "/var/lib/rancher/credentialprovider/bin",
+	}
+	ImageCredProvConfigFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-config",
+		Usage:       "(agent/node) The path to the credential provider plugin config file",
+		Destination: &AgentConfig.ImageCredProvConfig,
+		Value:       "/var/lib/rancher/credentialprovider/config.yaml",
+	}
+	DisableAgentLBFlag = &cli.BoolFlag{
+		Name:        "disable-apiserver-lb",
+		Usage:       "(agent/networking) (experimental) Disable the agent's client-side load-balancer and connect directly to the configured server address",
+		Destination: &AgentConfig.DisableLoadBalancer,
+	}
+	DisableDefaultRegistryEndpointFlag = &cli.BoolFlag{
+		Name:        "disable-default-registry-endpoint",
+		Usage:       "(agent/containerd) Disables containerd's fallback default registry endpoint when a mirror is configured for that registry",
+		Destination: &AgentConfig.ContainerdNoDefault,
+	}
+	NonrootDevicesFlag = &cli.BoolFlag{
+		Name:        "nonroot-devices",
+		Usage:       "(agent/containerd) Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config",
+		Destination: &AgentConfig.ContainerdNonrootDevices,
+	}
+	EnablePProfFlag = &cli.BoolFlag{
+		Name:        "enable-pprof",
+		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
+		Destination: &AgentConfig.EnablePProf,
+	}
+	BindAddressFlag = &cli.StringFlag{
+		Name:        "bind-address",
+		Usage:       "(listener) " + version.Program + " bind address (default: 0.0.0.0)",
+		Destination: &AgentConfig.BindAddress,
+	}
+)
+
+func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "agent",
+		Usage:     "Run node agent",
+		UsageText: appName + " agent [OPTIONS]",
+		Action:    action,
+		Flags: []cli.Flag{
+			ConfigFlag,
+			DebugFlag,
+			VLevel,
+			VModule,
+			LogFile,
+			AlsoLogToStderr,
+			AgentTokenFlag,
+			&cli.StringFlag{
+				Name:        "token-file",
+				Usage:       "(cluster) Token file to use for authentication",
+				EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+				Destination: &AgentConfig.TokenFile,
+			},
+			&cli.StringFlag{
+				Name:        "server",
+				Aliases:     []string{"s"},
+				Usage:       "(cluster) Server to connect to",
+				EnvVars:     []string{version.ProgramUpper + "_URL"},
+				Destination: &AgentConfig.ServerURL,
+			},
+			// Note that this is different from DataDirFlag used elswhere in the CLI,
+			// as this is bound to AgentConfig instead of ServerConfig.
+			&cli.StringFlag{
+				Name:        "data-dir",
+				Aliases:     []string{"d"},
+				Usage:       "(agent/data) Folder to hold state",
+				Destination: &AgentConfig.DataDir,
+				Value:       "/var/lib/rancher/" + version.Program + "",
+				EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+			},
+			NodeNameFlag,
+			WithNodeIDFlag,
+			NodeLabels,
+			NodeTaints,
+			ImageCredProvBinDirFlag,
+			ImageCredProvConfigFlag,
+			SELinuxFlag,
+			LBServerPortFlag,
+			ProtectKernelDefaultsFlag,
+			CRIEndpointFlag,
+			DefaultRuntimeFlag,
+			ImageServiceEndpointFlag,
+			PauseImageFlag,
+			SnapshotterFlag,
+			PrivateRegistryFlag,
+			DisableDefaultRegistryEndpointFlag,
+			NonrootDevicesFlag,
+			AirgapExtraRegistryFlag,
+			NodeIPFlag,
+			BindAddressFlag,
+			NodeExternalIPFlag,
+			NodeInternalDNSFlag,
+			NodeExternalDNSFlag,
+			ResolvConfFlag,
+			FlannelIfaceFlag,
+			FlannelConfFlag,
+			FlannelCniConfFileFlag,
+			ExtraKubeletArgs,
+			ExtraKubeProxyArgs,
+			// Experimental flags
+			EnablePProfFlag,
+			&cli.BoolFlag{
+				Name:        "rootless",
+				Usage:       "(experimental) Run rootless",
+				Destination: &AgentConfig.Rootless,
+			},
+			PreferBundledBin,
+			// Deprecated/hidden below
+			DockerFlag,
+			VPNAuth,
+			VPNAuthFile,
+			DisableAgentLBFlag,
+		},
+	}
+}

--- a/thirdparty-src/k3s/v1_31/zz_server.go
+++ b/thirdparty-src/k3s/v1_31/zz_server.go
@@ -1,0 +1,660 @@
+package cmds
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	defaultSnapshotRentention    = 5
+	defaultSnapshotIntervalHours = 12
+)
+
+type StartupHookArgs struct {
+	APIServerReady       <-chan struct{}
+	KubeConfigSupervisor string
+	Skips                map[string]bool
+	Disables             map[string]bool
+}
+
+type StartupHook func(context.Context, *sync.WaitGroup, StartupHookArgs) error
+
+type Server struct {
+	ClusterCIDR          cli.StringSlice
+	AgentToken           string
+	AgentTokenFile       string
+	Token                string
+	TokenFile            string
+	ClusterSecret        string
+	ServiceCIDR          cli.StringSlice
+	ServiceNodePortRange string
+	ClusterDNS           cli.StringSlice
+	ClusterDomain        string
+	// The port which kubectl clients can access k8s
+	HTTPSPort int
+	// The port which custom k3s API runs on
+	SupervisorPort int
+	// The port which kube-apiserver runs on
+	APIServerPort            int
+	APIServerBindAddress     string
+	DataDir                  string
+	DisableAgent             bool
+	KubeConfigOutput         string
+	KubeConfigMode           string
+	KubeConfigGroup          string
+	HelmJobImage             string
+	TLSSan                   cli.StringSlice
+	TLSSanSecurity           bool
+	ExtraAPIArgs             cli.StringSlice
+	ExtraEtcdArgs            cli.StringSlice
+	ExtraSchedulerArgs       cli.StringSlice
+	ExtraControllerArgs      cli.StringSlice
+	ExtraCloudControllerArgs cli.StringSlice
+	Rootless                 bool
+	DatastoreEndpoint        string
+	DatastoreCAFile          string
+	DatastoreCertFile        string
+	DatastoreKeyFile         string
+	KineTLS                  bool
+	AdvertiseIP              string
+	AdvertisePort            int
+	DisableScheduler         bool
+	ServerURL                string
+	FlannelBackend           string
+	FlannelIPv6Masq          bool
+	FlannelExternalIP        bool
+	EgressSelectorMode       string
+	DefaultLocalStoragePath  string
+	DisableCCM               bool
+	DisableNPC               bool
+	DisableHelmController    bool
+	DisableKubeProxy         bool
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableETCD              bool
+	EmbeddedRegistry         bool
+	ClusterInit              bool
+	ClusterReset             bool
+	ClusterResetRestorePath  string
+	EncryptSecrets           bool
+	EncryptForce             bool
+	EncryptOutput            string
+	EncryptSkip              bool
+	EncryptProvider          string
+	SystemDefaultRegistry    string
+	StartupHooks             []StartupHook
+	SupervisorMetrics        bool
+	EtcdSnapshotName         string
+	EtcdDisableSnapshots     bool
+	EtcdExposeMetrics        bool
+	EtcdSnapshotDir          string
+	EtcdSnapshotCron         string
+	EtcdSnapshotReconcile    time.Duration
+	EtcdSnapshotRetention    int
+	EtcdSnapshotCompress     bool
+	EtcdListFormat           string
+	EtcdS3                   bool
+	EtcdS3Endpoint           string
+	EtcdS3EndpointCA         string
+	EtcdS3SkipSSLVerify      bool
+	EtcdS3AccessKey          string
+	EtcdS3SecretKey          string
+	EtcdS3SessionToken       string
+	EtcdS3BucketName         string
+	EtcdS3Retention          int
+	EtcdS3BucketLookupType   string
+	EtcdS3Region             string
+	EtcdS3Folder             string
+	EtcdS3Proxy              string
+	EtcdS3ConfigSecret       string
+	EtcdS3Timeout            time.Duration
+	EtcdS3Insecure           bool
+	ServiceLBNamespace       string
+}
+
+var (
+	ServerConfig Server
+	DataDirFlag  = &cli.StringFlag{
+		Name:        "data-dir",
+		Aliases:     []string{"d"},
+		Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+		Destination: &ServerConfig.DataDir,
+		EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+	}
+	ServerToken = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
+		Destination: &ServerConfig.Token,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+	}
+	ClusterCIDR = &cli.StringSliceFlag{
+		Name:        "cluster-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
+		Destination: &ServerConfig.ClusterCIDR,
+	}
+	ServiceCIDR = &cli.StringSliceFlag{
+		Name:        "service-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
+		Destination: &ServerConfig.ServiceCIDR,
+	}
+	ServiceNodePortRange = &cli.StringFlag{
+		Name:        "service-node-port-range",
+		Usage:       "(networking) Port range to reserve for services with NodePort visibility",
+		Destination: &ServerConfig.ServiceNodePortRange,
+		Value:       "30000-32767",
+	}
+	ClusterDNS = &cli.StringSliceFlag{
+		Name:        "cluster-dns",
+		Usage:       "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+		Destination: &ServerConfig.ClusterDNS,
+	}
+	ClusterDomain = &cli.StringFlag{
+		Name:        "cluster-domain",
+		Usage:       "(networking) Cluster Domain",
+		Destination: &ServerConfig.ClusterDomain,
+		Value:       "cluster.local",
+	}
+	ExtraAPIArgs = &cli.StringSliceFlag{
+		Name:        "kube-apiserver-arg",
+		Usage:       "(flags) Customized flag for kube-apiserver process",
+		Destination: &ServerConfig.ExtraAPIArgs,
+	}
+	ExtraEtcdArgs = &cli.StringSliceFlag{
+		Name:        "etcd-arg",
+		Usage:       "(flags) Customized flag for etcd process",
+		Destination: &ServerConfig.ExtraEtcdArgs,
+	}
+	ExtraSchedulerArgs = &cli.StringSliceFlag{
+		Name:        "kube-scheduler-arg",
+		Usage:       "(flags) Customized flag for kube-scheduler process",
+		Destination: &ServerConfig.ExtraSchedulerArgs,
+	}
+	ExtraControllerArgs = &cli.StringSliceFlag{
+		Name:        "kube-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	}
+)
+
+var ServerFlags = []cli.Flag{
+	ConfigFlag,
+	DebugFlag,
+	VLevel,
+	VModule,
+	LogFile,
+	AlsoLogToStderr,
+	BindAddressFlag,
+	&cli.IntFlag{
+		Name:        "https-listen-port",
+		Usage:       "(listener) HTTPS listen port",
+		Value:       6443,
+		Destination: &ServerConfig.HTTPSPort,
+	},
+	&cli.IntFlag{
+		Name:        "supervisor-port",
+		EnvVars:     []string{version.ProgramUpper + "_SUPERVISOR_PORT"},
+		Usage:       "(experimental) Supervisor listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.SupervisorPort,
+	},
+	&cli.IntFlag{
+		Name:        "apiserver-port",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_PORT"},
+		Usage:       "(experimental) apiserver internal listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerPort,
+	},
+	&cli.StringFlag{
+		Name:        "apiserver-bind-address",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_BIND_ADDRESS"},
+		Usage:       "(experimental) apiserver internal bind address override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerBindAddress,
+	},
+	&cli.StringFlag{
+		Name:        "advertise-address",
+		Usage:       "(listener) IPv4/IPv6 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
+		Destination: &ServerConfig.AdvertiseIP,
+	},
+	&cli.IntFlag{
+		Name:        "advertise-port",
+		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: https-listen-port)",
+		Destination: &ServerConfig.AdvertisePort,
+	},
+	&cli.StringSliceFlag{
+		Name:        "tls-san",
+		Usage:       "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
+		Destination: &ServerConfig.TLSSan,
+	},
+	&cli.BoolFlag{
+		Name:        "tls-san-security",
+		Usage:       "(listener) Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option (default: true)",
+		Destination: &ServerConfig.TLSSanSecurity,
+		Value:       true,
+	},
+	DataDirFlag,
+	ClusterCIDR,
+	ServiceCIDR,
+	ServiceNodePortRange,
+	ClusterDNS,
+	ClusterDomain,
+	&cli.StringFlag{
+		Name:        "flannel-backend",
+		Usage:       "(networking) Backend (valid values: 'none', 'vxlan', 'host-gw', 'wireguard-native'",
+		Destination: &ServerConfig.FlannelBackend,
+		Value:       "vxlan",
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-ipv6-masq",
+		Usage:       "(networking) Enable IPv6 masquerading for pod",
+		Destination: &ServerConfig.FlannelIPv6Masq,
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-external-ip",
+		Usage:       "(networking) Use node external IP addresses for Flannel traffic",
+		Destination: &ServerConfig.FlannelExternalIP,
+	},
+	&cli.StringFlag{
+		Name:        "egress-selector-mode",
+		Usage:       "(networking) One of 'agent', 'cluster', 'pod', 'disabled'",
+		Destination: &ServerConfig.EgressSelectorMode,
+		Value:       "agent",
+	},
+	&cli.StringFlag{
+		Name:        "servicelb-namespace",
+		Usage:       "(networking) Namespace of the pods for the servicelb component",
+		Destination: &ServerConfig.ServiceLBNamespace,
+		Value:       "kube-system",
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig",
+		Aliases:     []string{"o"},
+		Usage:       "(client) Write kubeconfig for admin client to this file",
+		Destination: &ServerConfig.KubeConfigOutput,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_OUTPUT"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-mode",
+		Usage:       "(client) Write kubeconfig with this mode",
+		Destination: &ServerConfig.KubeConfigMode,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_MODE"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-group",
+		Usage:       "(client) Write kubeconfig with this group",
+		Destination: &ServerConfig.KubeConfigGroup,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_GROUP"},
+	},
+	&cli.StringFlag{
+		Name:        "helm-job-image",
+		Usage:       "(helm) Default image to use for helm jobs",
+		Destination: &ServerConfig.HelmJobImage,
+	},
+	ServerToken,
+	&cli.StringFlag{
+		Name:        "token-file",
+		Usage:       "(cluster) File containing the token",
+		Destination: &ServerConfig.TokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token",
+		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
+		Destination: &ServerConfig.AgentToken,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token-file",
+		Usage:       "(cluster) File containing the agent secret",
+		Destination: &ServerConfig.AgentTokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "server",
+		Aliases:     []string{"s"},
+		Usage:       "(cluster) Server to connect to, used to join a cluster",
+		EnvVars:     []string{version.ProgramUpper + "_URL"},
+		Destination: &ServerConfig.ServerURL,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-init",
+		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_INIT"},
+		Destination: &ServerConfig.ClusterInit,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-reset",
+		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_RESET"},
+		Destination: &ServerConfig.ClusterReset,
+	},
+	&cli.StringFlag{
+		Name:        "cluster-reset-restore-path",
+		Usage:       "(db) Path to snapshot file to be restored",
+		Destination: &ServerConfig.ClusterResetRestorePath,
+	},
+	ExtraAPIArgs,
+	ExtraEtcdArgs,
+	ExtraControllerArgs,
+	ExtraSchedulerArgs,
+	&cli.StringSliceFlag{
+		Name:        "kube-cloud-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+	&cli.BoolFlag{
+		Name:        "kine-tls",
+		Usage:       "(experimental/db) Enable TLS on the kine etcd server socket",
+		Destination: &ServerConfig.KineTLS,
+		Hidden:      true,
+	},
+	&cli.StringFlag{
+		Name:        "datastore-endpoint",
+		Usage:       "(db) Specify etcd, NATS, MySQL, Postgres, or SQLite (default) data source name",
+		Destination: &ServerConfig.DatastoreEndpoint,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_ENDPOINT"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-cafile",
+		Usage:       "(db) TLS Certificate Authority file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCAFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CAFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-certfile",
+		Usage:       "(db) TLS certification file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCertFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CERTFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-keyfile",
+		Usage:       "(db) TLS key file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreKeyFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_KEYFILE"},
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-expose-metrics",
+		Usage:       "(db) Expose etcd metrics to client interface",
+		Destination: &ServerConfig.EtcdExposeMetrics,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-disable-snapshots",
+		Usage:       "(db) Disable automatic etcd snapshots",
+		Destination: &ServerConfig.EtcdDisableSnapshots,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-name",
+		Usage:       "(db) Set the base name of etcd snapshots, appended with UNIX timestamp",
+		Destination: &ServerConfig.EtcdSnapshotName,
+		Value:       "etcd-snapshot",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-schedule-cron",
+		Usage:       "(db) Snapshot interval time in cron spec. eg. every 5 hours '0 */5 * * *'",
+		Destination: &ServerConfig.EtcdSnapshotCron,
+		Value:       "0 */12 * * *",
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-snapshot-reconcile-interval",
+		Usage:       "(db) Snapshot reconcile interval",
+		Destination: &ServerConfig.EtcdSnapshotReconcile,
+		Value:       10 * time.Minute,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-snapshot-retention",
+		Usage:       "(db) Number of snapshots to retain",
+		Destination: &ServerConfig.EtcdSnapshotRetention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-dir",
+		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/server/db/snapshots)",
+		Destination: &ServerConfig.EtcdSnapshotDir,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-snapshot-compress",
+		Usage:       "(db) Compress etcd snapshot",
+		Destination: &ServerConfig.EtcdSnapshotCompress,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3",
+		Usage:       "(db) Enable backup to S3",
+		Destination: &ServerConfig.EtcdS3,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint",
+		Usage:       "(db) S3 endpoint url",
+		Destination: &ServerConfig.EtcdS3Endpoint,
+		Value:       "s3.amazonaws.com",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint-ca",
+		Usage:       "(db) S3 custom CA cert to connect to S3 endpoint",
+		Destination: &ServerConfig.EtcdS3EndpointCA,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-skip-ssl-verify",
+		Usage:       "(db) Disables S3 SSL certificate validation",
+		Destination: &ServerConfig.EtcdS3SkipSSLVerify,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-access-key",
+		Usage:       "(db) S3 access key",
+		EnvVars:     []string{"AWS_ACCESS_KEY_ID"},
+		Destination: &ServerConfig.EtcdS3AccessKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-secret-key",
+		Usage:       "(db) S3 secret key",
+		EnvVars:     []string{"AWS_SECRET_ACCESS_KEY"},
+		Destination: &ServerConfig.EtcdS3SecretKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-session-token",
+		Usage:       "(db) S3 session token",
+		EnvVars:     []string{"AWS_SESSION_TOKEN"},
+		Destination: &ServerConfig.EtcdS3SessionToken,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket",
+		Usage:       "(db) S3 bucket name",
+		Destination: &ServerConfig.EtcdS3BucketName,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket-lookup-type",
+		Usage:       "(db) S3 bucket lookup type, one of 'auto', 'dns', 'path'; default is 'auto' if not set",
+		Destination: &ServerConfig.EtcdS3BucketLookupType,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-region",
+		Usage:       "(db) S3 region / bucket location (optional)",
+		Destination: &ServerConfig.EtcdS3Region,
+		Value:       "us-east-1",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-folder",
+		Usage:       "(db) S3 folder",
+		Destination: &ServerConfig.EtcdS3Folder,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-s3-retention",
+		Usage:       "(db) S3 retention limit",
+		Destination: &ServerConfig.EtcdS3Retention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-proxy",
+		Usage:       "(db) Proxy server to use when connecting to S3, overriding any proxy-releated environment variables",
+		Destination: &ServerConfig.EtcdS3Proxy,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-config-secret",
+		Usage:       "(db) Name of secret in the kube-system namespace used to configure S3, if etcd-s3 is enabled and no other etcd-s3 options are set",
+		Destination: &ServerConfig.EtcdS3ConfigSecret,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-insecure",
+		Usage:       "(db) Disables S3 over HTTPS",
+		Destination: &ServerConfig.EtcdS3Insecure,
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-s3-timeout",
+		Usage:       "(db) S3 timeout",
+		Destination: &ServerConfig.EtcdS3Timeout,
+		Value:       5 * time.Minute,
+	},
+	&cli.StringFlag{
+		Name:        "default-local-storage-path",
+		Usage:       "(storage) Default local storage path for local provisioner storage class",
+		Destination: &ServerConfig.DefaultLocalStoragePath,
+	},
+	&cli.StringSliceFlag{
+		Name:  "disable",
+		Usage: "(components) Do not deploy packaged components and delete any deployed components (valid values: " + DisableItems + ")",
+	},
+	&cli.BoolFlag{
+		Name:        "disable-scheduler",
+		Usage:       "(components) Disable Kubernetes default scheduler",
+		Destination: &ServerConfig.DisableScheduler,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-cloud-controller",
+		Usage:       "(components) Disable " + version.Program + " default cloud controller manager",
+		Destination: &ServerConfig.DisableCCM,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-kube-proxy",
+		Usage:       "(components) Disable running kube-proxy",
+		Destination: &ServerConfig.DisableKubeProxy,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-network-policy",
+		Usage:       "(components) Disable " + version.Program + " default network policy controller",
+		Destination: &ServerConfig.DisableNPC,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-helm-controller",
+		Usage:       "(components) Disable Helm controller",
+		Destination: &ServerConfig.DisableHelmController,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-apiserver",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running api server",
+		Destination: &ServerConfig.DisableAPIServer,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-controller-manager",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running kube-controller-manager",
+		Destination: &ServerConfig.DisableControllerManager,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-etcd",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running etcd",
+		Destination: &ServerConfig.DisableETCD,
+	},
+	&cli.BoolFlag{
+		Name:        "embedded-registry",
+		Usage:       "(components) Enable embedded distributed container registry; requires use of embedded containerd; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.EmbeddedRegistry,
+	},
+	&cli.BoolFlag{
+		Name:        "supervisor-metrics",
+		Usage:       "(experimental/components) Enable serving " + version.Program + " internal metrics on the supervisor port; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.SupervisorMetrics,
+	},
+	NodeNameFlag,
+	WithNodeIDFlag,
+	NodeLabels,
+	NodeTaints,
+	ImageCredProvBinDirFlag,
+	ImageCredProvConfigFlag,
+	DockerFlag,
+	CRIEndpointFlag,
+	DefaultRuntimeFlag,
+	ImageServiceEndpointFlag,
+	DisableDefaultRegistryEndpointFlag,
+	NonrootDevicesFlag,
+	PauseImageFlag,
+	SnapshotterFlag,
+	PrivateRegistryFlag,
+	&cli.StringFlag{
+		Name:        "system-default-registry",
+		Usage:       "(agent/runtime) Private registry to be used for all system images",
+		EnvVars:     []string{version.ProgramUpper + "_SYSTEM_DEFAULT_REGISTRY"},
+		Destination: &ServerConfig.SystemDefaultRegistry,
+	},
+	AirgapExtraRegistryFlag,
+	NodeIPFlag,
+	NodeExternalIPFlag,
+	NodeInternalDNSFlag,
+	NodeExternalDNSFlag,
+	ResolvConfFlag,
+	FlannelIfaceFlag,
+	FlannelConfFlag,
+	FlannelCniConfFileFlag,
+	VPNAuth,
+	VPNAuthFile,
+	ExtraKubeletArgs,
+	ExtraKubeProxyArgs,
+	ProtectKernelDefaultsFlag,
+	&cli.BoolFlag{
+		Name:        "secrets-encryption",
+		Usage:       "Enable secret encryption at rest",
+		Destination: &ServerConfig.EncryptSecrets,
+	},
+	// Experimental flags
+	EnablePProfFlag,
+	&cli.BoolFlag{
+		Name:        "rootless",
+		Usage:       "(experimental) Run rootless",
+		Destination: &ServerConfig.Rootless,
+	},
+	&cli.StringFlag{
+		Name:        "secrets-encryption-provider",
+		Usage:       "(experimental) Secret encryption provider (valid values: 'aescbc', 'secretbox')",
+		Destination: &ServerConfig.EncryptProvider,
+		Value:       "aescbc",
+	},
+	PreferBundledBin,
+	SELinuxFlag,
+	LBServerPortFlag,
+
+	// Hidden/Deprecated flags below
+
+	&cli.BoolFlag{
+		Name:        "disable-agent",
+		Usage:       "Do not run a local agent and register a local kubelet",
+		Hidden:      true,
+		Destination: &ServerConfig.DisableAgent,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-controller-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-cloud-controller-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+}
+
+func NewServerCommand(action func(*cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "server",
+		Usage:     "Run management server",
+		UsageText: appName + " server [OPTIONS]",
+		Action:    action,
+		Flags:     ServerFlags,
+	}
+}

--- a/thirdparty-src/k3s/v1_32/SOURCE.txt
+++ b/thirdparty-src/k3s/v1_32/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/k3s-io/k3s
+tag:    v1.32.13+k3s1
+commit: bf43a24f544763b0f3ef2d2da0beeea1cf357a35
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go

--- a/thirdparty-src/k3s/v1_32/zz_agent.go
+++ b/thirdparty-src/k3s/v1_32/zz_agent.go
@@ -1,0 +1,343 @@
+package cmds
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+type Agent struct {
+	Token                    string
+	TokenFile                string
+	ClusterSecret            string
+	ServerURL                string
+	APIAddressCh             chan []string
+	DisableLoadBalancer      bool
+	DisableServiceLB         bool
+	ETCDAgent                bool
+	LBServerPort             int
+	ResolvConf               string
+	DataDir                  string
+	BindAddress              string
+	NodeIP                   cli.StringSlice
+	NodeExternalIP           cli.StringSlice
+	NodeInternalDNS          cli.StringSlice
+	NodeExternalDNS          cli.StringSlice
+	NodeName                 string
+	PauseImage               string
+	Snapshotter              string
+	Docker                   bool
+	ContainerdNoDefault      bool
+	ContainerdNonrootDevices bool
+	ContainerRuntimeEndpoint string
+	DefaultRuntime           string
+	ImageServiceEndpoint     string
+	FlannelIface             string
+	FlannelConf              string
+	FlannelCniConfFile       string
+	VPNAuth                  string
+	VPNAuthFile              string
+	Debug                    bool
+	EnablePProf              bool
+	Rootless                 bool
+	RootlessAlreadyUnshared  bool
+	WithNodeID               bool
+	EnableSELinux            bool
+	ProtectKernelDefaults    bool
+	ClusterReset             bool
+	PrivateRegistry          string
+	SystemDefaultRegistry    string
+	AirgapExtraRegistry      cli.StringSlice
+	ExtraKubeletArgs         cli.StringSlice
+	ExtraKubeProxyArgs       cli.StringSlice
+	Labels                   cli.StringSlice
+	Taints                   cli.StringSlice
+	ImageCredProvBinDir      string
+	ImageCredProvConfig      string
+	AgentShared
+}
+
+type AgentShared struct {
+	NodeIP string
+}
+
+var (
+	appName        = filepath.Base(os.Args[0])
+	AgentConfig    Agent
+	AgentTokenFlag = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Token to use for authentication",
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+		Destination: &AgentConfig.Token,
+	}
+	NodeIPFlag = &cli.StringSliceFlag{
+		Name:        "node-ip",
+		Aliases:     []string{"i"},
+		Usage:       "(agent/networking) IPv4/IPv6 addresses to advertise for node",
+		Destination: &AgentConfig.NodeIP,
+	}
+	NodeExternalIPFlag = &cli.StringSliceFlag{
+		Name:        "node-external-ip",
+		Usage:       "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalIP,
+	}
+	NodeInternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-internal-dns",
+		Usage:       "(agent/networking) internal DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeInternalDNS,
+	}
+	NodeExternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-external-dns",
+		Usage:       "(agent/networking) external DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalDNS,
+	}
+	NodeNameFlag = &cli.StringFlag{
+		Name:        "node-name",
+		Usage:       "(agent/node) Node name",
+		EnvVars:     []string{version.ProgramUpper + "_NODE_NAME"},
+		Destination: &AgentConfig.NodeName,
+	}
+	WithNodeIDFlag = &cli.BoolFlag{
+		Name:        "with-node-id",
+		Usage:       "(agent/node) Append id to node name",
+		Destination: &AgentConfig.WithNodeID,
+	}
+	ProtectKernelDefaultsFlag = &cli.BoolFlag{
+		Name:        "protect-kernel-defaults",
+		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
+		Destination: &AgentConfig.ProtectKernelDefaults,
+	}
+	SELinuxFlag = &cli.BoolFlag{
+		Name:        "selinux",
+		Usage:       "(agent/node) Enable SELinux in containerd",
+		Destination: &AgentConfig.EnableSELinux,
+		EnvVars:     []string{version.ProgramUpper + "_SELINUX"},
+	}
+	LBServerPortFlag = &cli.IntFlag{
+		Name:        "lb-server-port",
+		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
+		Destination: &AgentConfig.LBServerPort,
+		EnvVars:     []string{version.ProgramUpper + "_LB_SERVER_PORT"},
+		Value:       6444,
+	}
+	DockerFlag = &cli.BoolFlag{
+		Name:        "docker",
+		Usage:       "(agent/runtime) (experimental) Use cri-dockerd instead of containerd",
+		Destination: &AgentConfig.Docker,
+	}
+	CRIEndpointFlag = &cli.StringFlag{
+		Name:        "container-runtime-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
+		Destination: &AgentConfig.ContainerRuntimeEndpoint,
+	}
+	DefaultRuntimeFlag = &cli.StringFlag{
+		Name:        "default-runtime",
+		Usage:       "(agent/runtime) Set the default runtime in containerd",
+		Destination: &AgentConfig.DefaultRuntime,
+	}
+	ImageServiceEndpointFlag = &cli.StringFlag{
+		Name:        "image-service-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd image service and use remote image service socket at the given path. If not specified, defaults to --container-runtime-endpoint.",
+		Destination: &AgentConfig.ImageServiceEndpoint,
+	}
+	PrivateRegistryFlag = &cli.StringFlag{
+		Name:        "private-registry",
+		Usage:       "(agent/runtime) Private registry configuration file",
+		Destination: &AgentConfig.PrivateRegistry,
+		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
+	}
+	AirgapExtraRegistryFlag = &cli.StringSliceFlag{
+		Name:        "airgap-extra-registry",
+		Usage:       "(agent/runtime) Additional registry to tag airgap images as being sourced from",
+		Destination: &AgentConfig.AirgapExtraRegistry,
+		Hidden:      true,
+	}
+	PauseImageFlag = &cli.StringFlag{
+		Name:        "pause-image",
+		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
+		Destination: &AgentConfig.PauseImage,
+		Value:       "rancher/mirrored-pause:3.6",
+	}
+	SnapshotterFlag = &cli.StringFlag{
+		Name:        "snapshotter",
+		Usage:       "(agent/runtime) Override default containerd snapshotter",
+		Destination: &AgentConfig.Snapshotter,
+		Value:       DefaultSnapshotter,
+	}
+	FlannelIfaceFlag = &cli.StringFlag{
+		Name:        "flannel-iface",
+		Usage:       "(agent/networking) Override default flannel interface",
+		Destination: &AgentConfig.FlannelIface,
+	}
+	FlannelConfFlag = &cli.StringFlag{
+		Name:        "flannel-conf",
+		Usage:       "(agent/networking) Override default flannel config file",
+		Destination: &AgentConfig.FlannelConf,
+	}
+	FlannelCniConfFileFlag = &cli.StringFlag{
+		Name:        "flannel-cni-conf",
+		Usage:       "(agent/networking) Override default flannel cni config file",
+		Destination: &AgentConfig.FlannelCniConfFile,
+	}
+	VPNAuth = &cli.StringFlag{
+		Name:        "vpn-auth",
+		Usage:       "(agent/networking) (experimental) Credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH"},
+		Destination: &AgentConfig.VPNAuth,
+	}
+	VPNAuthFile = &cli.StringFlag{
+		Name:        "vpn-auth-file",
+		Usage:       "(agent/networking) (experimental) File containing credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH_FILE"},
+		Destination: &AgentConfig.VPNAuthFile,
+	}
+	ResolvConfFlag = &cli.StringFlag{
+		Name:        "resolv-conf",
+		Usage:       "(agent/networking) Kubelet resolv.conf file",
+		EnvVars:     []string{version.ProgramUpper + "_RESOLV_CONF"},
+		Destination: &AgentConfig.ResolvConf,
+	}
+	ExtraKubeletArgs = &cli.StringSliceFlag{
+		Name:        "kubelet-arg",
+		Usage:       "(agent/flags) Customized flag for kubelet process",
+		Destination: &AgentConfig.ExtraKubeletArgs,
+	}
+	ExtraKubeProxyArgs = &cli.StringSliceFlag{
+		Name:        "kube-proxy-arg",
+		Usage:       "(agent/flags) Customized flag for kube-proxy process",
+		Destination: &AgentConfig.ExtraKubeProxyArgs,
+	}
+	NodeTaints = &cli.StringSliceFlag{
+		Name:        "node-taint",
+		Usage:       "(agent/node) Registering kubelet with set of taints",
+		Destination: &AgentConfig.Taints,
+	}
+	NodeLabels = &cli.StringSliceFlag{
+		Name:        "node-label",
+		Usage:       "(agent/node) Registering and starting kubelet with set of labels",
+		Destination: &AgentConfig.Labels,
+	}
+	ImageCredProvBinDirFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-bin-dir",
+		Usage:       "(agent/node) The path to the directory where credential provider plugin binaries are located",
+		Destination: &AgentConfig.ImageCredProvBinDir,
+		Value:       "/var/lib/rancher/credentialprovider/bin",
+	}
+	ImageCredProvConfigFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-config",
+		Usage:       "(agent/node) The path to the credential provider plugin config file",
+		Destination: &AgentConfig.ImageCredProvConfig,
+		Value:       "/var/lib/rancher/credentialprovider/config.yaml",
+	}
+	DisableAgentLBFlag = &cli.BoolFlag{
+		Name:        "disable-apiserver-lb",
+		Usage:       "(agent/networking) (experimental) Disable the agent's client-side load-balancer and connect directly to the configured server address",
+		Destination: &AgentConfig.DisableLoadBalancer,
+	}
+	DisableDefaultRegistryEndpointFlag = &cli.BoolFlag{
+		Name:        "disable-default-registry-endpoint",
+		Usage:       "(agent/containerd) Disables containerd's fallback default registry endpoint when a mirror is configured for that registry",
+		Destination: &AgentConfig.ContainerdNoDefault,
+	}
+	NonrootDevicesFlag = &cli.BoolFlag{
+		Name:        "nonroot-devices",
+		Usage:       "(agent/containerd) Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config",
+		Destination: &AgentConfig.ContainerdNonrootDevices,
+	}
+	EnablePProfFlag = &cli.BoolFlag{
+		Name:        "enable-pprof",
+		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
+		Destination: &AgentConfig.EnablePProf,
+	}
+	BindAddressFlag = &cli.StringFlag{
+		Name:        "bind-address",
+		Usage:       "(listener) " + version.Program + " bind address (default: 0.0.0.0)",
+		Destination: &AgentConfig.BindAddress,
+	}
+)
+
+func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "agent",
+		Usage:     "Run node agent",
+		UsageText: appName + " agent [OPTIONS]",
+		Action:    action,
+		Flags: []cli.Flag{
+			ConfigFlag,
+			DebugFlag,
+			VLevel,
+			VModule,
+			LogFile,
+			AlsoLogToStderr,
+			AgentTokenFlag,
+			&cli.StringFlag{
+				Name:        "token-file",
+				Usage:       "(cluster) Token file to use for authentication",
+				EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+				Destination: &AgentConfig.TokenFile,
+			},
+			&cli.StringFlag{
+				Name:        "server",
+				Aliases:     []string{"s"},
+				Usage:       "(cluster) Server to connect to",
+				EnvVars:     []string{version.ProgramUpper + "_URL"},
+				Destination: &AgentConfig.ServerURL,
+			},
+			// Note that this is different from DataDirFlag used elswhere in the CLI,
+			// as this is bound to AgentConfig instead of ServerConfig.
+			&cli.StringFlag{
+				Name:        "data-dir",
+				Aliases:     []string{"d"},
+				Usage:       "(agent/data) Folder to hold state",
+				Destination: &AgentConfig.DataDir,
+				Value:       "/var/lib/rancher/" + version.Program + "",
+				EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+			},
+			NodeNameFlag,
+			WithNodeIDFlag,
+			NodeLabels,
+			NodeTaints,
+			ImageCredProvBinDirFlag,
+			ImageCredProvConfigFlag,
+			SELinuxFlag,
+			LBServerPortFlag,
+			ProtectKernelDefaultsFlag,
+			CRIEndpointFlag,
+			DefaultRuntimeFlag,
+			ImageServiceEndpointFlag,
+			PauseImageFlag,
+			SnapshotterFlag,
+			PrivateRegistryFlag,
+			DisableDefaultRegistryEndpointFlag,
+			NonrootDevicesFlag,
+			AirgapExtraRegistryFlag,
+			NodeIPFlag,
+			BindAddressFlag,
+			NodeExternalIPFlag,
+			NodeInternalDNSFlag,
+			NodeExternalDNSFlag,
+			ResolvConfFlag,
+			FlannelIfaceFlag,
+			FlannelConfFlag,
+			FlannelCniConfFileFlag,
+			ExtraKubeletArgs,
+			ExtraKubeProxyArgs,
+			// Experimental flags
+			EnablePProfFlag,
+			&cli.BoolFlag{
+				Name:        "rootless",
+				Usage:       "(experimental) Run rootless",
+				Destination: &AgentConfig.Rootless,
+			},
+			PreferBundledBin,
+			// Deprecated/hidden below
+			DockerFlag,
+			VPNAuth,
+			VPNAuthFile,
+			DisableAgentLBFlag,
+		},
+	}
+}

--- a/thirdparty-src/k3s/v1_32/zz_server.go
+++ b/thirdparty-src/k3s/v1_32/zz_server.go
@@ -1,0 +1,660 @@
+package cmds
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	defaultSnapshotRentention    = 5
+	defaultSnapshotIntervalHours = 12
+)
+
+type StartupHookArgs struct {
+	APIServerReady       <-chan struct{}
+	KubeConfigSupervisor string
+	Skips                map[string]bool
+	Disables             map[string]bool
+}
+
+type StartupHook func(context.Context, *sync.WaitGroup, StartupHookArgs) error
+
+type Server struct {
+	ClusterCIDR          cli.StringSlice
+	AgentToken           string
+	AgentTokenFile       string
+	Token                string
+	TokenFile            string
+	ClusterSecret        string
+	ServiceCIDR          cli.StringSlice
+	ServiceNodePortRange string
+	ClusterDNS           cli.StringSlice
+	ClusterDomain        string
+	// The port which kubectl clients can access k8s
+	HTTPSPort int
+	// The port which custom k3s API runs on
+	SupervisorPort int
+	// The port which kube-apiserver runs on
+	APIServerPort            int
+	APIServerBindAddress     string
+	DataDir                  string
+	DisableAgent             bool
+	KubeConfigOutput         string
+	KubeConfigMode           string
+	KubeConfigGroup          string
+	HelmJobImage             string
+	TLSSan                   cli.StringSlice
+	TLSSanSecurity           bool
+	ExtraAPIArgs             cli.StringSlice
+	ExtraEtcdArgs            cli.StringSlice
+	ExtraSchedulerArgs       cli.StringSlice
+	ExtraControllerArgs      cli.StringSlice
+	ExtraCloudControllerArgs cli.StringSlice
+	Rootless                 bool
+	DatastoreEndpoint        string
+	DatastoreCAFile          string
+	DatastoreCertFile        string
+	DatastoreKeyFile         string
+	KineTLS                  bool
+	AdvertiseIP              string
+	AdvertisePort            int
+	DisableScheduler         bool
+	ServerURL                string
+	FlannelBackend           string
+	FlannelIPv6Masq          bool
+	FlannelExternalIP        bool
+	EgressSelectorMode       string
+	DefaultLocalStoragePath  string
+	DisableCCM               bool
+	DisableNPC               bool
+	DisableHelmController    bool
+	DisableKubeProxy         bool
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableETCD              bool
+	EmbeddedRegistry         bool
+	ClusterInit              bool
+	ClusterReset             bool
+	ClusterResetRestorePath  string
+	EncryptSecrets           bool
+	EncryptForce             bool
+	EncryptOutput            string
+	EncryptSkip              bool
+	EncryptProvider          string
+	SystemDefaultRegistry    string
+	StartupHooks             []StartupHook
+	SupervisorMetrics        bool
+	EtcdSnapshotName         string
+	EtcdDisableSnapshots     bool
+	EtcdExposeMetrics        bool
+	EtcdSnapshotDir          string
+	EtcdSnapshotCron         string
+	EtcdSnapshotReconcile    time.Duration
+	EtcdSnapshotRetention    int
+	EtcdSnapshotCompress     bool
+	EtcdListFormat           string
+	EtcdS3                   bool
+	EtcdS3Endpoint           string
+	EtcdS3EndpointCA         string
+	EtcdS3SkipSSLVerify      bool
+	EtcdS3AccessKey          string
+	EtcdS3SecretKey          string
+	EtcdS3SessionToken       string
+	EtcdS3BucketName         string
+	EtcdS3Retention          int
+	EtcdS3BucketLookupType   string
+	EtcdS3Region             string
+	EtcdS3Folder             string
+	EtcdS3Proxy              string
+	EtcdS3ConfigSecret       string
+	EtcdS3Timeout            time.Duration
+	EtcdS3Insecure           bool
+	ServiceLBNamespace       string
+}
+
+var (
+	ServerConfig Server
+	DataDirFlag  = &cli.StringFlag{
+		Name:        "data-dir",
+		Aliases:     []string{"d"},
+		Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+		Destination: &ServerConfig.DataDir,
+		EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+	}
+	ServerToken = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
+		Destination: &ServerConfig.Token,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+	}
+	ClusterCIDR = &cli.StringSliceFlag{
+		Name:        "cluster-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
+		Destination: &ServerConfig.ClusterCIDR,
+	}
+	ServiceCIDR = &cli.StringSliceFlag{
+		Name:        "service-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
+		Destination: &ServerConfig.ServiceCIDR,
+	}
+	ServiceNodePortRange = &cli.StringFlag{
+		Name:        "service-node-port-range",
+		Usage:       "(networking) Port range to reserve for services with NodePort visibility",
+		Destination: &ServerConfig.ServiceNodePortRange,
+		Value:       "30000-32767",
+	}
+	ClusterDNS = &cli.StringSliceFlag{
+		Name:        "cluster-dns",
+		Usage:       "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+		Destination: &ServerConfig.ClusterDNS,
+	}
+	ClusterDomain = &cli.StringFlag{
+		Name:        "cluster-domain",
+		Usage:       "(networking) Cluster Domain",
+		Destination: &ServerConfig.ClusterDomain,
+		Value:       "cluster.local",
+	}
+	ExtraAPIArgs = &cli.StringSliceFlag{
+		Name:        "kube-apiserver-arg",
+		Usage:       "(flags) Customized flag for kube-apiserver process",
+		Destination: &ServerConfig.ExtraAPIArgs,
+	}
+	ExtraEtcdArgs = &cli.StringSliceFlag{
+		Name:        "etcd-arg",
+		Usage:       "(flags) Customized flag for etcd process",
+		Destination: &ServerConfig.ExtraEtcdArgs,
+	}
+	ExtraSchedulerArgs = &cli.StringSliceFlag{
+		Name:        "kube-scheduler-arg",
+		Usage:       "(flags) Customized flag for kube-scheduler process",
+		Destination: &ServerConfig.ExtraSchedulerArgs,
+	}
+	ExtraControllerArgs = &cli.StringSliceFlag{
+		Name:        "kube-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	}
+)
+
+var ServerFlags = []cli.Flag{
+	ConfigFlag,
+	DebugFlag,
+	VLevel,
+	VModule,
+	LogFile,
+	AlsoLogToStderr,
+	BindAddressFlag,
+	&cli.IntFlag{
+		Name:        "https-listen-port",
+		Usage:       "(listener) HTTPS listen port",
+		Value:       6443,
+		Destination: &ServerConfig.HTTPSPort,
+	},
+	&cli.IntFlag{
+		Name:        "supervisor-port",
+		EnvVars:     []string{version.ProgramUpper + "_SUPERVISOR_PORT"},
+		Usage:       "(experimental) Supervisor listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.SupervisorPort,
+	},
+	&cli.IntFlag{
+		Name:        "apiserver-port",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_PORT"},
+		Usage:       "(experimental) apiserver internal listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerPort,
+	},
+	&cli.StringFlag{
+		Name:        "apiserver-bind-address",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_BIND_ADDRESS"},
+		Usage:       "(experimental) apiserver internal bind address override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerBindAddress,
+	},
+	&cli.StringFlag{
+		Name:        "advertise-address",
+		Usage:       "(listener) IPv4/IPv6 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
+		Destination: &ServerConfig.AdvertiseIP,
+	},
+	&cli.IntFlag{
+		Name:        "advertise-port",
+		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: https-listen-port)",
+		Destination: &ServerConfig.AdvertisePort,
+	},
+	&cli.StringSliceFlag{
+		Name:        "tls-san",
+		Usage:       "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
+		Destination: &ServerConfig.TLSSan,
+	},
+	&cli.BoolFlag{
+		Name:        "tls-san-security",
+		Usage:       "(listener) Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option (default: true)",
+		Destination: &ServerConfig.TLSSanSecurity,
+		Value:       true,
+	},
+	DataDirFlag,
+	ClusterCIDR,
+	ServiceCIDR,
+	ServiceNodePortRange,
+	ClusterDNS,
+	ClusterDomain,
+	&cli.StringFlag{
+		Name:        "flannel-backend",
+		Usage:       "(networking) Backend (valid values: 'none', 'vxlan', 'host-gw', 'wireguard-native'",
+		Destination: &ServerConfig.FlannelBackend,
+		Value:       "vxlan",
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-ipv6-masq",
+		Usage:       "(networking) Enable IPv6 masquerading for pod",
+		Destination: &ServerConfig.FlannelIPv6Masq,
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-external-ip",
+		Usage:       "(networking) Use node external IP addresses for Flannel traffic",
+		Destination: &ServerConfig.FlannelExternalIP,
+	},
+	&cli.StringFlag{
+		Name:        "egress-selector-mode",
+		Usage:       "(networking) One of 'agent', 'cluster', 'pod', 'disabled'",
+		Destination: &ServerConfig.EgressSelectorMode,
+		Value:       "agent",
+	},
+	&cli.StringFlag{
+		Name:        "servicelb-namespace",
+		Usage:       "(networking) Namespace of the pods for the servicelb component",
+		Destination: &ServerConfig.ServiceLBNamespace,
+		Value:       "kube-system",
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig",
+		Aliases:     []string{"o"},
+		Usage:       "(client) Write kubeconfig for admin client to this file",
+		Destination: &ServerConfig.KubeConfigOutput,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_OUTPUT"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-mode",
+		Usage:       "(client) Write kubeconfig with this mode",
+		Destination: &ServerConfig.KubeConfigMode,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_MODE"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-group",
+		Usage:       "(client) Write kubeconfig with this group",
+		Destination: &ServerConfig.KubeConfigGroup,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_GROUP"},
+	},
+	&cli.StringFlag{
+		Name:        "helm-job-image",
+		Usage:       "(helm) Default image to use for helm jobs",
+		Destination: &ServerConfig.HelmJobImage,
+	},
+	ServerToken,
+	&cli.StringFlag{
+		Name:        "token-file",
+		Usage:       "(cluster) File containing the token",
+		Destination: &ServerConfig.TokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token",
+		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
+		Destination: &ServerConfig.AgentToken,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token-file",
+		Usage:       "(cluster) File containing the agent secret",
+		Destination: &ServerConfig.AgentTokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "server",
+		Aliases:     []string{"s"},
+		Usage:       "(cluster) Server to connect to, used to join a cluster",
+		EnvVars:     []string{version.ProgramUpper + "_URL"},
+		Destination: &ServerConfig.ServerURL,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-init",
+		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_INIT"},
+		Destination: &ServerConfig.ClusterInit,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-reset",
+		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_RESET"},
+		Destination: &ServerConfig.ClusterReset,
+	},
+	&cli.StringFlag{
+		Name:        "cluster-reset-restore-path",
+		Usage:       "(db) Path to snapshot file to be restored",
+		Destination: &ServerConfig.ClusterResetRestorePath,
+	},
+	ExtraAPIArgs,
+	ExtraEtcdArgs,
+	ExtraControllerArgs,
+	ExtraSchedulerArgs,
+	&cli.StringSliceFlag{
+		Name:        "kube-cloud-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+	&cli.BoolFlag{
+		Name:        "kine-tls",
+		Usage:       "(experimental/db) Enable TLS on the kine etcd server socket",
+		Destination: &ServerConfig.KineTLS,
+		Hidden:      true,
+	},
+	&cli.StringFlag{
+		Name:        "datastore-endpoint",
+		Usage:       "(db) Specify etcd, NATS, MySQL, Postgres, or SQLite (default) data source name",
+		Destination: &ServerConfig.DatastoreEndpoint,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_ENDPOINT"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-cafile",
+		Usage:       "(db) TLS Certificate Authority file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCAFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CAFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-certfile",
+		Usage:       "(db) TLS certification file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCertFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CERTFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-keyfile",
+		Usage:       "(db) TLS key file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreKeyFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_KEYFILE"},
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-expose-metrics",
+		Usage:       "(db) Expose etcd metrics to client interface",
+		Destination: &ServerConfig.EtcdExposeMetrics,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-disable-snapshots",
+		Usage:       "(db) Disable automatic etcd snapshots",
+		Destination: &ServerConfig.EtcdDisableSnapshots,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-name",
+		Usage:       "(db) Set the base name of etcd snapshots, appended with UNIX timestamp",
+		Destination: &ServerConfig.EtcdSnapshotName,
+		Value:       "etcd-snapshot",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-schedule-cron",
+		Usage:       "(db) Snapshot interval time in cron spec. eg. every 5 hours '0 */5 * * *'",
+		Destination: &ServerConfig.EtcdSnapshotCron,
+		Value:       "0 */12 * * *",
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-snapshot-reconcile-interval",
+		Usage:       "(db) Snapshot reconcile interval",
+		Destination: &ServerConfig.EtcdSnapshotReconcile,
+		Value:       10 * time.Minute,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-snapshot-retention",
+		Usage:       "(db) Number of snapshots to retain",
+		Destination: &ServerConfig.EtcdSnapshotRetention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-dir",
+		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/server/db/snapshots)",
+		Destination: &ServerConfig.EtcdSnapshotDir,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-snapshot-compress",
+		Usage:       "(db) Compress etcd snapshot",
+		Destination: &ServerConfig.EtcdSnapshotCompress,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3",
+		Usage:       "(db) Enable backup to S3",
+		Destination: &ServerConfig.EtcdS3,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint",
+		Usage:       "(db) S3 endpoint url",
+		Destination: &ServerConfig.EtcdS3Endpoint,
+		Value:       "s3.amazonaws.com",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint-ca",
+		Usage:       "(db) S3 custom CA cert to connect to S3 endpoint",
+		Destination: &ServerConfig.EtcdS3EndpointCA,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-skip-ssl-verify",
+		Usage:       "(db) Disables S3 SSL certificate validation",
+		Destination: &ServerConfig.EtcdS3SkipSSLVerify,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-access-key",
+		Usage:       "(db) S3 access key",
+		EnvVars:     []string{"AWS_ACCESS_KEY_ID"},
+		Destination: &ServerConfig.EtcdS3AccessKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-secret-key",
+		Usage:       "(db) S3 secret key",
+		EnvVars:     []string{"AWS_SECRET_ACCESS_KEY"},
+		Destination: &ServerConfig.EtcdS3SecretKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-session-token",
+		Usage:       "(db) S3 session token",
+		EnvVars:     []string{"AWS_SESSION_TOKEN"},
+		Destination: &ServerConfig.EtcdS3SessionToken,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket",
+		Usage:       "(db) S3 bucket name",
+		Destination: &ServerConfig.EtcdS3BucketName,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket-lookup-type",
+		Usage:       "(db) S3 bucket lookup type, one of 'auto', 'dns', 'path'; default is 'auto' if not set",
+		Destination: &ServerConfig.EtcdS3BucketLookupType,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-region",
+		Usage:       "(db) S3 region / bucket location (optional)",
+		Destination: &ServerConfig.EtcdS3Region,
+		Value:       "us-east-1",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-folder",
+		Usage:       "(db) S3 folder",
+		Destination: &ServerConfig.EtcdS3Folder,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-s3-retention",
+		Usage:       "(db) S3 retention limit",
+		Destination: &ServerConfig.EtcdS3Retention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-proxy",
+		Usage:       "(db) Proxy server to use when connecting to S3, overriding any proxy-releated environment variables",
+		Destination: &ServerConfig.EtcdS3Proxy,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-config-secret",
+		Usage:       "(db) Name of secret in the kube-system namespace used to configure S3, if etcd-s3 is enabled and no other etcd-s3 options are set",
+		Destination: &ServerConfig.EtcdS3ConfigSecret,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-insecure",
+		Usage:       "(db) Disables S3 over HTTPS",
+		Destination: &ServerConfig.EtcdS3Insecure,
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-s3-timeout",
+		Usage:       "(db) S3 timeout",
+		Destination: &ServerConfig.EtcdS3Timeout,
+		Value:       5 * time.Minute,
+	},
+	&cli.StringFlag{
+		Name:        "default-local-storage-path",
+		Usage:       "(storage) Default local storage path for local provisioner storage class",
+		Destination: &ServerConfig.DefaultLocalStoragePath,
+	},
+	&cli.StringSliceFlag{
+		Name:  "disable",
+		Usage: "(components) Do not deploy packaged components and delete any deployed components (valid values: " + DisableItems + ")",
+	},
+	&cli.BoolFlag{
+		Name:        "disable-scheduler",
+		Usage:       "(components) Disable Kubernetes default scheduler",
+		Destination: &ServerConfig.DisableScheduler,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-cloud-controller",
+		Usage:       "(components) Disable " + version.Program + " default cloud controller manager",
+		Destination: &ServerConfig.DisableCCM,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-kube-proxy",
+		Usage:       "(components) Disable running kube-proxy",
+		Destination: &ServerConfig.DisableKubeProxy,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-network-policy",
+		Usage:       "(components) Disable " + version.Program + " default network policy controller",
+		Destination: &ServerConfig.DisableNPC,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-helm-controller",
+		Usage:       "(components) Disable Helm controller",
+		Destination: &ServerConfig.DisableHelmController,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-apiserver",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running api server",
+		Destination: &ServerConfig.DisableAPIServer,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-controller-manager",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running kube-controller-manager",
+		Destination: &ServerConfig.DisableControllerManager,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-etcd",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running etcd",
+		Destination: &ServerConfig.DisableETCD,
+	},
+	&cli.BoolFlag{
+		Name:        "embedded-registry",
+		Usage:       "(components) Enable embedded distributed container registry; requires use of embedded containerd; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.EmbeddedRegistry,
+	},
+	&cli.BoolFlag{
+		Name:        "supervisor-metrics",
+		Usage:       "(experimental/components) Enable serving " + version.Program + " internal metrics on the supervisor port; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.SupervisorMetrics,
+	},
+	NodeNameFlag,
+	WithNodeIDFlag,
+	NodeLabels,
+	NodeTaints,
+	ImageCredProvBinDirFlag,
+	ImageCredProvConfigFlag,
+	DockerFlag,
+	CRIEndpointFlag,
+	DefaultRuntimeFlag,
+	ImageServiceEndpointFlag,
+	DisableDefaultRegistryEndpointFlag,
+	NonrootDevicesFlag,
+	PauseImageFlag,
+	SnapshotterFlag,
+	PrivateRegistryFlag,
+	&cli.StringFlag{
+		Name:        "system-default-registry",
+		Usage:       "(agent/runtime) Private registry to be used for all system images",
+		EnvVars:     []string{version.ProgramUpper + "_SYSTEM_DEFAULT_REGISTRY"},
+		Destination: &ServerConfig.SystemDefaultRegistry,
+	},
+	AirgapExtraRegistryFlag,
+	NodeIPFlag,
+	NodeExternalIPFlag,
+	NodeInternalDNSFlag,
+	NodeExternalDNSFlag,
+	ResolvConfFlag,
+	FlannelIfaceFlag,
+	FlannelConfFlag,
+	FlannelCniConfFileFlag,
+	VPNAuth,
+	VPNAuthFile,
+	ExtraKubeletArgs,
+	ExtraKubeProxyArgs,
+	ProtectKernelDefaultsFlag,
+	&cli.BoolFlag{
+		Name:        "secrets-encryption",
+		Usage:       "Enable secret encryption at rest",
+		Destination: &ServerConfig.EncryptSecrets,
+	},
+	// Experimental flags
+	EnablePProfFlag,
+	&cli.BoolFlag{
+		Name:        "rootless",
+		Usage:       "(experimental) Run rootless",
+		Destination: &ServerConfig.Rootless,
+	},
+	&cli.StringFlag{
+		Name:        "secrets-encryption-provider",
+		Usage:       "(experimental) Secret encryption provider (valid values: 'aescbc', 'secretbox')",
+		Destination: &ServerConfig.EncryptProvider,
+		Value:       "aescbc",
+	},
+	PreferBundledBin,
+	SELinuxFlag,
+	LBServerPortFlag,
+
+	// Hidden/Deprecated flags below
+
+	&cli.BoolFlag{
+		Name:        "disable-agent",
+		Usage:       "Do not run a local agent and register a local kubelet",
+		Hidden:      true,
+		Destination: &ServerConfig.DisableAgent,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-controller-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-cloud-controller-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+}
+
+func NewServerCommand(action func(*cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "server",
+		Usage:     "Run management server",
+		UsageText: appName + " server [OPTIONS]",
+		Action:    action,
+		Flags:     ServerFlags,
+	}
+}

--- a/thirdparty-src/k3s/v1_33/SOURCE.txt
+++ b/thirdparty-src/k3s/v1_33/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/k3s-io/k3s
+tag:    v1.33.13+k3s1
+commit: 86c2c10c51e4340bb8252fff312d74dcafaf39d5
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go

--- a/thirdparty-src/k3s/v1_33/zz_agent.go
+++ b/thirdparty-src/k3s/v1_33/zz_agent.go
@@ -1,0 +1,343 @@
+package cmds
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+type Agent struct {
+	Token                    string
+	TokenFile                string
+	ClusterSecret            string
+	ServerURL                string
+	APIAddressCh             chan []string
+	DisableLoadBalancer      bool
+	DisableServiceLB         bool
+	ETCDAgent                bool
+	LBServerPort             int
+	ResolvConf               string
+	DataDir                  string
+	BindAddress              string
+	NodeIP                   cli.StringSlice
+	NodeExternalIP           cli.StringSlice
+	NodeInternalDNS          cli.StringSlice
+	NodeExternalDNS          cli.StringSlice
+	NodeName                 string
+	PauseImage               string
+	Snapshotter              string
+	Docker                   bool
+	ContainerdNoDefault      bool
+	ContainerdNonrootDevices bool
+	ContainerRuntimeEndpoint string
+	DefaultRuntime           string
+	ImageServiceEndpoint     string
+	FlannelIface             string
+	FlannelConf              string
+	FlannelCniConfFile       string
+	VPNAuth                  string
+	VPNAuthFile              string
+	Debug                    bool
+	EnablePProf              bool
+	Rootless                 bool
+	RootlessAlreadyUnshared  bool
+	WithNodeID               bool
+	EnableSELinux            bool
+	ProtectKernelDefaults    bool
+	ClusterReset             bool
+	PrivateRegistry          string
+	SystemDefaultRegistry    string
+	AirgapExtraRegistry      cli.StringSlice
+	ExtraKubeletArgs         cli.StringSlice
+	ExtraKubeProxyArgs       cli.StringSlice
+	Labels                   cli.StringSlice
+	Taints                   cli.StringSlice
+	ImageCredProvBinDir      string
+	ImageCredProvConfig      string
+	AgentShared
+}
+
+type AgentShared struct {
+	NodeIP string
+}
+
+var (
+	appName        = filepath.Base(os.Args[0])
+	AgentConfig    Agent
+	AgentTokenFlag = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Token to use for authentication",
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+		Destination: &AgentConfig.Token,
+	}
+	NodeIPFlag = &cli.StringSliceFlag{
+		Name:        "node-ip",
+		Aliases:     []string{"i"},
+		Usage:       "(agent/networking) IPv4/IPv6 addresses to advertise for node",
+		Destination: &AgentConfig.NodeIP,
+	}
+	NodeExternalIPFlag = &cli.StringSliceFlag{
+		Name:        "node-external-ip",
+		Usage:       "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalIP,
+	}
+	NodeInternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-internal-dns",
+		Usage:       "(agent/networking) internal DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeInternalDNS,
+	}
+	NodeExternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-external-dns",
+		Usage:       "(agent/networking) external DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalDNS,
+	}
+	NodeNameFlag = &cli.StringFlag{
+		Name:        "node-name",
+		Usage:       "(agent/node) Node name",
+		EnvVars:     []string{version.ProgramUpper + "_NODE_NAME"},
+		Destination: &AgentConfig.NodeName,
+	}
+	WithNodeIDFlag = &cli.BoolFlag{
+		Name:        "with-node-id",
+		Usage:       "(agent/node) Append id to node name",
+		Destination: &AgentConfig.WithNodeID,
+	}
+	ProtectKernelDefaultsFlag = &cli.BoolFlag{
+		Name:        "protect-kernel-defaults",
+		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
+		Destination: &AgentConfig.ProtectKernelDefaults,
+	}
+	SELinuxFlag = &cli.BoolFlag{
+		Name:        "selinux",
+		Usage:       "(agent/node) Enable SELinux in containerd",
+		Destination: &AgentConfig.EnableSELinux,
+		EnvVars:     []string{version.ProgramUpper + "_SELINUX"},
+	}
+	LBServerPortFlag = &cli.IntFlag{
+		Name:        "lb-server-port",
+		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
+		Destination: &AgentConfig.LBServerPort,
+		EnvVars:     []string{version.ProgramUpper + "_LB_SERVER_PORT"},
+		Value:       6444,
+	}
+	DockerFlag = &cli.BoolFlag{
+		Name:        "docker",
+		Usage:       "(agent/runtime) (experimental) Use cri-dockerd instead of containerd",
+		Destination: &AgentConfig.Docker,
+	}
+	CRIEndpointFlag = &cli.StringFlag{
+		Name:        "container-runtime-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
+		Destination: &AgentConfig.ContainerRuntimeEndpoint,
+	}
+	DefaultRuntimeFlag = &cli.StringFlag{
+		Name:        "default-runtime",
+		Usage:       "(agent/runtime) Set the default runtime in containerd",
+		Destination: &AgentConfig.DefaultRuntime,
+	}
+	ImageServiceEndpointFlag = &cli.StringFlag{
+		Name:        "image-service-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd image service and use remote image service socket at the given path. If not specified, defaults to --container-runtime-endpoint.",
+		Destination: &AgentConfig.ImageServiceEndpoint,
+	}
+	PrivateRegistryFlag = &cli.StringFlag{
+		Name:        "private-registry",
+		Usage:       "(agent/runtime) Private registry configuration file",
+		Destination: &AgentConfig.PrivateRegistry,
+		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
+	}
+	AirgapExtraRegistryFlag = &cli.StringSliceFlag{
+		Name:        "airgap-extra-registry",
+		Usage:       "(agent/runtime) Additional registry to tag airgap images as being sourced from",
+		Destination: &AgentConfig.AirgapExtraRegistry,
+		Hidden:      true,
+	}
+	PauseImageFlag = &cli.StringFlag{
+		Name:        "pause-image",
+		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
+		Destination: &AgentConfig.PauseImage,
+		Value:       "rancher/mirrored-pause:3.6",
+	}
+	SnapshotterFlag = &cli.StringFlag{
+		Name:        "snapshotter",
+		Usage:       "(agent/runtime) Override default containerd snapshotter",
+		Destination: &AgentConfig.Snapshotter,
+		Value:       DefaultSnapshotter,
+	}
+	FlannelIfaceFlag = &cli.StringFlag{
+		Name:        "flannel-iface",
+		Usage:       "(agent/networking) Override default flannel interface",
+		Destination: &AgentConfig.FlannelIface,
+	}
+	FlannelConfFlag = &cli.StringFlag{
+		Name:        "flannel-conf",
+		Usage:       "(agent/networking) Override default flannel config file",
+		Destination: &AgentConfig.FlannelConf,
+	}
+	FlannelCniConfFileFlag = &cli.StringFlag{
+		Name:        "flannel-cni-conf",
+		Usage:       "(agent/networking) Override default flannel cni config file",
+		Destination: &AgentConfig.FlannelCniConfFile,
+	}
+	VPNAuth = &cli.StringFlag{
+		Name:        "vpn-auth",
+		Usage:       "(agent/networking) (experimental) Credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH"},
+		Destination: &AgentConfig.VPNAuth,
+	}
+	VPNAuthFile = &cli.StringFlag{
+		Name:        "vpn-auth-file",
+		Usage:       "(agent/networking) (experimental) File containing credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH_FILE"},
+		Destination: &AgentConfig.VPNAuthFile,
+	}
+	ResolvConfFlag = &cli.StringFlag{
+		Name:        "resolv-conf",
+		Usage:       "(agent/networking) Kubelet resolv.conf file",
+		EnvVars:     []string{version.ProgramUpper + "_RESOLV_CONF"},
+		Destination: &AgentConfig.ResolvConf,
+	}
+	ExtraKubeletArgs = &cli.StringSliceFlag{
+		Name:        "kubelet-arg",
+		Usage:       "(agent/flags) Customized flag for kubelet process",
+		Destination: &AgentConfig.ExtraKubeletArgs,
+	}
+	ExtraKubeProxyArgs = &cli.StringSliceFlag{
+		Name:        "kube-proxy-arg",
+		Usage:       "(agent/flags) Customized flag for kube-proxy process",
+		Destination: &AgentConfig.ExtraKubeProxyArgs,
+	}
+	NodeTaints = &cli.StringSliceFlag{
+		Name:        "node-taint",
+		Usage:       "(agent/node) Registering kubelet with set of taints",
+		Destination: &AgentConfig.Taints,
+	}
+	NodeLabels = &cli.StringSliceFlag{
+		Name:        "node-label",
+		Usage:       "(agent/node) Registering and starting kubelet with set of labels",
+		Destination: &AgentConfig.Labels,
+	}
+	ImageCredProvBinDirFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-bin-dir",
+		Usage:       "(agent/node) The path to the directory where credential provider plugin binaries are located",
+		Destination: &AgentConfig.ImageCredProvBinDir,
+		Value:       "/var/lib/rancher/credentialprovider/bin",
+	}
+	ImageCredProvConfigFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-config",
+		Usage:       "(agent/node) The path to the credential provider plugin config file",
+		Destination: &AgentConfig.ImageCredProvConfig,
+		Value:       "/var/lib/rancher/credentialprovider/config.yaml",
+	}
+	DisableAgentLBFlag = &cli.BoolFlag{
+		Name:        "disable-apiserver-lb",
+		Usage:       "(agent/networking) (experimental) Disable the agent's client-side load-balancer and connect directly to the configured server address",
+		Destination: &AgentConfig.DisableLoadBalancer,
+	}
+	DisableDefaultRegistryEndpointFlag = &cli.BoolFlag{
+		Name:        "disable-default-registry-endpoint",
+		Usage:       "(agent/containerd) Disables containerd's fallback default registry endpoint when a mirror is configured for that registry",
+		Destination: &AgentConfig.ContainerdNoDefault,
+	}
+	NonrootDevicesFlag = &cli.BoolFlag{
+		Name:        "nonroot-devices",
+		Usage:       "(agent/containerd) Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config",
+		Destination: &AgentConfig.ContainerdNonrootDevices,
+	}
+	EnablePProfFlag = &cli.BoolFlag{
+		Name:        "enable-pprof",
+		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
+		Destination: &AgentConfig.EnablePProf,
+	}
+	BindAddressFlag = &cli.StringFlag{
+		Name:        "bind-address",
+		Usage:       "(listener) " + version.Program + " bind address (default: 0.0.0.0)",
+		Destination: &AgentConfig.BindAddress,
+	}
+)
+
+func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "agent",
+		Usage:     "Run node agent",
+		UsageText: appName + " agent [OPTIONS]",
+		Action:    action,
+		Flags: []cli.Flag{
+			ConfigFlag,
+			DebugFlag,
+			VLevel,
+			VModule,
+			LogFile,
+			AlsoLogToStderr,
+			AgentTokenFlag,
+			&cli.StringFlag{
+				Name:        "token-file",
+				Usage:       "(cluster) Token file to use for authentication",
+				EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+				Destination: &AgentConfig.TokenFile,
+			},
+			&cli.StringFlag{
+				Name:        "server",
+				Aliases:     []string{"s"},
+				Usage:       "(cluster) Server to connect to",
+				EnvVars:     []string{version.ProgramUpper + "_URL"},
+				Destination: &AgentConfig.ServerURL,
+			},
+			// Note that this is different from DataDirFlag used elswhere in the CLI,
+			// as this is bound to AgentConfig instead of ServerConfig.
+			&cli.StringFlag{
+				Name:        "data-dir",
+				Aliases:     []string{"d"},
+				Usage:       "(agent/data) Folder to hold state",
+				Destination: &AgentConfig.DataDir,
+				Value:       "/var/lib/rancher/" + version.Program + "",
+				EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+			},
+			NodeNameFlag,
+			WithNodeIDFlag,
+			NodeLabels,
+			NodeTaints,
+			ImageCredProvBinDirFlag,
+			ImageCredProvConfigFlag,
+			SELinuxFlag,
+			LBServerPortFlag,
+			ProtectKernelDefaultsFlag,
+			CRIEndpointFlag,
+			DefaultRuntimeFlag,
+			ImageServiceEndpointFlag,
+			PauseImageFlag,
+			SnapshotterFlag,
+			PrivateRegistryFlag,
+			DisableDefaultRegistryEndpointFlag,
+			NonrootDevicesFlag,
+			AirgapExtraRegistryFlag,
+			NodeIPFlag,
+			BindAddressFlag,
+			NodeExternalIPFlag,
+			NodeInternalDNSFlag,
+			NodeExternalDNSFlag,
+			ResolvConfFlag,
+			FlannelIfaceFlag,
+			FlannelConfFlag,
+			FlannelCniConfFileFlag,
+			ExtraKubeletArgs,
+			ExtraKubeProxyArgs,
+			// Experimental flags
+			EnablePProfFlag,
+			&cli.BoolFlag{
+				Name:        "rootless",
+				Usage:       "(experimental) Run rootless",
+				Destination: &AgentConfig.Rootless,
+			},
+			PreferBundledBin,
+			// Deprecated/hidden below
+			DockerFlag,
+			VPNAuth,
+			VPNAuthFile,
+			DisableAgentLBFlag,
+		},
+	}
+}

--- a/thirdparty-src/k3s/v1_33/zz_server.go
+++ b/thirdparty-src/k3s/v1_33/zz_server.go
@@ -1,0 +1,660 @@
+package cmds
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	defaultSnapshotRentention    = 5
+	defaultSnapshotIntervalHours = 12
+)
+
+type StartupHookArgs struct {
+	APIServerReady       <-chan struct{}
+	KubeConfigSupervisor string
+	Skips                map[string]bool
+	Disables             map[string]bool
+}
+
+type StartupHook func(context.Context, *sync.WaitGroup, StartupHookArgs) error
+
+type Server struct {
+	ClusterCIDR          cli.StringSlice
+	AgentToken           string
+	AgentTokenFile       string
+	Token                string
+	TokenFile            string
+	ClusterSecret        string
+	ServiceCIDR          cli.StringSlice
+	ServiceNodePortRange string
+	ClusterDNS           cli.StringSlice
+	ClusterDomain        string
+	// The port which kubectl clients can access k8s
+	HTTPSPort int
+	// The port which custom k3s API runs on
+	SupervisorPort int
+	// The port which kube-apiserver runs on
+	APIServerPort            int
+	APIServerBindAddress     string
+	DataDir                  string
+	DisableAgent             bool
+	KubeConfigOutput         string
+	KubeConfigMode           string
+	KubeConfigGroup          string
+	HelmJobImage             string
+	TLSSan                   cli.StringSlice
+	TLSSanSecurity           bool
+	ExtraAPIArgs             cli.StringSlice
+	ExtraEtcdArgs            cli.StringSlice
+	ExtraSchedulerArgs       cli.StringSlice
+	ExtraControllerArgs      cli.StringSlice
+	ExtraCloudControllerArgs cli.StringSlice
+	Rootless                 bool
+	DatastoreEndpoint        string
+	DatastoreCAFile          string
+	DatastoreCertFile        string
+	DatastoreKeyFile         string
+	KineTLS                  bool
+	AdvertiseIP              string
+	AdvertisePort            int
+	DisableScheduler         bool
+	ServerURL                string
+	FlannelBackend           string
+	FlannelIPv6Masq          bool
+	FlannelExternalIP        bool
+	EgressSelectorMode       string
+	DefaultLocalStoragePath  string
+	DisableCCM               bool
+	DisableNPC               bool
+	DisableHelmController    bool
+	DisableKubeProxy         bool
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableETCD              bool
+	EmbeddedRegistry         bool
+	ClusterInit              bool
+	ClusterReset             bool
+	ClusterResetRestorePath  string
+	EncryptSecrets           bool
+	EncryptForce             bool
+	EncryptOutput            string
+	EncryptSkip              bool
+	EncryptProvider          string
+	SystemDefaultRegistry    string
+	StartupHooks             []StartupHook
+	SupervisorMetrics        bool
+	EtcdSnapshotName         string
+	EtcdDisableSnapshots     bool
+	EtcdExposeMetrics        bool
+	EtcdSnapshotDir          string
+	EtcdSnapshotCron         string
+	EtcdSnapshotReconcile    time.Duration
+	EtcdSnapshotRetention    int
+	EtcdSnapshotCompress     bool
+	EtcdListFormat           string
+	EtcdS3                   bool
+	EtcdS3Endpoint           string
+	EtcdS3EndpointCA         string
+	EtcdS3SkipSSLVerify      bool
+	EtcdS3AccessKey          string
+	EtcdS3SecretKey          string
+	EtcdS3SessionToken       string
+	EtcdS3BucketName         string
+	EtcdS3Retention          int
+	EtcdS3BucketLookupType   string
+	EtcdS3Region             string
+	EtcdS3Folder             string
+	EtcdS3Proxy              string
+	EtcdS3ConfigSecret       string
+	EtcdS3Timeout            time.Duration
+	EtcdS3Insecure           bool
+	ServiceLBNamespace       string
+}
+
+var (
+	ServerConfig Server
+	DataDirFlag  = &cli.StringFlag{
+		Name:        "data-dir",
+		Aliases:     []string{"d"},
+		Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+		Destination: &ServerConfig.DataDir,
+		EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+	}
+	ServerToken = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
+		Destination: &ServerConfig.Token,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+	}
+	ClusterCIDR = &cli.StringSliceFlag{
+		Name:        "cluster-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
+		Destination: &ServerConfig.ClusterCIDR,
+	}
+	ServiceCIDR = &cli.StringSliceFlag{
+		Name:        "service-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
+		Destination: &ServerConfig.ServiceCIDR,
+	}
+	ServiceNodePortRange = &cli.StringFlag{
+		Name:        "service-node-port-range",
+		Usage:       "(networking) Port range to reserve for services with NodePort visibility",
+		Destination: &ServerConfig.ServiceNodePortRange,
+		Value:       "30000-32767",
+	}
+	ClusterDNS = &cli.StringSliceFlag{
+		Name:        "cluster-dns",
+		Usage:       "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+		Destination: &ServerConfig.ClusterDNS,
+	}
+	ClusterDomain = &cli.StringFlag{
+		Name:        "cluster-domain",
+		Usage:       "(networking) Cluster Domain",
+		Destination: &ServerConfig.ClusterDomain,
+		Value:       "cluster.local",
+	}
+	ExtraAPIArgs = &cli.StringSliceFlag{
+		Name:        "kube-apiserver-arg",
+		Usage:       "(flags) Customized flag for kube-apiserver process",
+		Destination: &ServerConfig.ExtraAPIArgs,
+	}
+	ExtraEtcdArgs = &cli.StringSliceFlag{
+		Name:        "etcd-arg",
+		Usage:       "(flags) Customized flag for etcd process",
+		Destination: &ServerConfig.ExtraEtcdArgs,
+	}
+	ExtraSchedulerArgs = &cli.StringSliceFlag{
+		Name:        "kube-scheduler-arg",
+		Usage:       "(flags) Customized flag for kube-scheduler process",
+		Destination: &ServerConfig.ExtraSchedulerArgs,
+	}
+	ExtraControllerArgs = &cli.StringSliceFlag{
+		Name:        "kube-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	}
+)
+
+var ServerFlags = []cli.Flag{
+	ConfigFlag,
+	DebugFlag,
+	VLevel,
+	VModule,
+	LogFile,
+	AlsoLogToStderr,
+	BindAddressFlag,
+	&cli.IntFlag{
+		Name:        "https-listen-port",
+		Usage:       "(listener) HTTPS listen port",
+		Value:       6443,
+		Destination: &ServerConfig.HTTPSPort,
+	},
+	&cli.IntFlag{
+		Name:        "supervisor-port",
+		EnvVars:     []string{version.ProgramUpper + "_SUPERVISOR_PORT"},
+		Usage:       "(experimental) Supervisor listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.SupervisorPort,
+	},
+	&cli.IntFlag{
+		Name:        "apiserver-port",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_PORT"},
+		Usage:       "(experimental) apiserver internal listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerPort,
+	},
+	&cli.StringFlag{
+		Name:        "apiserver-bind-address",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_BIND_ADDRESS"},
+		Usage:       "(experimental) apiserver internal bind address override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerBindAddress,
+	},
+	&cli.StringFlag{
+		Name:        "advertise-address",
+		Usage:       "(listener) IPv4/IPv6 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
+		Destination: &ServerConfig.AdvertiseIP,
+	},
+	&cli.IntFlag{
+		Name:        "advertise-port",
+		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: https-listen-port)",
+		Destination: &ServerConfig.AdvertisePort,
+	},
+	&cli.StringSliceFlag{
+		Name:        "tls-san",
+		Usage:       "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
+		Destination: &ServerConfig.TLSSan,
+	},
+	&cli.BoolFlag{
+		Name:        "tls-san-security",
+		Usage:       "(listener) Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option (default: true)",
+		Destination: &ServerConfig.TLSSanSecurity,
+		Value:       true,
+	},
+	DataDirFlag,
+	ClusterCIDR,
+	ServiceCIDR,
+	ServiceNodePortRange,
+	ClusterDNS,
+	ClusterDomain,
+	&cli.StringFlag{
+		Name:        "flannel-backend",
+		Usage:       "(networking) Backend (valid values: 'none', 'vxlan', 'host-gw', 'wireguard-native'",
+		Destination: &ServerConfig.FlannelBackend,
+		Value:       "vxlan",
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-ipv6-masq",
+		Usage:       "(networking) Enable IPv6 masquerading for pod",
+		Destination: &ServerConfig.FlannelIPv6Masq,
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-external-ip",
+		Usage:       "(networking) Use node external IP addresses for Flannel traffic",
+		Destination: &ServerConfig.FlannelExternalIP,
+	},
+	&cli.StringFlag{
+		Name:        "egress-selector-mode",
+		Usage:       "(networking) One of 'agent', 'cluster', 'pod', 'disabled'",
+		Destination: &ServerConfig.EgressSelectorMode,
+		Value:       "agent",
+	},
+	&cli.StringFlag{
+		Name:        "servicelb-namespace",
+		Usage:       "(networking) Namespace of the pods for the servicelb component",
+		Destination: &ServerConfig.ServiceLBNamespace,
+		Value:       "kube-system",
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig",
+		Aliases:     []string{"o"},
+		Usage:       "(client) Write kubeconfig for admin client to this file",
+		Destination: &ServerConfig.KubeConfigOutput,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_OUTPUT"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-mode",
+		Usage:       "(client) Write kubeconfig with this mode",
+		Destination: &ServerConfig.KubeConfigMode,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_MODE"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-group",
+		Usage:       "(client) Write kubeconfig with this group",
+		Destination: &ServerConfig.KubeConfigGroup,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_GROUP"},
+	},
+	&cli.StringFlag{
+		Name:        "helm-job-image",
+		Usage:       "(helm) Default image to use for helm jobs",
+		Destination: &ServerConfig.HelmJobImage,
+	},
+	ServerToken,
+	&cli.StringFlag{
+		Name:        "token-file",
+		Usage:       "(cluster) File containing the token",
+		Destination: &ServerConfig.TokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token",
+		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
+		Destination: &ServerConfig.AgentToken,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token-file",
+		Usage:       "(cluster) File containing the agent secret",
+		Destination: &ServerConfig.AgentTokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "server",
+		Aliases:     []string{"s"},
+		Usage:       "(cluster) Server to connect to, used to join a cluster",
+		EnvVars:     []string{version.ProgramUpper + "_URL"},
+		Destination: &ServerConfig.ServerURL,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-init",
+		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_INIT"},
+		Destination: &ServerConfig.ClusterInit,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-reset",
+		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_RESET"},
+		Destination: &ServerConfig.ClusterReset,
+	},
+	&cli.StringFlag{
+		Name:        "cluster-reset-restore-path",
+		Usage:       "(db) Path to snapshot file to be restored",
+		Destination: &ServerConfig.ClusterResetRestorePath,
+	},
+	ExtraAPIArgs,
+	ExtraEtcdArgs,
+	ExtraControllerArgs,
+	ExtraSchedulerArgs,
+	&cli.StringSliceFlag{
+		Name:        "kube-cloud-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+	&cli.BoolFlag{
+		Name:        "kine-tls",
+		Usage:       "(experimental/db) Enable TLS on the kine etcd server socket",
+		Destination: &ServerConfig.KineTLS,
+		Hidden:      true,
+	},
+	&cli.StringFlag{
+		Name:        "datastore-endpoint",
+		Usage:       "(db) Specify etcd, NATS, MySQL, Postgres, or SQLite (default) data source name",
+		Destination: &ServerConfig.DatastoreEndpoint,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_ENDPOINT"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-cafile",
+		Usage:       "(db) TLS Certificate Authority file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCAFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CAFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-certfile",
+		Usage:       "(db) TLS certification file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCertFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CERTFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-keyfile",
+		Usage:       "(db) TLS key file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreKeyFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_KEYFILE"},
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-expose-metrics",
+		Usage:       "(db) Expose etcd metrics to client interface",
+		Destination: &ServerConfig.EtcdExposeMetrics,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-disable-snapshots",
+		Usage:       "(db) Disable automatic etcd snapshots",
+		Destination: &ServerConfig.EtcdDisableSnapshots,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-name",
+		Usage:       "(db) Set the base name of etcd snapshots, appended with UNIX timestamp",
+		Destination: &ServerConfig.EtcdSnapshotName,
+		Value:       "etcd-snapshot",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-schedule-cron",
+		Usage:       "(db) Snapshot interval time in cron spec. eg. every 5 hours '0 */5 * * *'",
+		Destination: &ServerConfig.EtcdSnapshotCron,
+		Value:       "0 */12 * * *",
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-snapshot-reconcile-interval",
+		Usage:       "(db) Snapshot reconcile interval",
+		Destination: &ServerConfig.EtcdSnapshotReconcile,
+		Value:       10 * time.Minute,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-snapshot-retention",
+		Usage:       "(db) Number of snapshots to retain",
+		Destination: &ServerConfig.EtcdSnapshotRetention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-dir",
+		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/server/db/snapshots)",
+		Destination: &ServerConfig.EtcdSnapshotDir,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-snapshot-compress",
+		Usage:       "(db) Compress etcd snapshot",
+		Destination: &ServerConfig.EtcdSnapshotCompress,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3",
+		Usage:       "(db) Enable backup to S3",
+		Destination: &ServerConfig.EtcdS3,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint",
+		Usage:       "(db) S3 endpoint url",
+		Destination: &ServerConfig.EtcdS3Endpoint,
+		Value:       "s3.amazonaws.com",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint-ca",
+		Usage:       "(db) S3 custom CA cert to connect to S3 endpoint",
+		Destination: &ServerConfig.EtcdS3EndpointCA,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-skip-ssl-verify",
+		Usage:       "(db) Disables S3 SSL certificate validation",
+		Destination: &ServerConfig.EtcdS3SkipSSLVerify,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-access-key",
+		Usage:       "(db) S3 access key",
+		EnvVars:     []string{"AWS_ACCESS_KEY_ID"},
+		Destination: &ServerConfig.EtcdS3AccessKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-secret-key",
+		Usage:       "(db) S3 secret key",
+		EnvVars:     []string{"AWS_SECRET_ACCESS_KEY"},
+		Destination: &ServerConfig.EtcdS3SecretKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-session-token",
+		Usage:       "(db) S3 session token",
+		EnvVars:     []string{"AWS_SESSION_TOKEN"},
+		Destination: &ServerConfig.EtcdS3SessionToken,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket",
+		Usage:       "(db) S3 bucket name",
+		Destination: &ServerConfig.EtcdS3BucketName,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket-lookup-type",
+		Usage:       "(db) S3 bucket lookup type, one of 'auto', 'dns', 'path'; default is 'auto' if not set",
+		Destination: &ServerConfig.EtcdS3BucketLookupType,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-region",
+		Usage:       "(db) S3 region / bucket location (optional)",
+		Destination: &ServerConfig.EtcdS3Region,
+		Value:       "us-east-1",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-folder",
+		Usage:       "(db) S3 folder",
+		Destination: &ServerConfig.EtcdS3Folder,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-s3-retention",
+		Usage:       "(db) S3 retention limit",
+		Destination: &ServerConfig.EtcdS3Retention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-proxy",
+		Usage:       "(db) Proxy server to use when connecting to S3, overriding any proxy-releated environment variables",
+		Destination: &ServerConfig.EtcdS3Proxy,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-config-secret",
+		Usage:       "(db) Name of secret in the kube-system namespace used to configure S3, if etcd-s3 is enabled and no other etcd-s3 options are set",
+		Destination: &ServerConfig.EtcdS3ConfigSecret,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-insecure",
+		Usage:       "(db) Disables S3 over HTTPS",
+		Destination: &ServerConfig.EtcdS3Insecure,
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-s3-timeout",
+		Usage:       "(db) S3 timeout",
+		Destination: &ServerConfig.EtcdS3Timeout,
+		Value:       5 * time.Minute,
+	},
+	&cli.StringFlag{
+		Name:        "default-local-storage-path",
+		Usage:       "(storage) Default local storage path for local provisioner storage class",
+		Destination: &ServerConfig.DefaultLocalStoragePath,
+	},
+	&cli.StringSliceFlag{
+		Name:  "disable",
+		Usage: "(components) Do not deploy packaged components and delete any deployed components (valid values: " + DisableItems + ")",
+	},
+	&cli.BoolFlag{
+		Name:        "disable-scheduler",
+		Usage:       "(components) Disable Kubernetes default scheduler",
+		Destination: &ServerConfig.DisableScheduler,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-cloud-controller",
+		Usage:       "(components) Disable " + version.Program + " default cloud controller manager",
+		Destination: &ServerConfig.DisableCCM,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-kube-proxy",
+		Usage:       "(components) Disable running kube-proxy",
+		Destination: &ServerConfig.DisableKubeProxy,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-network-policy",
+		Usage:       "(components) Disable " + version.Program + " default network policy controller",
+		Destination: &ServerConfig.DisableNPC,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-helm-controller",
+		Usage:       "(components) Disable Helm controller",
+		Destination: &ServerConfig.DisableHelmController,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-apiserver",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running api server",
+		Destination: &ServerConfig.DisableAPIServer,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-controller-manager",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running kube-controller-manager",
+		Destination: &ServerConfig.DisableControllerManager,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-etcd",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running etcd",
+		Destination: &ServerConfig.DisableETCD,
+	},
+	&cli.BoolFlag{
+		Name:        "embedded-registry",
+		Usage:       "(components) Enable embedded distributed container registry; requires use of embedded containerd; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.EmbeddedRegistry,
+	},
+	&cli.BoolFlag{
+		Name:        "supervisor-metrics",
+		Usage:       "(experimental/components) Enable serving " + version.Program + " internal metrics on the supervisor port; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.SupervisorMetrics,
+	},
+	NodeNameFlag,
+	WithNodeIDFlag,
+	NodeLabels,
+	NodeTaints,
+	ImageCredProvBinDirFlag,
+	ImageCredProvConfigFlag,
+	DockerFlag,
+	CRIEndpointFlag,
+	DefaultRuntimeFlag,
+	ImageServiceEndpointFlag,
+	DisableDefaultRegistryEndpointFlag,
+	NonrootDevicesFlag,
+	PauseImageFlag,
+	SnapshotterFlag,
+	PrivateRegistryFlag,
+	&cli.StringFlag{
+		Name:        "system-default-registry",
+		Usage:       "(agent/runtime) Private registry to be used for all system images",
+		EnvVars:     []string{version.ProgramUpper + "_SYSTEM_DEFAULT_REGISTRY"},
+		Destination: &ServerConfig.SystemDefaultRegistry,
+	},
+	AirgapExtraRegistryFlag,
+	NodeIPFlag,
+	NodeExternalIPFlag,
+	NodeInternalDNSFlag,
+	NodeExternalDNSFlag,
+	ResolvConfFlag,
+	FlannelIfaceFlag,
+	FlannelConfFlag,
+	FlannelCniConfFileFlag,
+	VPNAuth,
+	VPNAuthFile,
+	ExtraKubeletArgs,
+	ExtraKubeProxyArgs,
+	ProtectKernelDefaultsFlag,
+	&cli.BoolFlag{
+		Name:        "secrets-encryption",
+		Usage:       "Enable secret encryption at rest",
+		Destination: &ServerConfig.EncryptSecrets,
+	},
+	// Experimental flags
+	EnablePProfFlag,
+	&cli.BoolFlag{
+		Name:        "rootless",
+		Usage:       "(experimental) Run rootless",
+		Destination: &ServerConfig.Rootless,
+	},
+	&cli.StringFlag{
+		Name:        "secrets-encryption-provider",
+		Usage:       "(experimental) Secret encryption provider (valid values: 'aescbc', 'secretbox')",
+		Destination: &ServerConfig.EncryptProvider,
+		Value:       "aescbc",
+	},
+	PreferBundledBin,
+	SELinuxFlag,
+	LBServerPortFlag,
+
+	// Hidden/Deprecated flags below
+
+	&cli.BoolFlag{
+		Name:        "disable-agent",
+		Usage:       "Do not run a local agent and register a local kubelet",
+		Hidden:      true,
+		Destination: &ServerConfig.DisableAgent,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-controller-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-cloud-controller-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+}
+
+func NewServerCommand(action func(*cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "server",
+		Usage:     "Run management server",
+		UsageText: appName + " server [OPTIONS]",
+		Action:    action,
+		Flags:     ServerFlags,
+	}
+}

--- a/thirdparty-src/k3s/v1_34/SOURCE.txt
+++ b/thirdparty-src/k3s/v1_34/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/k3s-io/k3s
+tag:    v1.34.11+k3s1
+commit: 9312658016b9e33288b528da68bf88e37e6aeecf
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go

--- a/thirdparty-src/k3s/v1_34/zz_agent.go
+++ b/thirdparty-src/k3s/v1_34/zz_agent.go
@@ -1,0 +1,343 @@
+package cmds
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+type Agent struct {
+	Token                    string
+	TokenFile                string
+	ClusterSecret            string
+	ServerURL                string
+	APIAddressCh             chan []string
+	DisableLoadBalancer      bool
+	DisableServiceLB         bool
+	ETCDAgent                bool
+	LBServerPort             int
+	ResolvConf               string
+	DataDir                  string
+	BindAddress              string
+	NodeIP                   cli.StringSlice
+	NodeExternalIP           cli.StringSlice
+	NodeInternalDNS          cli.StringSlice
+	NodeExternalDNS          cli.StringSlice
+	NodeName                 string
+	PauseImage               string
+	Snapshotter              string
+	Docker                   bool
+	ContainerdNoDefault      bool
+	ContainerdNonrootDevices bool
+	ContainerRuntimeEndpoint string
+	DefaultRuntime           string
+	ImageServiceEndpoint     string
+	FlannelIface             string
+	FlannelConf              string
+	FlannelCniConfFile       string
+	VPNAuth                  string
+	VPNAuthFile              string
+	Debug                    bool
+	EnablePProf              bool
+	Rootless                 bool
+	RootlessAlreadyUnshared  bool
+	WithNodeID               bool
+	EnableSELinux            bool
+	ProtectKernelDefaults    bool
+	ClusterReset             bool
+	PrivateRegistry          string
+	SystemDefaultRegistry    string
+	AirgapExtraRegistry      cli.StringSlice
+	ExtraKubeletArgs         cli.StringSlice
+	ExtraKubeProxyArgs       cli.StringSlice
+	Labels                   cli.StringSlice
+	Taints                   cli.StringSlice
+	ImageCredProvBinDir      string
+	ImageCredProvConfig      string
+	AgentShared
+}
+
+type AgentShared struct {
+	NodeIP string
+}
+
+var (
+	appName        = filepath.Base(os.Args[0])
+	AgentConfig    Agent
+	AgentTokenFlag = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Token to use for authentication",
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+		Destination: &AgentConfig.Token,
+	}
+	NodeIPFlag = &cli.StringSliceFlag{
+		Name:        "node-ip",
+		Aliases:     []string{"i"},
+		Usage:       "(agent/networking) IPv4/IPv6 addresses to advertise for node",
+		Destination: &AgentConfig.NodeIP,
+	}
+	NodeExternalIPFlag = &cli.StringSliceFlag{
+		Name:        "node-external-ip",
+		Usage:       "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalIP,
+	}
+	NodeInternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-internal-dns",
+		Usage:       "(agent/networking) internal DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeInternalDNS,
+	}
+	NodeExternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-external-dns",
+		Usage:       "(agent/networking) external DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalDNS,
+	}
+	NodeNameFlag = &cli.StringFlag{
+		Name:        "node-name",
+		Usage:       "(agent/node) Node name",
+		EnvVars:     []string{version.ProgramUpper + "_NODE_NAME"},
+		Destination: &AgentConfig.NodeName,
+	}
+	WithNodeIDFlag = &cli.BoolFlag{
+		Name:        "with-node-id",
+		Usage:       "(agent/node) Append id to node name",
+		Destination: &AgentConfig.WithNodeID,
+	}
+	ProtectKernelDefaultsFlag = &cli.BoolFlag{
+		Name:        "protect-kernel-defaults",
+		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
+		Destination: &AgentConfig.ProtectKernelDefaults,
+	}
+	SELinuxFlag = &cli.BoolFlag{
+		Name:        "selinux",
+		Usage:       "(agent/node) Enable SELinux in containerd",
+		Destination: &AgentConfig.EnableSELinux,
+		EnvVars:     []string{version.ProgramUpper + "_SELINUX"},
+	}
+	LBServerPortFlag = &cli.IntFlag{
+		Name:        "lb-server-port",
+		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
+		Destination: &AgentConfig.LBServerPort,
+		EnvVars:     []string{version.ProgramUpper + "_LB_SERVER_PORT"},
+		Value:       6444,
+	}
+	DockerFlag = &cli.BoolFlag{
+		Name:        "docker",
+		Usage:       "(agent/runtime) (experimental) Use cri-dockerd instead of containerd",
+		Destination: &AgentConfig.Docker,
+	}
+	CRIEndpointFlag = &cli.StringFlag{
+		Name:        "container-runtime-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
+		Destination: &AgentConfig.ContainerRuntimeEndpoint,
+	}
+	DefaultRuntimeFlag = &cli.StringFlag{
+		Name:        "default-runtime",
+		Usage:       "(agent/runtime) Set the default runtime in containerd",
+		Destination: &AgentConfig.DefaultRuntime,
+	}
+	ImageServiceEndpointFlag = &cli.StringFlag{
+		Name:        "image-service-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd image service and use remote image service socket at the given path. If not specified, defaults to --container-runtime-endpoint.",
+		Destination: &AgentConfig.ImageServiceEndpoint,
+	}
+	PrivateRegistryFlag = &cli.StringFlag{
+		Name:        "private-registry",
+		Usage:       "(agent/runtime) Private registry configuration file",
+		Destination: &AgentConfig.PrivateRegistry,
+		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
+	}
+	AirgapExtraRegistryFlag = &cli.StringSliceFlag{
+		Name:        "airgap-extra-registry",
+		Usage:       "(agent/runtime) Additional registry to tag airgap images as being sourced from",
+		Destination: &AgentConfig.AirgapExtraRegistry,
+		Hidden:      true,
+	}
+	PauseImageFlag = &cli.StringFlag{
+		Name:        "pause-image",
+		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
+		Destination: &AgentConfig.PauseImage,
+		Value:       "rancher/mirrored-pause:3.10.2",
+	}
+	SnapshotterFlag = &cli.StringFlag{
+		Name:        "snapshotter",
+		Usage:       "(agent/runtime) Override default containerd snapshotter",
+		Destination: &AgentConfig.Snapshotter,
+		Value:       DefaultSnapshotter,
+	}
+	FlannelIfaceFlag = &cli.StringFlag{
+		Name:        "flannel-iface",
+		Usage:       "(agent/networking) Override default flannel interface",
+		Destination: &AgentConfig.FlannelIface,
+	}
+	FlannelConfFlag = &cli.StringFlag{
+		Name:        "flannel-conf",
+		Usage:       "(agent/networking) Override default flannel config file",
+		Destination: &AgentConfig.FlannelConf,
+	}
+	FlannelCniConfFileFlag = &cli.StringFlag{
+		Name:        "flannel-cni-conf",
+		Usage:       "(agent/networking) Override default flannel cni config file",
+		Destination: &AgentConfig.FlannelCniConfFile,
+	}
+	VPNAuth = &cli.StringFlag{
+		Name:        "vpn-auth",
+		Usage:       "(agent/networking) (experimental) Credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH"},
+		Destination: &AgentConfig.VPNAuth,
+	}
+	VPNAuthFile = &cli.StringFlag{
+		Name:        "vpn-auth-file",
+		Usage:       "(agent/networking) (experimental) File containing credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH_FILE"},
+		Destination: &AgentConfig.VPNAuthFile,
+	}
+	ResolvConfFlag = &cli.StringFlag{
+		Name:        "resolv-conf",
+		Usage:       "(agent/networking) Kubelet resolv.conf file",
+		EnvVars:     []string{version.ProgramUpper + "_RESOLV_CONF"},
+		Destination: &AgentConfig.ResolvConf,
+	}
+	ExtraKubeletArgs = &cli.StringSliceFlag{
+		Name:        "kubelet-arg",
+		Usage:       "(agent/flags) Customized flag for kubelet process",
+		Destination: &AgentConfig.ExtraKubeletArgs,
+	}
+	ExtraKubeProxyArgs = &cli.StringSliceFlag{
+		Name:        "kube-proxy-arg",
+		Usage:       "(agent/flags) Customized flag for kube-proxy process",
+		Destination: &AgentConfig.ExtraKubeProxyArgs,
+	}
+	NodeTaints = &cli.StringSliceFlag{
+		Name:        "node-taint",
+		Usage:       "(agent/node) Registering kubelet with set of taints",
+		Destination: &AgentConfig.Taints,
+	}
+	NodeLabels = &cli.StringSliceFlag{
+		Name:        "node-label",
+		Usage:       "(agent/node) Registering and starting kubelet with set of labels",
+		Destination: &AgentConfig.Labels,
+	}
+	ImageCredProvBinDirFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-bin-dir",
+		Usage:       "(agent/node) The path to the directory where credential provider plugin binaries are located",
+		Destination: &AgentConfig.ImageCredProvBinDir,
+		Value:       "/var/lib/rancher/credentialprovider/bin",
+	}
+	ImageCredProvConfigFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-config",
+		Usage:       "(agent/node) The path to the credential provider plugin config file",
+		Destination: &AgentConfig.ImageCredProvConfig,
+		Value:       "/var/lib/rancher/credentialprovider/config.yaml",
+	}
+	DisableAgentLBFlag = &cli.BoolFlag{
+		Name:        "disable-apiserver-lb",
+		Usage:       "(agent/networking) (experimental) Disable the agent's client-side load-balancer and connect directly to the configured server address",
+		Destination: &AgentConfig.DisableLoadBalancer,
+	}
+	DisableDefaultRegistryEndpointFlag = &cli.BoolFlag{
+		Name:        "disable-default-registry-endpoint",
+		Usage:       "(agent/containerd) Disables containerd's fallback default registry endpoint when a mirror is configured for that registry",
+		Destination: &AgentConfig.ContainerdNoDefault,
+	}
+	NonrootDevicesFlag = &cli.BoolFlag{
+		Name:        "nonroot-devices",
+		Usage:       "(agent/containerd) Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config",
+		Destination: &AgentConfig.ContainerdNonrootDevices,
+	}
+	EnablePProfFlag = &cli.BoolFlag{
+		Name:        "enable-pprof",
+		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
+		Destination: &AgentConfig.EnablePProf,
+	}
+	BindAddressFlag = &cli.StringFlag{
+		Name:        "bind-address",
+		Usage:       "(listener) " + version.Program + " bind address (default: 0.0.0.0)",
+		Destination: &AgentConfig.BindAddress,
+	}
+)
+
+func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "agent",
+		Usage:     "Run node agent",
+		UsageText: appName + " agent [OPTIONS]",
+		Action:    action,
+		Flags: []cli.Flag{
+			ConfigFlag,
+			DebugFlag,
+			VLevel,
+			VModule,
+			LogFile,
+			AlsoLogToStderr,
+			AgentTokenFlag,
+			&cli.StringFlag{
+				Name:        "token-file",
+				Usage:       "(cluster) Token file to use for authentication",
+				EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+				Destination: &AgentConfig.TokenFile,
+			},
+			&cli.StringFlag{
+				Name:        "server",
+				Aliases:     []string{"s"},
+				Usage:       "(cluster) Server to connect to",
+				EnvVars:     []string{version.ProgramUpper + "_URL"},
+				Destination: &AgentConfig.ServerURL,
+			},
+			// Note that this is different from DataDirFlag used elswhere in the CLI,
+			// as this is bound to AgentConfig instead of ServerConfig.
+			&cli.StringFlag{
+				Name:        "data-dir",
+				Aliases:     []string{"d"},
+				Usage:       "(agent/data) Folder to hold state",
+				Destination: &AgentConfig.DataDir,
+				Value:       "/var/lib/rancher/" + version.Program + "",
+				EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+			},
+			NodeNameFlag,
+			WithNodeIDFlag,
+			NodeLabels,
+			NodeTaints,
+			ImageCredProvBinDirFlag,
+			ImageCredProvConfigFlag,
+			SELinuxFlag,
+			LBServerPortFlag,
+			ProtectKernelDefaultsFlag,
+			CRIEndpointFlag,
+			DefaultRuntimeFlag,
+			ImageServiceEndpointFlag,
+			PauseImageFlag,
+			SnapshotterFlag,
+			PrivateRegistryFlag,
+			DisableDefaultRegistryEndpointFlag,
+			NonrootDevicesFlag,
+			AirgapExtraRegistryFlag,
+			NodeIPFlag,
+			BindAddressFlag,
+			NodeExternalIPFlag,
+			NodeInternalDNSFlag,
+			NodeExternalDNSFlag,
+			ResolvConfFlag,
+			FlannelIfaceFlag,
+			FlannelConfFlag,
+			FlannelCniConfFileFlag,
+			ExtraKubeletArgs,
+			ExtraKubeProxyArgs,
+			// Experimental flags
+			EnablePProfFlag,
+			&cli.BoolFlag{
+				Name:        "rootless",
+				Usage:       "(experimental) Run rootless",
+				Destination: &AgentConfig.Rootless,
+			},
+			PreferBundledBin,
+			// Deprecated/hidden below
+			DockerFlag,
+			VPNAuth,
+			VPNAuthFile,
+			DisableAgentLBFlag,
+		},
+	}
+}

--- a/thirdparty-src/k3s/v1_34/zz_server.go
+++ b/thirdparty-src/k3s/v1_34/zz_server.go
@@ -1,0 +1,667 @@
+package cmds
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	defaultSnapshotRentention    = 5
+	defaultSnapshotIntervalHours = 12
+)
+
+type StartupHookArgs struct {
+	APIServerReady       <-chan struct{}
+	KubeConfigSupervisor string
+	Skips                map[string]bool
+	Disables             map[string]bool
+}
+
+type StartupHook func(context.Context, *sync.WaitGroup, StartupHookArgs) error
+
+type Server struct {
+	ClusterCIDR          cli.StringSlice
+	AgentToken           string
+	AgentTokenFile       string
+	Token                string
+	TokenFile            string
+	ClusterSecret        string
+	ServiceCIDR          cli.StringSlice
+	ServiceNodePortRange string
+	ClusterDNS           cli.StringSlice
+	ClusterDomain        string
+	// The port which kubectl clients can access k8s
+	HTTPSPort int
+	// The port which custom k3s API runs on
+	SupervisorPort int
+	// The port which kube-apiserver runs on
+	APIServerPort            int
+	APIServerBindAddress     string
+	DataDir                  string
+	DisableAgent             bool
+	KubeConfigOutput         string
+	KubeConfigMode           string
+	KubeConfigGroup          string
+	HelmJobImage             string
+	TLSSan                   cli.StringSlice
+	TLSSanSecurity           bool
+	ExtraAPIArgs             cli.StringSlice
+	ExtraEtcdArgs            cli.StringSlice
+	ExtraSchedulerArgs       cli.StringSlice
+	ExtraControllerArgs      cli.StringSlice
+	ExtraCloudControllerArgs cli.StringSlice
+	ExtraHelmArgs            cli.StringSlice
+	Rootless                 bool
+	DatastoreEndpoint        string
+	DatastoreCAFile          string
+	DatastoreCertFile        string
+	DatastoreKeyFile         string
+	KineTLS                  bool
+	AdvertiseIP              string
+	AdvertisePort            int
+	DisableScheduler         bool
+	ServerURL                string
+	FlannelBackend           string
+	FlannelIPv6Masq          bool
+	FlannelExternalIP        bool
+	EgressSelectorMode       string
+	DefaultLocalStoragePath  string
+	DisableCCM               bool
+	DisableNPC               bool
+	DisableHelmController    bool
+	DisableKubeProxy         bool
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableETCD              bool
+	EmbeddedRegistry         bool
+	ClusterInit              bool
+	ClusterReset             bool
+	ClusterResetRestorePath  string
+	EncryptSecrets           bool
+	EncryptForce             bool
+	EncryptOutput            string
+	EncryptSkip              bool
+	EncryptProvider          string
+	SystemDefaultRegistry    string
+	StartupHooks             []StartupHook
+	SupervisorMetrics        bool
+	EtcdSnapshotName         string
+	EtcdDisableSnapshots     bool
+	EtcdExposeMetrics        bool
+	EtcdSnapshotDir          string
+	EtcdSnapshotCron         string
+	EtcdSnapshotReconcile    time.Duration
+	EtcdSnapshotRetention    int
+	EtcdSnapshotCompress     bool
+	EtcdListFormat           string
+	EtcdS3                   bool
+	EtcdS3Endpoint           string
+	EtcdS3EndpointCA         string
+	EtcdS3SkipSSLVerify      bool
+	EtcdS3AccessKey          string
+	EtcdS3SecretKey          string
+	EtcdS3SessionToken       string
+	EtcdS3BucketName         string
+	EtcdS3Retention          int
+	EtcdS3BucketLookupType   string
+	EtcdS3Region             string
+	EtcdS3Folder             string
+	EtcdS3Proxy              string
+	EtcdS3ConfigSecret       string
+	EtcdS3Timeout            time.Duration
+	EtcdS3Insecure           bool
+	ServiceLBNamespace       string
+}
+
+var (
+	ServerConfig Server
+	DataDirFlag  = &cli.StringFlag{
+		Name:        "data-dir",
+		Aliases:     []string{"d"},
+		Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+		Destination: &ServerConfig.DataDir,
+		EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+	}
+	ServerToken = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
+		Destination: &ServerConfig.Token,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+	}
+	ClusterCIDR = &cli.StringSliceFlag{
+		Name:        "cluster-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
+		Destination: &ServerConfig.ClusterCIDR,
+	}
+	ServiceCIDR = &cli.StringSliceFlag{
+		Name:        "service-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
+		Destination: &ServerConfig.ServiceCIDR,
+	}
+	ServiceNodePortRange = &cli.StringFlag{
+		Name:        "service-node-port-range",
+		Usage:       "(networking) Port range to reserve for services with NodePort visibility",
+		Destination: &ServerConfig.ServiceNodePortRange,
+		Value:       "30000-32767",
+	}
+	ClusterDNS = &cli.StringSliceFlag{
+		Name:        "cluster-dns",
+		Usage:       "(networking) IPv4 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+		Destination: &ServerConfig.ClusterDNS,
+	}
+	ClusterDomain = &cli.StringFlag{
+		Name:        "cluster-domain",
+		Usage:       "(networking) Cluster Domain",
+		Destination: &ServerConfig.ClusterDomain,
+		Value:       "cluster.local",
+	}
+	ExtraAPIArgs = &cli.StringSliceFlag{
+		Name:        "kube-apiserver-arg",
+		Usage:       "(flags) Customized flag for kube-apiserver process",
+		Destination: &ServerConfig.ExtraAPIArgs,
+	}
+	ExtraEtcdArgs = &cli.StringSliceFlag{
+		Name:        "etcd-arg",
+		Usage:       "(flags) Customized flag for etcd process",
+		Destination: &ServerConfig.ExtraEtcdArgs,
+	}
+	ExtraSchedulerArgs = &cli.StringSliceFlag{
+		Name:        "kube-scheduler-arg",
+		Usage:       "(flags) Customized flag for kube-scheduler process",
+		Destination: &ServerConfig.ExtraSchedulerArgs,
+	}
+	ExtraControllerArgs = &cli.StringSliceFlag{
+		Name:        "kube-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	}
+	ExtraHelmArgs = &cli.StringSliceFlag{
+		Name:        "helm-controller-arg",
+		Usage:       "(flags) Customized flag for helm-controller process",
+		Destination: &ServerConfig.ExtraHelmArgs,
+	}
+)
+
+var ServerFlags = []cli.Flag{
+	ConfigFlag,
+	DebugFlag,
+	VLevel,
+	VModule,
+	LogFile,
+	AlsoLogToStderr,
+	BindAddressFlag,
+	&cli.IntFlag{
+		Name:        "https-listen-port",
+		Usage:       "(listener) HTTPS listen port",
+		Value:       6443,
+		Destination: &ServerConfig.HTTPSPort,
+	},
+	&cli.IntFlag{
+		Name:        "supervisor-port",
+		EnvVars:     []string{version.ProgramUpper + "_SUPERVISOR_PORT"},
+		Usage:       "(experimental) Supervisor listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.SupervisorPort,
+	},
+	&cli.IntFlag{
+		Name:        "apiserver-port",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_PORT"},
+		Usage:       "(experimental) apiserver internal listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerPort,
+	},
+	&cli.StringFlag{
+		Name:        "apiserver-bind-address",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_BIND_ADDRESS"},
+		Usage:       "(experimental) apiserver internal bind address override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerBindAddress,
+	},
+	&cli.StringFlag{
+		Name:        "advertise-address",
+		Usage:       "(listener) IPv4/IPv6 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
+		Destination: &ServerConfig.AdvertiseIP,
+	},
+	&cli.IntFlag{
+		Name:        "advertise-port",
+		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: https-listen-port)",
+		Destination: &ServerConfig.AdvertisePort,
+	},
+	&cli.StringSliceFlag{
+		Name:        "tls-san",
+		Usage:       "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
+		Destination: &ServerConfig.TLSSan,
+	},
+	&cli.BoolFlag{
+		Name:        "tls-san-security",
+		Usage:       "(listener) Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option (default: true)",
+		Destination: &ServerConfig.TLSSanSecurity,
+		Value:       true,
+	},
+	DataDirFlag,
+	ClusterCIDR,
+	ServiceCIDR,
+	ServiceNodePortRange,
+	ClusterDNS,
+	ClusterDomain,
+	&cli.StringFlag{
+		Name:        "flannel-backend",
+		Usage:       "(networking) Backend (valid values: 'none', 'vxlan', 'host-gw', 'wireguard-native'",
+		Destination: &ServerConfig.FlannelBackend,
+		Value:       "vxlan",
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-ipv6-masq",
+		Usage:       "(networking) Enable IPv6 masquerading for pod",
+		Destination: &ServerConfig.FlannelIPv6Masq,
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-external-ip",
+		Usage:       "(networking) Use node external IP addresses for Flannel traffic",
+		Destination: &ServerConfig.FlannelExternalIP,
+	},
+	&cli.StringFlag{
+		Name:        "egress-selector-mode",
+		Usage:       "(networking) One of 'agent', 'cluster', 'pod', 'disabled'",
+		Destination: &ServerConfig.EgressSelectorMode,
+		Value:       "agent",
+	},
+	&cli.StringFlag{
+		Name:        "servicelb-namespace",
+		Usage:       "(networking) Namespace of the pods for the servicelb component",
+		Destination: &ServerConfig.ServiceLBNamespace,
+		Value:       "kube-system",
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig",
+		Aliases:     []string{"o"},
+		Usage:       "(client) Write kubeconfig for admin client to this file",
+		Destination: &ServerConfig.KubeConfigOutput,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_OUTPUT"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-mode",
+		Usage:       "(client) Write kubeconfig with this mode",
+		Destination: &ServerConfig.KubeConfigMode,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_MODE"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-group",
+		Usage:       "(client) Write kubeconfig with this group",
+		Destination: &ServerConfig.KubeConfigGroup,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_GROUP"},
+	},
+	&cli.StringFlag{
+		Name:        "helm-job-image",
+		Usage:       "(helm) (deprecated) Default image to use for helm jobs. Use --helm-controller-arg=default-job-image instead",
+		Destination: &ServerConfig.HelmJobImage,
+	},
+	ServerToken,
+	&cli.StringFlag{
+		Name:        "token-file",
+		Usage:       "(cluster) File containing the token",
+		Destination: &ServerConfig.TokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token",
+		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
+		Destination: &ServerConfig.AgentToken,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token-file",
+		Usage:       "(cluster) File containing the agent secret",
+		Destination: &ServerConfig.AgentTokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "server",
+		Aliases:     []string{"s"},
+		Usage:       "(cluster) Server to connect to, used to join a cluster",
+		EnvVars:     []string{version.ProgramUpper + "_URL"},
+		Destination: &ServerConfig.ServerURL,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-init",
+		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_INIT"},
+		Destination: &ServerConfig.ClusterInit,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-reset",
+		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_RESET"},
+		Destination: &ServerConfig.ClusterReset,
+	},
+	&cli.StringFlag{
+		Name:        "cluster-reset-restore-path",
+		Usage:       "(db) Path to snapshot file to be restored",
+		Destination: &ServerConfig.ClusterResetRestorePath,
+	},
+	ExtraAPIArgs,
+	ExtraEtcdArgs,
+	ExtraControllerArgs,
+	ExtraSchedulerArgs,
+	ExtraHelmArgs,
+	&cli.StringSliceFlag{
+		Name:        "kube-cloud-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+	&cli.BoolFlag{
+		Name:        "kine-tls",
+		Usage:       "(experimental/db) Enable TLS on the kine etcd server socket",
+		Destination: &ServerConfig.KineTLS,
+		Hidden:      true,
+	},
+	&cli.StringFlag{
+		Name:        "datastore-endpoint",
+		Usage:       "(db) Specify etcd, NATS, MySQL, Postgres, or SQLite (default) data source name",
+		Destination: &ServerConfig.DatastoreEndpoint,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_ENDPOINT"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-cafile",
+		Usage:       "(db) TLS Certificate Authority file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCAFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CAFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-certfile",
+		Usage:       "(db) TLS certification file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCertFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CERTFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-keyfile",
+		Usage:       "(db) TLS key file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreKeyFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_KEYFILE"},
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-expose-metrics",
+		Usage:       "(db) Expose etcd metrics to client interface",
+		Destination: &ServerConfig.EtcdExposeMetrics,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-disable-snapshots",
+		Usage:       "(db) Disable automatic etcd snapshots",
+		Destination: &ServerConfig.EtcdDisableSnapshots,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-name",
+		Usage:       "(db) Set the base name of etcd snapshots, appended with UNIX timestamp",
+		Destination: &ServerConfig.EtcdSnapshotName,
+		Value:       "etcd-snapshot",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-schedule-cron",
+		Usage:       "(db) Snapshot interval time in cron spec. eg. every 5 hours '0 */5 * * *'",
+		Destination: &ServerConfig.EtcdSnapshotCron,
+		Value:       "0 */12 * * *",
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-snapshot-reconcile-interval",
+		Usage:       "(db) Snapshot reconcile interval",
+		Destination: &ServerConfig.EtcdSnapshotReconcile,
+		Value:       10 * time.Minute,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-snapshot-retention",
+		Usage:       "(db) Number of snapshots to retain",
+		Destination: &ServerConfig.EtcdSnapshotRetention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-dir",
+		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/server/db/snapshots)",
+		Destination: &ServerConfig.EtcdSnapshotDir,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-snapshot-compress",
+		Usage:       "(db) Compress etcd snapshot",
+		Destination: &ServerConfig.EtcdSnapshotCompress,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3",
+		Usage:       "(db) Enable backup to S3",
+		Destination: &ServerConfig.EtcdS3,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint",
+		Usage:       "(db) S3 endpoint url",
+		Destination: &ServerConfig.EtcdS3Endpoint,
+		Value:       "s3.amazonaws.com",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint-ca",
+		Usage:       "(db) S3 custom CA cert to connect to S3 endpoint",
+		Destination: &ServerConfig.EtcdS3EndpointCA,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-skip-ssl-verify",
+		Usage:       "(db) Disables S3 SSL certificate validation",
+		Destination: &ServerConfig.EtcdS3SkipSSLVerify,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-access-key",
+		Usage:       "(db) S3 access key",
+		EnvVars:     []string{"AWS_ACCESS_KEY_ID"},
+		Destination: &ServerConfig.EtcdS3AccessKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-secret-key",
+		Usage:       "(db) S3 secret key",
+		EnvVars:     []string{"AWS_SECRET_ACCESS_KEY"},
+		Destination: &ServerConfig.EtcdS3SecretKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-session-token",
+		Usage:       "(db) S3 session token",
+		EnvVars:     []string{"AWS_SESSION_TOKEN"},
+		Destination: &ServerConfig.EtcdS3SessionToken,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket",
+		Usage:       "(db) S3 bucket name",
+		Destination: &ServerConfig.EtcdS3BucketName,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket-lookup-type",
+		Usage:       "(db) S3 bucket lookup type, one of 'auto', 'dns', 'path'; default is 'auto' if not set",
+		Destination: &ServerConfig.EtcdS3BucketLookupType,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-region",
+		Usage:       "(db) S3 region / bucket location (optional)",
+		Destination: &ServerConfig.EtcdS3Region,
+		Value:       "us-east-1",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-folder",
+		Usage:       "(db) S3 folder",
+		Destination: &ServerConfig.EtcdS3Folder,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-s3-retention",
+		Usage:       "(db) S3 retention limit",
+		Destination: &ServerConfig.EtcdS3Retention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-proxy",
+		Usage:       "(db) Proxy server to use when connecting to S3, overriding any proxy-releated environment variables",
+		Destination: &ServerConfig.EtcdS3Proxy,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-config-secret",
+		Usage:       "(db) Name of secret in the kube-system namespace used to configure S3, if etcd-s3 is enabled and no other etcd-s3 options are set",
+		Destination: &ServerConfig.EtcdS3ConfigSecret,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-insecure",
+		Usage:       "(db) Disables S3 over HTTPS",
+		Destination: &ServerConfig.EtcdS3Insecure,
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-s3-timeout",
+		Usage:       "(db) S3 timeout",
+		Destination: &ServerConfig.EtcdS3Timeout,
+		Value:       5 * time.Minute,
+	},
+	&cli.StringFlag{
+		Name:        "default-local-storage-path",
+		Usage:       "(storage) Default local storage path for local provisioner storage class",
+		Destination: &ServerConfig.DefaultLocalStoragePath,
+	},
+	&cli.StringSliceFlag{
+		Name:  "disable",
+		Usage: "(components) Do not deploy packaged components and delete any deployed components (valid values: " + DisableItems + ")",
+	},
+	&cli.BoolFlag{
+		Name:        "disable-scheduler",
+		Usage:       "(components) Disable Kubernetes default scheduler",
+		Destination: &ServerConfig.DisableScheduler,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-cloud-controller",
+		Usage:       "(components) Disable " + version.Program + " default cloud controller manager",
+		Destination: &ServerConfig.DisableCCM,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-kube-proxy",
+		Usage:       "(components) Disable running kube-proxy",
+		Destination: &ServerConfig.DisableKubeProxy,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-network-policy",
+		Usage:       "(components) Disable " + version.Program + " default network policy controller",
+		Destination: &ServerConfig.DisableNPC,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-helm-controller",
+		Usage:       "(components) Disable Helm controller",
+		Destination: &ServerConfig.DisableHelmController,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-apiserver",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running api server",
+		Destination: &ServerConfig.DisableAPIServer,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-controller-manager",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running kube-controller-manager",
+		Destination: &ServerConfig.DisableControllerManager,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-etcd",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running etcd",
+		Destination: &ServerConfig.DisableETCD,
+	},
+	&cli.BoolFlag{
+		Name:        "embedded-registry",
+		Usage:       "(components) Enable embedded distributed container registry; requires use of embedded containerd; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.EmbeddedRegistry,
+	},
+	&cli.BoolFlag{
+		Name:        "supervisor-metrics",
+		Usage:       "(experimental/components) Enable serving " + version.Program + " internal metrics on the supervisor port; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.SupervisorMetrics,
+	},
+	NodeNameFlag,
+	WithNodeIDFlag,
+	NodeLabels,
+	NodeTaints,
+	ImageCredProvBinDirFlag,
+	ImageCredProvConfigFlag,
+	DockerFlag,
+	CRIEndpointFlag,
+	DefaultRuntimeFlag,
+	ImageServiceEndpointFlag,
+	DisableDefaultRegistryEndpointFlag,
+	NonrootDevicesFlag,
+	PauseImageFlag,
+	SnapshotterFlag,
+	PrivateRegistryFlag,
+	&cli.StringFlag{
+		Name:        "system-default-registry",
+		Usage:       "(agent/runtime) Private registry to be used for all system images",
+		EnvVars:     []string{version.ProgramUpper + "_SYSTEM_DEFAULT_REGISTRY"},
+		Destination: &ServerConfig.SystemDefaultRegistry,
+	},
+	AirgapExtraRegistryFlag,
+	NodeIPFlag,
+	NodeExternalIPFlag,
+	NodeInternalDNSFlag,
+	NodeExternalDNSFlag,
+	ResolvConfFlag,
+	FlannelIfaceFlag,
+	FlannelConfFlag,
+	FlannelCniConfFileFlag,
+	VPNAuth,
+	VPNAuthFile,
+	ExtraKubeletArgs,
+	ExtraKubeProxyArgs,
+	ProtectKernelDefaultsFlag,
+	&cli.BoolFlag{
+		Name:        "secrets-encryption",
+		Usage:       "Enable secret encryption at rest",
+		Destination: &ServerConfig.EncryptSecrets,
+	},
+	// Experimental flags
+	EnablePProfFlag,
+	&cli.BoolFlag{
+		Name:        "rootless",
+		Usage:       "(experimental) Run rootless",
+		Destination: &ServerConfig.Rootless,
+	},
+	&cli.StringFlag{
+		Name:        "secrets-encryption-provider",
+		Usage:       "(experimental) Secret encryption provider (valid values: 'aescbc', 'secretbox')",
+		Destination: &ServerConfig.EncryptProvider,
+		Value:       "aescbc",
+	},
+	PreferBundledBin,
+	SELinuxFlag,
+	LBServerPortFlag,
+
+	// Hidden/Deprecated flags below
+
+	&cli.BoolFlag{
+		Name:        "disable-agent",
+		Usage:       "Do not run a local agent and register a local kubelet",
+		Hidden:      true,
+		Destination: &ServerConfig.DisableAgent,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-controller-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-cloud-controller-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+}
+
+func NewServerCommand(action func(*cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "server",
+		Usage:     "Run management server",
+		UsageText: appName + " server [OPTIONS]",
+		Action:    action,
+		Flags:     ServerFlags,
+	}
+}

--- a/thirdparty-src/k3s/v1_35/SOURCE.txt
+++ b/thirdparty-src/k3s/v1_35/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/k3s-io/k3s
+tag:    v1.35.8+k3s1
+commit: e952d68a5a5f8953c4549cf8fb557f3eae417107
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go

--- a/thirdparty-src/k3s/v1_35/zz_agent.go
+++ b/thirdparty-src/k3s/v1_35/zz_agent.go
@@ -1,0 +1,343 @@
+package cmds
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+type Agent struct {
+	Token                    string
+	TokenFile                string
+	ClusterSecret            string
+	ServerURL                string
+	APIAddressCh             chan []string
+	DisableLoadBalancer      bool
+	DisableServiceLB         bool
+	ETCDAgent                bool
+	LBServerPort             int
+	ResolvConf               string
+	DataDir                  string
+	BindAddress              string
+	NodeIP                   cli.StringSlice
+	NodeExternalIP           cli.StringSlice
+	NodeInternalDNS          cli.StringSlice
+	NodeExternalDNS          cli.StringSlice
+	NodeName                 string
+	PauseImage               string
+	Snapshotter              string
+	Docker                   bool
+	ContainerdNoDefault      bool
+	ContainerdNonrootDevices bool
+	ContainerRuntimeEndpoint string
+	DefaultRuntime           string
+	ImageServiceEndpoint     string
+	FlannelIface             string
+	FlannelConf              string
+	FlannelCniConfFile       string
+	VPNAuth                  string
+	VPNAuthFile              string
+	Debug                    bool
+	EnablePProf              bool
+	Rootless                 bool
+	RootlessAlreadyUnshared  bool
+	WithNodeID               bool
+	EnableSELinux            bool
+	ProtectKernelDefaults    bool
+	ClusterReset             bool
+	PrivateRegistry          string
+	SystemDefaultRegistry    string
+	AirgapExtraRegistry      cli.StringSlice
+	ExtraKubeletArgs         cli.StringSlice
+	ExtraKubeProxyArgs       cli.StringSlice
+	Labels                   cli.StringSlice
+	Taints                   cli.StringSlice
+	ImageCredProvBinDir      string
+	ImageCredProvConfig      string
+	AgentShared
+}
+
+type AgentShared struct {
+	NodeIP string
+}
+
+var (
+	appName        = filepath.Base(os.Args[0])
+	AgentConfig    Agent
+	AgentTokenFlag = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Token to use for authentication",
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+		Destination: &AgentConfig.Token,
+	}
+	NodeIPFlag = &cli.StringSliceFlag{
+		Name:        "node-ip",
+		Aliases:     []string{"i"},
+		Usage:       "(agent/networking) IPv4/IPv6 addresses to advertise for node",
+		Destination: &AgentConfig.NodeIP,
+	}
+	NodeExternalIPFlag = &cli.StringSliceFlag{
+		Name:        "node-external-ip",
+		Usage:       "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalIP,
+	}
+	NodeInternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-internal-dns",
+		Usage:       "(agent/networking) internal DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeInternalDNS,
+	}
+	NodeExternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-external-dns",
+		Usage:       "(agent/networking) external DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalDNS,
+	}
+	NodeNameFlag = &cli.StringFlag{
+		Name:        "node-name",
+		Usage:       "(agent/node) Node name",
+		EnvVars:     []string{version.ProgramUpper + "_NODE_NAME"},
+		Destination: &AgentConfig.NodeName,
+	}
+	WithNodeIDFlag = &cli.BoolFlag{
+		Name:        "with-node-id",
+		Usage:       "(agent/node) Append id to node name",
+		Destination: &AgentConfig.WithNodeID,
+	}
+	ProtectKernelDefaultsFlag = &cli.BoolFlag{
+		Name:        "protect-kernel-defaults",
+		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
+		Destination: &AgentConfig.ProtectKernelDefaults,
+	}
+	SELinuxFlag = &cli.BoolFlag{
+		Name:        "selinux",
+		Usage:       "(agent/node) Enable SELinux in containerd",
+		Destination: &AgentConfig.EnableSELinux,
+		EnvVars:     []string{version.ProgramUpper + "_SELINUX"},
+	}
+	LBServerPortFlag = &cli.IntFlag{
+		Name:        "lb-server-port",
+		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
+		Destination: &AgentConfig.LBServerPort,
+		EnvVars:     []string{version.ProgramUpper + "_LB_SERVER_PORT"},
+		Value:       6444,
+	}
+	DockerFlag = &cli.BoolFlag{
+		Name:        "docker",
+		Usage:       "(agent/runtime) (experimental) Use cri-dockerd instead of containerd",
+		Destination: &AgentConfig.Docker,
+	}
+	CRIEndpointFlag = &cli.StringFlag{
+		Name:        "container-runtime-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
+		Destination: &AgentConfig.ContainerRuntimeEndpoint,
+	}
+	DefaultRuntimeFlag = &cli.StringFlag{
+		Name:        "default-runtime",
+		Usage:       "(agent/runtime) Set the default runtime in containerd",
+		Destination: &AgentConfig.DefaultRuntime,
+	}
+	ImageServiceEndpointFlag = &cli.StringFlag{
+		Name:        "image-service-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd image service and use remote image service socket at the given path. If not specified, defaults to --container-runtime-endpoint.",
+		Destination: &AgentConfig.ImageServiceEndpoint,
+	}
+	PrivateRegistryFlag = &cli.StringFlag{
+		Name:        "private-registry",
+		Usage:       "(agent/runtime) Private registry configuration file",
+		Destination: &AgentConfig.PrivateRegistry,
+		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
+	}
+	AirgapExtraRegistryFlag = &cli.StringSliceFlag{
+		Name:        "airgap-extra-registry",
+		Usage:       "(agent/runtime) Additional registry to tag airgap images as being sourced from",
+		Destination: &AgentConfig.AirgapExtraRegistry,
+		Hidden:      true,
+	}
+	PauseImageFlag = &cli.StringFlag{
+		Name:        "pause-image",
+		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
+		Destination: &AgentConfig.PauseImage,
+		Value:       "rancher/mirrored-pause:3.10.2",
+	}
+	SnapshotterFlag = &cli.StringFlag{
+		Name:        "snapshotter",
+		Usage:       "(agent/runtime) Override default containerd snapshotter",
+		Destination: &AgentConfig.Snapshotter,
+		Value:       DefaultSnapshotter,
+	}
+	FlannelIfaceFlag = &cli.StringFlag{
+		Name:        "flannel-iface",
+		Usage:       "(agent/networking) Override default flannel interface",
+		Destination: &AgentConfig.FlannelIface,
+	}
+	FlannelConfFlag = &cli.StringFlag{
+		Name:        "flannel-conf",
+		Usage:       "(agent/networking) Override default flannel config file",
+		Destination: &AgentConfig.FlannelConf,
+	}
+	FlannelCniConfFileFlag = &cli.StringFlag{
+		Name:        "flannel-cni-conf",
+		Usage:       "(agent/networking) Override default flannel cni config file",
+		Destination: &AgentConfig.FlannelCniConfFile,
+	}
+	VPNAuth = &cli.StringFlag{
+		Name:        "vpn-auth",
+		Usage:       "(agent/networking) (experimental) Credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH"},
+		Destination: &AgentConfig.VPNAuth,
+	}
+	VPNAuthFile = &cli.StringFlag{
+		Name:        "vpn-auth-file",
+		Usage:       "(agent/networking) (experimental) File containing credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH_FILE"},
+		Destination: &AgentConfig.VPNAuthFile,
+	}
+	ResolvConfFlag = &cli.StringFlag{
+		Name:        "resolv-conf",
+		Usage:       "(agent/networking) Kubelet resolv.conf file",
+		EnvVars:     []string{version.ProgramUpper + "_RESOLV_CONF"},
+		Destination: &AgentConfig.ResolvConf,
+	}
+	ExtraKubeletArgs = &cli.StringSliceFlag{
+		Name:        "kubelet-arg",
+		Usage:       "(agent/flags) Customized flag for kubelet process",
+		Destination: &AgentConfig.ExtraKubeletArgs,
+	}
+	ExtraKubeProxyArgs = &cli.StringSliceFlag{
+		Name:        "kube-proxy-arg",
+		Usage:       "(agent/flags) Customized flag for kube-proxy process",
+		Destination: &AgentConfig.ExtraKubeProxyArgs,
+	}
+	NodeTaints = &cli.StringSliceFlag{
+		Name:        "node-taint",
+		Usage:       "(agent/node) Registering kubelet with set of taints",
+		Destination: &AgentConfig.Taints,
+	}
+	NodeLabels = &cli.StringSliceFlag{
+		Name:        "node-label",
+		Usage:       "(agent/node) Registering and starting kubelet with set of labels",
+		Destination: &AgentConfig.Labels,
+	}
+	ImageCredProvBinDirFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-bin-dir",
+		Usage:       "(agent/node) The path to the directory where credential provider plugin binaries are located",
+		Destination: &AgentConfig.ImageCredProvBinDir,
+		Value:       "/var/lib/rancher/credentialprovider/bin",
+	}
+	ImageCredProvConfigFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-config",
+		Usage:       "(agent/node) The path to the credential provider plugin config file",
+		Destination: &AgentConfig.ImageCredProvConfig,
+		Value:       "/var/lib/rancher/credentialprovider/config.yaml",
+	}
+	DisableAgentLBFlag = &cli.BoolFlag{
+		Name:        "disable-apiserver-lb",
+		Usage:       "(agent/networking) (experimental) Disable the agent's client-side load-balancer and connect directly to the configured server address",
+		Destination: &AgentConfig.DisableLoadBalancer,
+	}
+	DisableDefaultRegistryEndpointFlag = &cli.BoolFlag{
+		Name:        "disable-default-registry-endpoint",
+		Usage:       "(agent/containerd) Disables containerd's fallback default registry endpoint when a mirror is configured for that registry",
+		Destination: &AgentConfig.ContainerdNoDefault,
+	}
+	NonrootDevicesFlag = &cli.BoolFlag{
+		Name:        "nonroot-devices",
+		Usage:       "(agent/containerd) Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config",
+		Destination: &AgentConfig.ContainerdNonrootDevices,
+	}
+	EnablePProfFlag = &cli.BoolFlag{
+		Name:        "enable-pprof",
+		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
+		Destination: &AgentConfig.EnablePProf,
+	}
+	BindAddressFlag = &cli.StringFlag{
+		Name:        "bind-address",
+		Usage:       "(listener) " + version.Program + " bind address (default: 0.0.0.0)",
+		Destination: &AgentConfig.BindAddress,
+	}
+)
+
+func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "agent",
+		Usage:     "Run node agent",
+		UsageText: appName + " agent [OPTIONS]",
+		Action:    action,
+		Flags: []cli.Flag{
+			ConfigFlag,
+			DebugFlag,
+			VLevel,
+			VModule,
+			LogFile,
+			AlsoLogToStderr,
+			AgentTokenFlag,
+			&cli.StringFlag{
+				Name:        "token-file",
+				Usage:       "(cluster) Token file to use for authentication",
+				EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+				Destination: &AgentConfig.TokenFile,
+			},
+			&cli.StringFlag{
+				Name:        "server",
+				Aliases:     []string{"s"},
+				Usage:       "(cluster) Server to connect to",
+				EnvVars:     []string{version.ProgramUpper + "_URL"},
+				Destination: &AgentConfig.ServerURL,
+			},
+			// Note that this is different from DataDirFlag used elswhere in the CLI,
+			// as this is bound to AgentConfig instead of ServerConfig.
+			&cli.StringFlag{
+				Name:        "data-dir",
+				Aliases:     []string{"d"},
+				Usage:       "(agent/data) Folder to hold state",
+				Destination: &AgentConfig.DataDir,
+				Value:       "/var/lib/rancher/" + version.Program + "",
+				EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+			},
+			NodeNameFlag,
+			WithNodeIDFlag,
+			NodeLabels,
+			NodeTaints,
+			ImageCredProvBinDirFlag,
+			ImageCredProvConfigFlag,
+			SELinuxFlag,
+			LBServerPortFlag,
+			ProtectKernelDefaultsFlag,
+			CRIEndpointFlag,
+			DefaultRuntimeFlag,
+			ImageServiceEndpointFlag,
+			PauseImageFlag,
+			SnapshotterFlag,
+			PrivateRegistryFlag,
+			DisableDefaultRegistryEndpointFlag,
+			NonrootDevicesFlag,
+			AirgapExtraRegistryFlag,
+			NodeIPFlag,
+			BindAddressFlag,
+			NodeExternalIPFlag,
+			NodeInternalDNSFlag,
+			NodeExternalDNSFlag,
+			ResolvConfFlag,
+			FlannelIfaceFlag,
+			FlannelConfFlag,
+			FlannelCniConfFileFlag,
+			ExtraKubeletArgs,
+			ExtraKubeProxyArgs,
+			// Experimental flags
+			EnablePProfFlag,
+			&cli.BoolFlag{
+				Name:        "rootless",
+				Usage:       "(experimental) Run rootless",
+				Destination: &AgentConfig.Rootless,
+			},
+			PreferBundledBin,
+			// Deprecated/hidden below
+			DockerFlag,
+			VPNAuth,
+			VPNAuthFile,
+			DisableAgentLBFlag,
+		},
+	}
+}

--- a/thirdparty-src/k3s/v1_35/zz_server.go
+++ b/thirdparty-src/k3s/v1_35/zz_server.go
@@ -1,0 +1,667 @@
+package cmds
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	defaultSnapshotRentention    = 5
+	defaultSnapshotIntervalHours = 12
+)
+
+type StartupHookArgs struct {
+	APIServerReady       <-chan struct{}
+	KubeConfigSupervisor string
+	Skips                map[string]bool
+	Disables             map[string]bool
+}
+
+type StartupHook func(context.Context, *sync.WaitGroup, StartupHookArgs) error
+
+type Server struct {
+	ClusterCIDR          cli.StringSlice
+	AgentToken           string
+	AgentTokenFile       string
+	Token                string
+	TokenFile            string
+	ClusterSecret        string
+	ServiceCIDR          cli.StringSlice
+	ServiceNodePortRange string
+	ClusterDNS           cli.StringSlice
+	ClusterDomain        string
+	// The port which kubectl clients can access k8s
+	HTTPSPort int
+	// The port which custom k3s API runs on
+	SupervisorPort int
+	// The port which kube-apiserver runs on
+	APIServerPort            int
+	APIServerBindAddress     string
+	DataDir                  string
+	DisableAgent             bool
+	KubeConfigOutput         string
+	KubeConfigMode           string
+	KubeConfigGroup          string
+	HelmJobImage             string
+	TLSSan                   cli.StringSlice
+	TLSSanSecurity           bool
+	ExtraAPIArgs             cli.StringSlice
+	ExtraEtcdArgs            cli.StringSlice
+	ExtraSchedulerArgs       cli.StringSlice
+	ExtraControllerArgs      cli.StringSlice
+	ExtraCloudControllerArgs cli.StringSlice
+	ExtraHelmArgs            cli.StringSlice
+	Rootless                 bool
+	DatastoreEndpoint        string
+	DatastoreCAFile          string
+	DatastoreCertFile        string
+	DatastoreKeyFile         string
+	KineTLS                  bool
+	AdvertiseIP              string
+	AdvertisePort            int
+	DisableScheduler         bool
+	ServerURL                string
+	FlannelBackend           string
+	FlannelIPv6Masq          bool
+	FlannelExternalIP        bool
+	EgressSelectorMode       string
+	DefaultLocalStoragePath  string
+	DisableCCM               bool
+	DisableNPC               bool
+	DisableHelmController    bool
+	DisableKubeProxy         bool
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableETCD              bool
+	EmbeddedRegistry         bool
+	ClusterInit              bool
+	ClusterReset             bool
+	ClusterResetRestorePath  string
+	EncryptSecrets           bool
+	EncryptForce             bool
+	EncryptOutput            string
+	EncryptSkip              bool
+	EncryptProvider          string
+	SystemDefaultRegistry    string
+	StartupHooks             []StartupHook
+	SupervisorMetrics        bool
+	EtcdSnapshotName         string
+	EtcdDisableSnapshots     bool
+	EtcdExposeMetrics        bool
+	EtcdSnapshotDir          string
+	EtcdSnapshotCron         string
+	EtcdSnapshotReconcile    time.Duration
+	EtcdSnapshotRetention    int
+	EtcdSnapshotCompress     bool
+	EtcdListFormat           string
+	EtcdS3                   bool
+	EtcdS3Endpoint           string
+	EtcdS3EndpointCA         string
+	EtcdS3SkipSSLVerify      bool
+	EtcdS3AccessKey          string
+	EtcdS3SecretKey          string
+	EtcdS3SessionToken       string
+	EtcdS3BucketName         string
+	EtcdS3Retention          int
+	EtcdS3BucketLookupType   string
+	EtcdS3Region             string
+	EtcdS3Folder             string
+	EtcdS3Proxy              string
+	EtcdS3ConfigSecret       string
+	EtcdS3Timeout            time.Duration
+	EtcdS3Insecure           bool
+	ServiceLBNamespace       string
+}
+
+var (
+	ServerConfig Server
+	DataDirFlag  = &cli.StringFlag{
+		Name:        "data-dir",
+		Aliases:     []string{"d"},
+		Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+		Destination: &ServerConfig.DataDir,
+		EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+	}
+	ServerToken = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
+		Destination: &ServerConfig.Token,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+	}
+	ClusterCIDR = &cli.StringSliceFlag{
+		Name:        "cluster-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
+		Destination: &ServerConfig.ClusterCIDR,
+	}
+	ServiceCIDR = &cli.StringSliceFlag{
+		Name:        "service-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
+		Destination: &ServerConfig.ServiceCIDR,
+	}
+	ServiceNodePortRange = &cli.StringFlag{
+		Name:        "service-node-port-range",
+		Usage:       "(networking) Port range to reserve for services with NodePort visibility",
+		Destination: &ServerConfig.ServiceNodePortRange,
+		Value:       "30000-32767",
+	}
+	ClusterDNS = &cli.StringSliceFlag{
+		Name:        "cluster-dns",
+		Usage:       "(networking) IPv4/IPv6 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+		Destination: &ServerConfig.ClusterDNS,
+	}
+	ClusterDomain = &cli.StringFlag{
+		Name:        "cluster-domain",
+		Usage:       "(networking) Cluster Domain",
+		Destination: &ServerConfig.ClusterDomain,
+		Value:       "cluster.local",
+	}
+	ExtraAPIArgs = &cli.StringSliceFlag{
+		Name:        "kube-apiserver-arg",
+		Usage:       "(flags) Customized flag for kube-apiserver process",
+		Destination: &ServerConfig.ExtraAPIArgs,
+	}
+	ExtraEtcdArgs = &cli.StringSliceFlag{
+		Name:        "etcd-arg",
+		Usage:       "(flags) Customized flag for etcd process",
+		Destination: &ServerConfig.ExtraEtcdArgs,
+	}
+	ExtraSchedulerArgs = &cli.StringSliceFlag{
+		Name:        "kube-scheduler-arg",
+		Usage:       "(flags) Customized flag for kube-scheduler process",
+		Destination: &ServerConfig.ExtraSchedulerArgs,
+	}
+	ExtraControllerArgs = &cli.StringSliceFlag{
+		Name:        "kube-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	}
+	ExtraHelmArgs = &cli.StringSliceFlag{
+		Name:        "helm-controller-arg",
+		Usage:       "(flags) Customized flag for helm-controller process",
+		Destination: &ServerConfig.ExtraHelmArgs,
+	}
+)
+
+var ServerFlags = []cli.Flag{
+	ConfigFlag,
+	DebugFlag,
+	VLevel,
+	VModule,
+	LogFile,
+	AlsoLogToStderr,
+	BindAddressFlag,
+	&cli.IntFlag{
+		Name:        "https-listen-port",
+		Usage:       "(listener) HTTPS listen port",
+		Value:       6443,
+		Destination: &ServerConfig.HTTPSPort,
+	},
+	&cli.IntFlag{
+		Name:        "supervisor-port",
+		EnvVars:     []string{version.ProgramUpper + "_SUPERVISOR_PORT"},
+		Usage:       "(experimental) Supervisor listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.SupervisorPort,
+	},
+	&cli.IntFlag{
+		Name:        "apiserver-port",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_PORT"},
+		Usage:       "(experimental) apiserver internal listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerPort,
+	},
+	&cli.StringFlag{
+		Name:        "apiserver-bind-address",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_BIND_ADDRESS"},
+		Usage:       "(experimental) apiserver internal bind address override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerBindAddress,
+	},
+	&cli.StringFlag{
+		Name:        "advertise-address",
+		Usage:       "(listener) IPv4/IPv6 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
+		Destination: &ServerConfig.AdvertiseIP,
+	},
+	&cli.IntFlag{
+		Name:        "advertise-port",
+		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: https-listen-port)",
+		Destination: &ServerConfig.AdvertisePort,
+	},
+	&cli.StringSliceFlag{
+		Name:        "tls-san",
+		Usage:       "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
+		Destination: &ServerConfig.TLSSan,
+	},
+	&cli.BoolFlag{
+		Name:        "tls-san-security",
+		Usage:       "(listener) Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option (default: true)",
+		Destination: &ServerConfig.TLSSanSecurity,
+		Value:       true,
+	},
+	DataDirFlag,
+	ClusterCIDR,
+	ServiceCIDR,
+	ServiceNodePortRange,
+	ClusterDNS,
+	ClusterDomain,
+	&cli.StringFlag{
+		Name:        "flannel-backend",
+		Usage:       "(networking) Backend (valid values: 'none', 'vxlan', 'host-gw', 'wireguard-native'",
+		Destination: &ServerConfig.FlannelBackend,
+		Value:       "vxlan",
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-ipv6-masq",
+		Usage:       "(networking) Enable IPv6 masquerading for pod",
+		Destination: &ServerConfig.FlannelIPv6Masq,
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-external-ip",
+		Usage:       "(networking) Use node external IP addresses for Flannel traffic",
+		Destination: &ServerConfig.FlannelExternalIP,
+	},
+	&cli.StringFlag{
+		Name:        "egress-selector-mode",
+		Usage:       "(networking) One of 'agent', 'cluster', 'pod', 'disabled'",
+		Destination: &ServerConfig.EgressSelectorMode,
+		Value:       "agent",
+	},
+	&cli.StringFlag{
+		Name:        "servicelb-namespace",
+		Usage:       "(networking) Namespace of the pods for the servicelb component",
+		Destination: &ServerConfig.ServiceLBNamespace,
+		Value:       "kube-system",
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig",
+		Aliases:     []string{"o"},
+		Usage:       "(client) Write kubeconfig for admin client to this file",
+		Destination: &ServerConfig.KubeConfigOutput,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_OUTPUT"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-mode",
+		Usage:       "(client) Write kubeconfig with this mode",
+		Destination: &ServerConfig.KubeConfigMode,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_MODE"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-group",
+		Usage:       "(client) Write kubeconfig with this group",
+		Destination: &ServerConfig.KubeConfigGroup,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_GROUP"},
+	},
+	&cli.StringFlag{
+		Name:        "helm-job-image",
+		Usage:       "(helm) (deprecated) Default image to use for helm jobs. Use --helm-controller-arg=default-job-image instead",
+		Destination: &ServerConfig.HelmJobImage,
+	},
+	ServerToken,
+	&cli.StringFlag{
+		Name:        "token-file",
+		Usage:       "(cluster) File containing the token",
+		Destination: &ServerConfig.TokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token",
+		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
+		Destination: &ServerConfig.AgentToken,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token-file",
+		Usage:       "(cluster) File containing the agent secret",
+		Destination: &ServerConfig.AgentTokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "server",
+		Aliases:     []string{"s"},
+		Usage:       "(cluster) Server to connect to, used to join a cluster",
+		EnvVars:     []string{version.ProgramUpper + "_URL"},
+		Destination: &ServerConfig.ServerURL,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-init",
+		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_INIT"},
+		Destination: &ServerConfig.ClusterInit,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-reset",
+		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_RESET"},
+		Destination: &ServerConfig.ClusterReset,
+	},
+	&cli.StringFlag{
+		Name:        "cluster-reset-restore-path",
+		Usage:       "(db) Path to snapshot file to be restored",
+		Destination: &ServerConfig.ClusterResetRestorePath,
+	},
+	ExtraAPIArgs,
+	ExtraEtcdArgs,
+	ExtraControllerArgs,
+	ExtraSchedulerArgs,
+	ExtraHelmArgs,
+	&cli.StringSliceFlag{
+		Name:        "kube-cloud-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+	&cli.BoolFlag{
+		Name:        "kine-tls",
+		Usage:       "(experimental/db) Enable TLS on the kine etcd server socket",
+		Destination: &ServerConfig.KineTLS,
+		Hidden:      true,
+	},
+	&cli.StringFlag{
+		Name:        "datastore-endpoint",
+		Usage:       "(db) Specify etcd, NATS, MySQL, Postgres, or SQLite (default) data source name",
+		Destination: &ServerConfig.DatastoreEndpoint,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_ENDPOINT"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-cafile",
+		Usage:       "(db) TLS Certificate Authority file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCAFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CAFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-certfile",
+		Usage:       "(db) TLS certification file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCertFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CERTFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-keyfile",
+		Usage:       "(db) TLS key file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreKeyFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_KEYFILE"},
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-expose-metrics",
+		Usage:       "(db) Expose etcd metrics to client interface",
+		Destination: &ServerConfig.EtcdExposeMetrics,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-disable-snapshots",
+		Usage:       "(db) Disable automatic etcd snapshots",
+		Destination: &ServerConfig.EtcdDisableSnapshots,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-name",
+		Usage:       "(db) Set the base name of etcd snapshots, appended with UNIX timestamp",
+		Destination: &ServerConfig.EtcdSnapshotName,
+		Value:       "etcd-snapshot",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-schedule-cron",
+		Usage:       "(db) Snapshot interval time in cron spec. eg. every 5 hours '0 */5 * * *'",
+		Destination: &ServerConfig.EtcdSnapshotCron,
+		Value:       "0 */12 * * *",
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-snapshot-reconcile-interval",
+		Usage:       "(db) Snapshot reconcile interval",
+		Destination: &ServerConfig.EtcdSnapshotReconcile,
+		Value:       10 * time.Minute,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-snapshot-retention",
+		Usage:       "(db) Number of snapshots to retain",
+		Destination: &ServerConfig.EtcdSnapshotRetention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-dir",
+		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/server/db/snapshots)",
+		Destination: &ServerConfig.EtcdSnapshotDir,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-snapshot-compress",
+		Usage:       "(db) Compress etcd snapshot",
+		Destination: &ServerConfig.EtcdSnapshotCompress,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3",
+		Usage:       "(db) Enable backup to S3",
+		Destination: &ServerConfig.EtcdS3,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint",
+		Usage:       "(db) S3 endpoint url",
+		Destination: &ServerConfig.EtcdS3Endpoint,
+		Value:       "s3.amazonaws.com",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint-ca",
+		Usage:       "(db) S3 custom CA cert to connect to S3 endpoint",
+		Destination: &ServerConfig.EtcdS3EndpointCA,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-skip-ssl-verify",
+		Usage:       "(db) Disables S3 SSL certificate validation",
+		Destination: &ServerConfig.EtcdS3SkipSSLVerify,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-access-key",
+		Usage:       "(db) S3 access key",
+		EnvVars:     []string{"AWS_ACCESS_KEY_ID"},
+		Destination: &ServerConfig.EtcdS3AccessKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-secret-key",
+		Usage:       "(db) S3 secret key",
+		EnvVars:     []string{"AWS_SECRET_ACCESS_KEY"},
+		Destination: &ServerConfig.EtcdS3SecretKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-session-token",
+		Usage:       "(db) S3 session token",
+		EnvVars:     []string{"AWS_SESSION_TOKEN"},
+		Destination: &ServerConfig.EtcdS3SessionToken,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket",
+		Usage:       "(db) S3 bucket name",
+		Destination: &ServerConfig.EtcdS3BucketName,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket-lookup-type",
+		Usage:       "(db) S3 bucket lookup type, one of 'auto', 'dns', 'path'; default is 'auto' if not set",
+		Destination: &ServerConfig.EtcdS3BucketLookupType,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-region",
+		Usage:       "(db) S3 region / bucket location (optional)",
+		Destination: &ServerConfig.EtcdS3Region,
+		Value:       "us-east-1",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-folder",
+		Usage:       "(db) S3 folder",
+		Destination: &ServerConfig.EtcdS3Folder,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-s3-retention",
+		Usage:       "(db) S3 retention limit",
+		Destination: &ServerConfig.EtcdS3Retention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-proxy",
+		Usage:       "(db) Proxy server to use when connecting to S3, overriding any proxy-releated environment variables",
+		Destination: &ServerConfig.EtcdS3Proxy,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-config-secret",
+		Usage:       "(db) Name of secret in the kube-system namespace used to configure S3, if etcd-s3 is enabled and no other etcd-s3 options are set",
+		Destination: &ServerConfig.EtcdS3ConfigSecret,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-insecure",
+		Usage:       "(db) Disables S3 over HTTPS",
+		Destination: &ServerConfig.EtcdS3Insecure,
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-s3-timeout",
+		Usage:       "(db) S3 timeout",
+		Destination: &ServerConfig.EtcdS3Timeout,
+		Value:       5 * time.Minute,
+	},
+	&cli.StringFlag{
+		Name:        "default-local-storage-path",
+		Usage:       "(storage) Default local storage path for local provisioner storage class",
+		Destination: &ServerConfig.DefaultLocalStoragePath,
+	},
+	&cli.StringSliceFlag{
+		Name:  "disable",
+		Usage: "(components) Do not deploy packaged components and delete any deployed components (valid values: " + DisableItems + ")",
+	},
+	&cli.BoolFlag{
+		Name:        "disable-scheduler",
+		Usage:       "(components) Disable Kubernetes default scheduler",
+		Destination: &ServerConfig.DisableScheduler,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-cloud-controller",
+		Usage:       "(components) Disable " + version.Program + " default cloud controller manager",
+		Destination: &ServerConfig.DisableCCM,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-kube-proxy",
+		Usage:       "(components) Disable running kube-proxy",
+		Destination: &ServerConfig.DisableKubeProxy,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-network-policy",
+		Usage:       "(components) Disable " + version.Program + " default network policy controller",
+		Destination: &ServerConfig.DisableNPC,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-helm-controller",
+		Usage:       "(components) Disable Helm controller",
+		Destination: &ServerConfig.DisableHelmController,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-apiserver",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running api server",
+		Destination: &ServerConfig.DisableAPIServer,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-controller-manager",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running kube-controller-manager",
+		Destination: &ServerConfig.DisableControllerManager,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-etcd",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running etcd",
+		Destination: &ServerConfig.DisableETCD,
+	},
+	&cli.BoolFlag{
+		Name:        "embedded-registry",
+		Usage:       "(components) Enable embedded distributed container registry; requires use of embedded containerd; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.EmbeddedRegistry,
+	},
+	&cli.BoolFlag{
+		Name:        "supervisor-metrics",
+		Usage:       "(experimental/components) Enable serving " + version.Program + " internal metrics on the supervisor port; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.SupervisorMetrics,
+	},
+	NodeNameFlag,
+	WithNodeIDFlag,
+	NodeLabels,
+	NodeTaints,
+	ImageCredProvBinDirFlag,
+	ImageCredProvConfigFlag,
+	DockerFlag,
+	CRIEndpointFlag,
+	DefaultRuntimeFlag,
+	ImageServiceEndpointFlag,
+	DisableDefaultRegistryEndpointFlag,
+	NonrootDevicesFlag,
+	PauseImageFlag,
+	SnapshotterFlag,
+	PrivateRegistryFlag,
+	&cli.StringFlag{
+		Name:        "system-default-registry",
+		Usage:       "(agent/runtime) Private registry to be used for all system images",
+		EnvVars:     []string{version.ProgramUpper + "_SYSTEM_DEFAULT_REGISTRY"},
+		Destination: &ServerConfig.SystemDefaultRegistry,
+	},
+	AirgapExtraRegistryFlag,
+	NodeIPFlag,
+	NodeExternalIPFlag,
+	NodeInternalDNSFlag,
+	NodeExternalDNSFlag,
+	ResolvConfFlag,
+	FlannelIfaceFlag,
+	FlannelConfFlag,
+	FlannelCniConfFileFlag,
+	VPNAuth,
+	VPNAuthFile,
+	ExtraKubeletArgs,
+	ExtraKubeProxyArgs,
+	ProtectKernelDefaultsFlag,
+	&cli.BoolFlag{
+		Name:        "secrets-encryption",
+		Usage:       "Enable secret encryption at rest",
+		Destination: &ServerConfig.EncryptSecrets,
+	},
+	// Experimental flags
+	EnablePProfFlag,
+	&cli.BoolFlag{
+		Name:        "rootless",
+		Usage:       "(experimental) Run rootless",
+		Destination: &ServerConfig.Rootless,
+	},
+	&cli.StringFlag{
+		Name:        "secrets-encryption-provider",
+		Usage:       "(experimental) Secret encryption provider (valid values: 'aescbc', 'secretbox')",
+		Destination: &ServerConfig.EncryptProvider,
+		Value:       "aescbc",
+	},
+	PreferBundledBin,
+	SELinuxFlag,
+	LBServerPortFlag,
+
+	// Hidden/Deprecated flags below
+
+	&cli.BoolFlag{
+		Name:        "disable-agent",
+		Usage:       "Do not run a local agent and register a local kubelet",
+		Hidden:      true,
+		Destination: &ServerConfig.DisableAgent,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-controller-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-cloud-controller-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+}
+
+func NewServerCommand(action func(*cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "server",
+		Usage:     "Run management server",
+		UsageText: appName + " server [OPTIONS]",
+		Action:    action,
+		Flags:     ServerFlags,
+	}
+}

--- a/thirdparty-src/k3s/v1_36/SOURCE.txt
+++ b/thirdparty-src/k3s/v1_36/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/k3s-io/k3s
+tag:    v1.36.4+k3s1
+commit: 4dedb15be78017a8ddd5b9e81acd44f3481078ed
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go

--- a/thirdparty-src/k3s/v1_36/zz_agent.go
+++ b/thirdparty-src/k3s/v1_36/zz_agent.go
@@ -1,0 +1,343 @@
+package cmds
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+type Agent struct {
+	Token                    string
+	TokenFile                string
+	ClusterSecret            string
+	ServerURL                string
+	APIAddressCh             chan []string
+	DisableLoadBalancer      bool
+	DisableServiceLB         bool
+	ETCDAgent                bool
+	LBServerPort             int
+	ResolvConf               string
+	DataDir                  string
+	BindAddress              string
+	NodeIP                   cli.StringSlice
+	NodeExternalIP           cli.StringSlice
+	NodeInternalDNS          cli.StringSlice
+	NodeExternalDNS          cli.StringSlice
+	NodeName                 string
+	PauseImage               string
+	Snapshotter              string
+	Docker                   bool
+	ContainerdNoDefault      bool
+	ContainerdNonrootDevices bool
+	ContainerRuntimeEndpoint string
+	DefaultRuntime           string
+	ImageServiceEndpoint     string
+	FlannelIface             string
+	FlannelConf              string
+	FlannelCniConfFile       string
+	VPNAuth                  string
+	VPNAuthFile              string
+	Debug                    bool
+	EnablePProf              bool
+	Rootless                 bool
+	RootlessAlreadyUnshared  bool
+	WithNodeID               bool
+	EnableSELinux            bool
+	ProtectKernelDefaults    bool
+	ClusterReset             bool
+	PrivateRegistry          string
+	SystemDefaultRegistry    string
+	AirgapExtraRegistry      cli.StringSlice
+	ExtraKubeletArgs         cli.StringSlice
+	ExtraKubeProxyArgs       cli.StringSlice
+	Labels                   cli.StringSlice
+	Taints                   cli.StringSlice
+	ImageCredProvBinDir      string
+	ImageCredProvConfig      string
+	AgentShared
+}
+
+type AgentShared struct {
+	NodeIP string
+}
+
+var (
+	appName        = filepath.Base(os.Args[0])
+	AgentConfig    Agent
+	AgentTokenFlag = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Token to use for authentication",
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+		Destination: &AgentConfig.Token,
+	}
+	NodeIPFlag = &cli.StringSliceFlag{
+		Name:        "node-ip",
+		Aliases:     []string{"i"},
+		Usage:       "(agent/networking) IPv4/IPv6 addresses to advertise for node",
+		Destination: &AgentConfig.NodeIP,
+	}
+	NodeExternalIPFlag = &cli.StringSliceFlag{
+		Name:        "node-external-ip",
+		Usage:       "(agent/networking) IPv4/IPv6 external IP addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalIP,
+	}
+	NodeInternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-internal-dns",
+		Usage:       "(agent/networking) internal DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeInternalDNS,
+	}
+	NodeExternalDNSFlag = &cli.StringSliceFlag{
+		Name:        "node-external-dns",
+		Usage:       "(agent/networking) external DNS addresses to advertise for node",
+		Destination: &AgentConfig.NodeExternalDNS,
+	}
+	NodeNameFlag = &cli.StringFlag{
+		Name:        "node-name",
+		Usage:       "(agent/node) Node name",
+		EnvVars:     []string{version.ProgramUpper + "_NODE_NAME"},
+		Destination: &AgentConfig.NodeName,
+	}
+	WithNodeIDFlag = &cli.BoolFlag{
+		Name:        "with-node-id",
+		Usage:       "(agent/node) Append id to node name",
+		Destination: &AgentConfig.WithNodeID,
+	}
+	ProtectKernelDefaultsFlag = &cli.BoolFlag{
+		Name:        "protect-kernel-defaults",
+		Usage:       "(agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.",
+		Destination: &AgentConfig.ProtectKernelDefaults,
+	}
+	SELinuxFlag = &cli.BoolFlag{
+		Name:        "selinux",
+		Usage:       "(agent/node) Enable SELinux in containerd",
+		Destination: &AgentConfig.EnableSELinux,
+		EnvVars:     []string{version.ProgramUpper + "_SELINUX"},
+	}
+	LBServerPortFlag = &cli.IntFlag{
+		Name:        "lb-server-port",
+		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
+		Destination: &AgentConfig.LBServerPort,
+		EnvVars:     []string{version.ProgramUpper + "_LB_SERVER_PORT"},
+		Value:       6444,
+	}
+	DockerFlag = &cli.BoolFlag{
+		Name:        "docker",
+		Usage:       "(agent/runtime) (experimental) Use cri-dockerd instead of containerd",
+		Destination: &AgentConfig.Docker,
+	}
+	CRIEndpointFlag = &cli.StringFlag{
+		Name:        "container-runtime-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path",
+		Destination: &AgentConfig.ContainerRuntimeEndpoint,
+	}
+	DefaultRuntimeFlag = &cli.StringFlag{
+		Name:        "default-runtime",
+		Usage:       "(agent/runtime) Set the default runtime in containerd",
+		Destination: &AgentConfig.DefaultRuntime,
+	}
+	ImageServiceEndpointFlag = &cli.StringFlag{
+		Name:        "image-service-endpoint",
+		Usage:       "(agent/runtime) Disable embedded containerd image service and use remote image service socket at the given path. If not specified, defaults to --container-runtime-endpoint.",
+		Destination: &AgentConfig.ImageServiceEndpoint,
+	}
+	PrivateRegistryFlag = &cli.StringFlag{
+		Name:        "private-registry",
+		Usage:       "(agent/runtime) Private registry configuration file",
+		Destination: &AgentConfig.PrivateRegistry,
+		Value:       "/etc/rancher/" + version.Program + "/registries.yaml",
+	}
+	AirgapExtraRegistryFlag = &cli.StringSliceFlag{
+		Name:        "airgap-extra-registry",
+		Usage:       "(agent/runtime) Additional registry to tag airgap images as being sourced from",
+		Destination: &AgentConfig.AirgapExtraRegistry,
+		Hidden:      true,
+	}
+	PauseImageFlag = &cli.StringFlag{
+		Name:        "pause-image",
+		Usage:       "(agent/runtime) Customized pause image for containerd or docker sandbox",
+		Destination: &AgentConfig.PauseImage,
+		Value:       "rancher/mirrored-pause:3.10.2",
+	}
+	SnapshotterFlag = &cli.StringFlag{
+		Name:        "snapshotter",
+		Usage:       "(agent/runtime) Override default containerd snapshotter",
+		Destination: &AgentConfig.Snapshotter,
+		Value:       DefaultSnapshotter,
+	}
+	FlannelIfaceFlag = &cli.StringFlag{
+		Name:        "flannel-iface",
+		Usage:       "(agent/networking) Override default flannel interface",
+		Destination: &AgentConfig.FlannelIface,
+	}
+	FlannelConfFlag = &cli.StringFlag{
+		Name:        "flannel-conf",
+		Usage:       "(agent/networking) Override default flannel config file",
+		Destination: &AgentConfig.FlannelConf,
+	}
+	FlannelCniConfFileFlag = &cli.StringFlag{
+		Name:        "flannel-cni-conf",
+		Usage:       "(agent/networking) Override default flannel cni config file",
+		Destination: &AgentConfig.FlannelCniConfFile,
+	}
+	VPNAuth = &cli.StringFlag{
+		Name:        "vpn-auth",
+		Usage:       "(agent/networking) (experimental) Credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH"},
+		Destination: &AgentConfig.VPNAuth,
+	}
+	VPNAuthFile = &cli.StringFlag{
+		Name:        "vpn-auth-file",
+		Usage:       "(agent/networking) (experimental) File containing credentials for the VPN provider. It must include the provider name and join key in the format name=<vpn-provider>,joinKey=<key>[,controlServerURL=<url>][,extraArgs=<args>]",
+		EnvVars:     []string{version.ProgramUpper + "_VPN_AUTH_FILE"},
+		Destination: &AgentConfig.VPNAuthFile,
+	}
+	ResolvConfFlag = &cli.StringFlag{
+		Name:        "resolv-conf",
+		Usage:       "(agent/networking) Kubelet resolv.conf file",
+		EnvVars:     []string{version.ProgramUpper + "_RESOLV_CONF"},
+		Destination: &AgentConfig.ResolvConf,
+	}
+	ExtraKubeletArgs = &cli.StringSliceFlag{
+		Name:        "kubelet-arg",
+		Usage:       "(agent/flags) Customized flag for kubelet process",
+		Destination: &AgentConfig.ExtraKubeletArgs,
+	}
+	ExtraKubeProxyArgs = &cli.StringSliceFlag{
+		Name:        "kube-proxy-arg",
+		Usage:       "(agent/flags) Customized flag for kube-proxy process",
+		Destination: &AgentConfig.ExtraKubeProxyArgs,
+	}
+	NodeTaints = &cli.StringSliceFlag{
+		Name:        "node-taint",
+		Usage:       "(agent/node) Registering kubelet with set of taints",
+		Destination: &AgentConfig.Taints,
+	}
+	NodeLabels = &cli.StringSliceFlag{
+		Name:        "node-label",
+		Usage:       "(agent/node) Registering and starting kubelet with set of labels",
+		Destination: &AgentConfig.Labels,
+	}
+	ImageCredProvBinDirFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-bin-dir",
+		Usage:       "(agent/node) The path to the directory where credential provider plugin binaries are located",
+		Destination: &AgentConfig.ImageCredProvBinDir,
+		Value:       "/var/lib/rancher/credentialprovider/bin",
+	}
+	ImageCredProvConfigFlag = &cli.StringFlag{
+		Name:        "image-credential-provider-config",
+		Usage:       "(agent/node) The path to the credential provider plugin config file",
+		Destination: &AgentConfig.ImageCredProvConfig,
+		Value:       "/var/lib/rancher/credentialprovider/config.yaml",
+	}
+	DisableAgentLBFlag = &cli.BoolFlag{
+		Name:        "disable-apiserver-lb",
+		Usage:       "(agent/networking) (experimental) Disable the agent's client-side load-balancer and connect directly to the configured server address",
+		Destination: &AgentConfig.DisableLoadBalancer,
+	}
+	DisableDefaultRegistryEndpointFlag = &cli.BoolFlag{
+		Name:        "disable-default-registry-endpoint",
+		Usage:       "(agent/containerd) Disables containerd's fallback default registry endpoint when a mirror is configured for that registry",
+		Destination: &AgentConfig.ContainerdNoDefault,
+	}
+	NonrootDevicesFlag = &cli.BoolFlag{
+		Name:        "nonroot-devices",
+		Usage:       "(agent/containerd) Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config",
+		Destination: &AgentConfig.ContainerdNonrootDevices,
+	}
+	EnablePProfFlag = &cli.BoolFlag{
+		Name:        "enable-pprof",
+		Usage:       "(experimental) Enable pprof endpoint on supervisor port",
+		Destination: &AgentConfig.EnablePProf,
+	}
+	BindAddressFlag = &cli.StringFlag{
+		Name:        "bind-address",
+		Usage:       "(listener) " + version.Program + " bind address (default: 0.0.0.0)",
+		Destination: &AgentConfig.BindAddress,
+	}
+)
+
+func NewAgentCommand(action func(ctx *cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "agent",
+		Usage:     "Run node agent",
+		UsageText: appName + " agent [OPTIONS]",
+		Action:    action,
+		Flags: []cli.Flag{
+			ConfigFlag,
+			DebugFlag,
+			VLevel,
+			VModule,
+			LogFile,
+			AlsoLogToStderr,
+			AgentTokenFlag,
+			&cli.StringFlag{
+				Name:        "token-file",
+				Usage:       "(cluster) Token file to use for authentication",
+				EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+				Destination: &AgentConfig.TokenFile,
+			},
+			&cli.StringFlag{
+				Name:        "server",
+				Aliases:     []string{"s"},
+				Usage:       "(cluster) Server to connect to",
+				EnvVars:     []string{version.ProgramUpper + "_URL"},
+				Destination: &AgentConfig.ServerURL,
+			},
+			// Note that this is different from DataDirFlag used elswhere in the CLI,
+			// as this is bound to AgentConfig instead of ServerConfig.
+			&cli.StringFlag{
+				Name:        "data-dir",
+				Aliases:     []string{"d"},
+				Usage:       "(agent/data) Folder to hold state",
+				Destination: &AgentConfig.DataDir,
+				Value:       "/var/lib/rancher/" + version.Program + "",
+				EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+			},
+			NodeNameFlag,
+			WithNodeIDFlag,
+			NodeLabels,
+			NodeTaints,
+			ImageCredProvBinDirFlag,
+			ImageCredProvConfigFlag,
+			SELinuxFlag,
+			LBServerPortFlag,
+			ProtectKernelDefaultsFlag,
+			CRIEndpointFlag,
+			DefaultRuntimeFlag,
+			ImageServiceEndpointFlag,
+			PauseImageFlag,
+			SnapshotterFlag,
+			PrivateRegistryFlag,
+			DisableDefaultRegistryEndpointFlag,
+			NonrootDevicesFlag,
+			AirgapExtraRegistryFlag,
+			NodeIPFlag,
+			BindAddressFlag,
+			NodeExternalIPFlag,
+			NodeInternalDNSFlag,
+			NodeExternalDNSFlag,
+			ResolvConfFlag,
+			FlannelIfaceFlag,
+			FlannelConfFlag,
+			FlannelCniConfFileFlag,
+			ExtraKubeletArgs,
+			ExtraKubeProxyArgs,
+			// Experimental flags
+			EnablePProfFlag,
+			&cli.BoolFlag{
+				Name:        "rootless",
+				Usage:       "(experimental) Run rootless",
+				Destination: &AgentConfig.Rootless,
+			},
+			PreferBundledBin,
+			// Deprecated/hidden below
+			DockerFlag,
+			VPNAuth,
+			VPNAuthFile,
+			DisableAgentLBFlag,
+		},
+	}
+}

--- a/thirdparty-src/k3s/v1_36/zz_server.go
+++ b/thirdparty-src/k3s/v1_36/zz_server.go
@@ -1,0 +1,667 @@
+package cmds
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	defaultSnapshotRentention    = 5
+	defaultSnapshotIntervalHours = 12
+)
+
+type StartupHookArgs struct {
+	APIServerReady       <-chan struct{}
+	KubeConfigSupervisor string
+	Skips                map[string]bool
+	Disables             map[string]bool
+}
+
+type StartupHook func(context.Context, *sync.WaitGroup, StartupHookArgs) error
+
+type Server struct {
+	ClusterCIDR          cli.StringSlice
+	AgentToken           string
+	AgentTokenFile       string
+	Token                string
+	TokenFile            string
+	ClusterSecret        string
+	ServiceCIDR          cli.StringSlice
+	ServiceNodePortRange string
+	ClusterDNS           cli.StringSlice
+	ClusterDomain        string
+	// The port which kubectl clients can access k8s
+	HTTPSPort int
+	// The port which custom k3s API runs on
+	SupervisorPort int
+	// The port which kube-apiserver runs on
+	APIServerPort            int
+	APIServerBindAddress     string
+	DataDir                  string
+	DisableAgent             bool
+	KubeConfigOutput         string
+	KubeConfigMode           string
+	KubeConfigGroup          string
+	HelmJobImage             string
+	TLSSan                   cli.StringSlice
+	TLSSanSecurity           bool
+	ExtraAPIArgs             cli.StringSlice
+	ExtraEtcdArgs            cli.StringSlice
+	ExtraSchedulerArgs       cli.StringSlice
+	ExtraControllerArgs      cli.StringSlice
+	ExtraCloudControllerArgs cli.StringSlice
+	ExtraHelmArgs            cli.StringSlice
+	Rootless                 bool
+	DatastoreEndpoint        string
+	DatastoreCAFile          string
+	DatastoreCertFile        string
+	DatastoreKeyFile         string
+	KineTLS                  bool
+	AdvertiseIP              string
+	AdvertisePort            int
+	DisableScheduler         bool
+	ServerURL                string
+	FlannelBackend           string
+	FlannelIPv6Masq          bool
+	FlannelExternalIP        bool
+	EgressSelectorMode       string
+	DefaultLocalStoragePath  string
+	DisableCCM               bool
+	DisableNPC               bool
+	DisableHelmController    bool
+	DisableKubeProxy         bool
+	DisableAPIServer         bool
+	DisableControllerManager bool
+	DisableETCD              bool
+	EmbeddedRegistry         bool
+	ClusterInit              bool
+	ClusterReset             bool
+	ClusterResetRestorePath  string
+	EncryptSecrets           bool
+	EncryptForce             bool
+	EncryptOutput            string
+	EncryptSkip              bool
+	EncryptProvider          string
+	SystemDefaultRegistry    string
+	StartupHooks             []StartupHook
+	SupervisorMetrics        bool
+	EtcdSnapshotName         string
+	EtcdDisableSnapshots     bool
+	EtcdExposeMetrics        bool
+	EtcdSnapshotDir          string
+	EtcdSnapshotCron         string
+	EtcdSnapshotReconcile    time.Duration
+	EtcdSnapshotRetention    int
+	EtcdSnapshotCompress     bool
+	EtcdListFormat           string
+	EtcdS3                   bool
+	EtcdS3Endpoint           string
+	EtcdS3EndpointCA         string
+	EtcdS3SkipSSLVerify      bool
+	EtcdS3AccessKey          string
+	EtcdS3SecretKey          string
+	EtcdS3SessionToken       string
+	EtcdS3BucketName         string
+	EtcdS3Retention          int
+	EtcdS3BucketLookupType   string
+	EtcdS3Region             string
+	EtcdS3Folder             string
+	EtcdS3Proxy              string
+	EtcdS3ConfigSecret       string
+	EtcdS3Timeout            time.Duration
+	EtcdS3Insecure           bool
+	ServiceLBNamespace       string
+}
+
+var (
+	ServerConfig Server
+	DataDirFlag  = &cli.StringFlag{
+		Name:        "data-dir",
+		Aliases:     []string{"d"},
+		Usage:       "(data) Folder to hold state default /var/lib/rancher/" + version.Program + " or ${HOME}/.rancher/" + version.Program + " if not root",
+		Destination: &ServerConfig.DataDir,
+		EnvVars:     []string{version.ProgramUpper + "_DATA_DIR"},
+	}
+	ServerToken = &cli.StringFlag{
+		Name:        "token",
+		Aliases:     []string{"t"},
+		Usage:       "(cluster) Shared secret used to join a server or agent to a cluster",
+		Destination: &ServerConfig.Token,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN"},
+	}
+	ClusterCIDR = &cli.StringSliceFlag{
+		Name:        "cluster-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for pod IPs (default: 10.42.0.0/16)",
+		Destination: &ServerConfig.ClusterCIDR,
+	}
+	ServiceCIDR = &cli.StringSliceFlag{
+		Name:        "service-cidr",
+		Usage:       "(networking) IPv4/IPv6 network CIDRs to use for service IPs (default: 10.43.0.0/16)",
+		Destination: &ServerConfig.ServiceCIDR,
+	}
+	ServiceNodePortRange = &cli.StringFlag{
+		Name:        "service-node-port-range",
+		Usage:       "(networking) Port range to reserve for services with NodePort visibility",
+		Destination: &ServerConfig.ServiceNodePortRange,
+		Value:       "30000-32767",
+	}
+	ClusterDNS = &cli.StringSliceFlag{
+		Name:        "cluster-dns",
+		Usage:       "(networking) IPv4/IPv6 Cluster IP for coredns service. Should be in your service-cidr range (default: 10.43.0.10)",
+		Destination: &ServerConfig.ClusterDNS,
+	}
+	ClusterDomain = &cli.StringFlag{
+		Name:        "cluster-domain",
+		Usage:       "(networking) Cluster Domain",
+		Destination: &ServerConfig.ClusterDomain,
+		Value:       "cluster.local",
+	}
+	ExtraAPIArgs = &cli.StringSliceFlag{
+		Name:        "kube-apiserver-arg",
+		Usage:       "(flags) Customized flag for kube-apiserver process",
+		Destination: &ServerConfig.ExtraAPIArgs,
+	}
+	ExtraEtcdArgs = &cli.StringSliceFlag{
+		Name:        "etcd-arg",
+		Usage:       "(flags) Customized flag for etcd process",
+		Destination: &ServerConfig.ExtraEtcdArgs,
+	}
+	ExtraSchedulerArgs = &cli.StringSliceFlag{
+		Name:        "kube-scheduler-arg",
+		Usage:       "(flags) Customized flag for kube-scheduler process",
+		Destination: &ServerConfig.ExtraSchedulerArgs,
+	}
+	ExtraControllerArgs = &cli.StringSliceFlag{
+		Name:        "kube-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	}
+	ExtraHelmArgs = &cli.StringSliceFlag{
+		Name:        "helm-controller-arg",
+		Usage:       "(flags) Customized flag for helm-controller process",
+		Destination: &ServerConfig.ExtraHelmArgs,
+	}
+)
+
+var ServerFlags = []cli.Flag{
+	ConfigFlag,
+	DebugFlag,
+	VLevel,
+	VModule,
+	LogFile,
+	AlsoLogToStderr,
+	BindAddressFlag,
+	&cli.IntFlag{
+		Name:        "https-listen-port",
+		Usage:       "(listener) HTTPS listen port",
+		Value:       6443,
+		Destination: &ServerConfig.HTTPSPort,
+	},
+	&cli.IntFlag{
+		Name:        "supervisor-port",
+		EnvVars:     []string{version.ProgramUpper + "_SUPERVISOR_PORT"},
+		Usage:       "(experimental) Supervisor listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.SupervisorPort,
+	},
+	&cli.IntFlag{
+		Name:        "apiserver-port",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_PORT"},
+		Usage:       "(experimental) apiserver internal listen port override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerPort,
+	},
+	&cli.StringFlag{
+		Name:        "apiserver-bind-address",
+		EnvVars:     []string{version.ProgramUpper + "_APISERVER_BIND_ADDRESS"},
+		Usage:       "(experimental) apiserver internal bind address override",
+		Hidden:      true,
+		Destination: &ServerConfig.APIServerBindAddress,
+	},
+	&cli.StringFlag{
+		Name:        "advertise-address",
+		Usage:       "(listener) IPv4/IPv6 address that apiserver uses to advertise to members of the cluster (default: node-external-ip/node-ip)",
+		Destination: &ServerConfig.AdvertiseIP,
+	},
+	&cli.IntFlag{
+		Name:        "advertise-port",
+		Usage:       "(listener) Port that apiserver uses to advertise to members of the cluster (default: https-listen-port)",
+		Destination: &ServerConfig.AdvertisePort,
+	},
+	&cli.StringSliceFlag{
+		Name:        "tls-san",
+		Usage:       "(listener) Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert",
+		Destination: &ServerConfig.TLSSan,
+	},
+	&cli.BoolFlag{
+		Name:        "tls-san-security",
+		Usage:       "(listener) Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option (default: true)",
+		Destination: &ServerConfig.TLSSanSecurity,
+		Value:       true,
+	},
+	DataDirFlag,
+	ClusterCIDR,
+	ServiceCIDR,
+	ServiceNodePortRange,
+	ClusterDNS,
+	ClusterDomain,
+	&cli.StringFlag{
+		Name:        "flannel-backend",
+		Usage:       "(networking) Backend (valid values: 'none', 'vxlan', 'host-gw', 'wireguard-native'",
+		Destination: &ServerConfig.FlannelBackend,
+		Value:       "vxlan",
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-ipv6-masq",
+		Usage:       "(networking) Enable IPv6 masquerading for pod",
+		Destination: &ServerConfig.FlannelIPv6Masq,
+	},
+	&cli.BoolFlag{
+		Name:        "flannel-external-ip",
+		Usage:       "(networking) Use node external IP addresses for Flannel traffic",
+		Destination: &ServerConfig.FlannelExternalIP,
+	},
+	&cli.StringFlag{
+		Name:        "egress-selector-mode",
+		Usage:       "(networking) One of 'agent', 'cluster', 'pod', 'disabled'",
+		Destination: &ServerConfig.EgressSelectorMode,
+		Value:       "agent",
+	},
+	&cli.StringFlag{
+		Name:        "servicelb-namespace",
+		Usage:       "(networking) Namespace of the pods for the servicelb component",
+		Destination: &ServerConfig.ServiceLBNamespace,
+		Value:       "kube-system",
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig",
+		Aliases:     []string{"o"},
+		Usage:       "(client) Write kubeconfig for admin client to this file",
+		Destination: &ServerConfig.KubeConfigOutput,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_OUTPUT"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-mode",
+		Usage:       "(client) Write kubeconfig with this mode",
+		Destination: &ServerConfig.KubeConfigMode,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_MODE"},
+	},
+	&cli.StringFlag{
+		Name:        "write-kubeconfig-group",
+		Usage:       "(client) Write kubeconfig with this group",
+		Destination: &ServerConfig.KubeConfigGroup,
+		EnvVars:     []string{version.ProgramUpper + "_KUBECONFIG_GROUP"},
+	},
+	&cli.StringFlag{
+		Name:        "helm-job-image",
+		Usage:       "(helm) (deprecated) Default image to use for helm jobs. Use --helm-controller-arg=default-job-image instead",
+		Destination: &ServerConfig.HelmJobImage,
+	},
+	ServerToken,
+	&cli.StringFlag{
+		Name:        "token-file",
+		Usage:       "(cluster) File containing the token",
+		Destination: &ServerConfig.TokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token",
+		Usage:       "(cluster) Shared secret used to join agents to the cluster, but not servers",
+		Destination: &ServerConfig.AgentToken,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN"},
+	},
+	&cli.StringFlag{
+		Name:        "agent-token-file",
+		Usage:       "(cluster) File containing the agent secret",
+		Destination: &ServerConfig.AgentTokenFile,
+		EnvVars:     []string{version.ProgramUpper + "_AGENT_TOKEN_FILE"},
+	},
+	&cli.StringFlag{
+		Name:        "server",
+		Aliases:     []string{"s"},
+		Usage:       "(cluster) Server to connect to, used to join a cluster",
+		EnvVars:     []string{version.ProgramUpper + "_URL"},
+		Destination: &ServerConfig.ServerURL,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-init",
+		Usage:       "(cluster) Initialize a new cluster using embedded Etcd",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_INIT"},
+		Destination: &ServerConfig.ClusterInit,
+	},
+	&cli.BoolFlag{
+		Name:        "cluster-reset",
+		Usage:       "(cluster) Forget all peers and become sole member of a new cluster",
+		EnvVars:     []string{version.ProgramUpper + "_CLUSTER_RESET"},
+		Destination: &ServerConfig.ClusterReset,
+	},
+	&cli.StringFlag{
+		Name:        "cluster-reset-restore-path",
+		Usage:       "(db) Path to snapshot file to be restored",
+		Destination: &ServerConfig.ClusterResetRestorePath,
+	},
+	ExtraAPIArgs,
+	ExtraEtcdArgs,
+	ExtraControllerArgs,
+	ExtraSchedulerArgs,
+	ExtraHelmArgs,
+	&cli.StringSliceFlag{
+		Name:        "kube-cloud-controller-manager-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+	&cli.BoolFlag{
+		Name:        "kine-tls",
+		Usage:       "(experimental/db) Enable TLS on the kine etcd server socket",
+		Destination: &ServerConfig.KineTLS,
+		Hidden:      true,
+	},
+	&cli.StringFlag{
+		Name:        "datastore-endpoint",
+		Usage:       "(db) Specify etcd, NATS, MySQL, Postgres, or SQLite (default) data source name",
+		Destination: &ServerConfig.DatastoreEndpoint,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_ENDPOINT"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-cafile",
+		Usage:       "(db) TLS Certificate Authority file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCAFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CAFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-certfile",
+		Usage:       "(db) TLS certification file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreCertFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_CERTFILE"},
+	},
+	&cli.StringFlag{
+		Name:        "datastore-keyfile",
+		Usage:       "(db) TLS key file used to secure datastore backend communication",
+		Destination: &ServerConfig.DatastoreKeyFile,
+		EnvVars:     []string{version.ProgramUpper + "_DATASTORE_KEYFILE"},
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-expose-metrics",
+		Usage:       "(db) Expose etcd metrics to client interface",
+		Destination: &ServerConfig.EtcdExposeMetrics,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-disable-snapshots",
+		Usage:       "(db) Disable automatic etcd snapshots",
+		Destination: &ServerConfig.EtcdDisableSnapshots,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-name",
+		Usage:       "(db) Set the base name of etcd snapshots, appended with UNIX timestamp",
+		Destination: &ServerConfig.EtcdSnapshotName,
+		Value:       "etcd-snapshot",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-schedule-cron",
+		Usage:       "(db) Snapshot interval time in cron spec. eg. every 5 hours '0 */5 * * *'",
+		Destination: &ServerConfig.EtcdSnapshotCron,
+		Value:       "0 */12 * * *",
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-snapshot-reconcile-interval",
+		Usage:       "(db) Snapshot reconcile interval",
+		Destination: &ServerConfig.EtcdSnapshotReconcile,
+		Value:       10 * time.Minute,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-snapshot-retention",
+		Usage:       "(db) Number of snapshots to retain",
+		Destination: &ServerConfig.EtcdSnapshotRetention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-snapshot-dir",
+		Usage:       "(db) Directory to save db snapshots. (default: ${data-dir}/server/db/snapshots)",
+		Destination: &ServerConfig.EtcdSnapshotDir,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-snapshot-compress",
+		Usage:       "(db) Compress etcd snapshot",
+		Destination: &ServerConfig.EtcdSnapshotCompress,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3",
+		Usage:       "(db) Enable backup to S3",
+		Destination: &ServerConfig.EtcdS3,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint",
+		Usage:       "(db) S3 endpoint url",
+		Destination: &ServerConfig.EtcdS3Endpoint,
+		Value:       "s3.amazonaws.com",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-endpoint-ca",
+		Usage:       "(db) S3 custom CA cert to connect to S3 endpoint",
+		Destination: &ServerConfig.EtcdS3EndpointCA,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-skip-ssl-verify",
+		Usage:       "(db) Disables S3 SSL certificate validation",
+		Destination: &ServerConfig.EtcdS3SkipSSLVerify,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-access-key",
+		Usage:       "(db) S3 access key",
+		EnvVars:     []string{"AWS_ACCESS_KEY_ID"},
+		Destination: &ServerConfig.EtcdS3AccessKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-secret-key",
+		Usage:       "(db) S3 secret key",
+		EnvVars:     []string{"AWS_SECRET_ACCESS_KEY"},
+		Destination: &ServerConfig.EtcdS3SecretKey,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-session-token",
+		Usage:       "(db) S3 session token",
+		EnvVars:     []string{"AWS_SESSION_TOKEN"},
+		Destination: &ServerConfig.EtcdS3SessionToken,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket",
+		Usage:       "(db) S3 bucket name",
+		Destination: &ServerConfig.EtcdS3BucketName,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-bucket-lookup-type",
+		Usage:       "(db) S3 bucket lookup type, one of 'auto', 'dns', 'path'; default is 'auto' if not set",
+		Destination: &ServerConfig.EtcdS3BucketLookupType,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-region",
+		Usage:       "(db) S3 region / bucket location (optional)",
+		Destination: &ServerConfig.EtcdS3Region,
+		Value:       "us-east-1",
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-folder",
+		Usage:       "(db) S3 folder",
+		Destination: &ServerConfig.EtcdS3Folder,
+	},
+	&cli.IntFlag{
+		Name:        "etcd-s3-retention",
+		Usage:       "(db) S3 retention limit",
+		Destination: &ServerConfig.EtcdS3Retention,
+		Value:       defaultSnapshotRentention,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-proxy",
+		Usage:       "(db) Proxy server to use when connecting to S3, overriding any proxy-releated environment variables",
+		Destination: &ServerConfig.EtcdS3Proxy,
+	},
+	&cli.StringFlag{
+		Name:        "etcd-s3-config-secret",
+		Usage:       "(db) Name of secret in the kube-system namespace used to configure S3, if etcd-s3 is enabled and no other etcd-s3 options are set",
+		Destination: &ServerConfig.EtcdS3ConfigSecret,
+	},
+	&cli.BoolFlag{
+		Name:        "etcd-s3-insecure",
+		Usage:       "(db) Disables S3 over HTTPS",
+		Destination: &ServerConfig.EtcdS3Insecure,
+	},
+	&cli.DurationFlag{
+		Name:        "etcd-s3-timeout",
+		Usage:       "(db) S3 timeout",
+		Destination: &ServerConfig.EtcdS3Timeout,
+		Value:       5 * time.Minute,
+	},
+	&cli.StringFlag{
+		Name:        "default-local-storage-path",
+		Usage:       "(storage) Default local storage path for local provisioner storage class",
+		Destination: &ServerConfig.DefaultLocalStoragePath,
+	},
+	&cli.StringSliceFlag{
+		Name:  "disable",
+		Usage: "(components) Do not deploy packaged components and delete any deployed components (valid values: " + DisableItems + ")",
+	},
+	&cli.BoolFlag{
+		Name:        "disable-scheduler",
+		Usage:       "(components) Disable Kubernetes default scheduler",
+		Destination: &ServerConfig.DisableScheduler,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-cloud-controller",
+		Usage:       "(components) Disable " + version.Program + " default cloud controller manager",
+		Destination: &ServerConfig.DisableCCM,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-kube-proxy",
+		Usage:       "(components) Disable running kube-proxy",
+		Destination: &ServerConfig.DisableKubeProxy,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-network-policy",
+		Usage:       "(components) Disable " + version.Program + " default network policy controller",
+		Destination: &ServerConfig.DisableNPC,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-helm-controller",
+		Usage:       "(components) Disable Helm controller",
+		Destination: &ServerConfig.DisableHelmController,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-apiserver",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running api server",
+		Destination: &ServerConfig.DisableAPIServer,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-controller-manager",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running kube-controller-manager",
+		Destination: &ServerConfig.DisableControllerManager,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-etcd",
+		Hidden:      true,
+		Usage:       "(experimental/components) Disable running etcd",
+		Destination: &ServerConfig.DisableETCD,
+	},
+	&cli.BoolFlag{
+		Name:        "embedded-registry",
+		Usage:       "(components) Enable embedded distributed container registry; requires use of embedded containerd; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.EmbeddedRegistry,
+	},
+	&cli.BoolFlag{
+		Name:        "supervisor-metrics",
+		Usage:       "(experimental/components) Enable serving " + version.Program + " internal metrics on the supervisor port; when enabled agents will also listen on the supervisor port",
+		Destination: &ServerConfig.SupervisorMetrics,
+	},
+	NodeNameFlag,
+	WithNodeIDFlag,
+	NodeLabels,
+	NodeTaints,
+	ImageCredProvBinDirFlag,
+	ImageCredProvConfigFlag,
+	DockerFlag,
+	CRIEndpointFlag,
+	DefaultRuntimeFlag,
+	ImageServiceEndpointFlag,
+	DisableDefaultRegistryEndpointFlag,
+	NonrootDevicesFlag,
+	PauseImageFlag,
+	SnapshotterFlag,
+	PrivateRegistryFlag,
+	&cli.StringFlag{
+		Name:        "system-default-registry",
+		Usage:       "(agent/runtime) Private registry to be used for all system images",
+		EnvVars:     []string{version.ProgramUpper + "_SYSTEM_DEFAULT_REGISTRY"},
+		Destination: &ServerConfig.SystemDefaultRegistry,
+	},
+	AirgapExtraRegistryFlag,
+	NodeIPFlag,
+	NodeExternalIPFlag,
+	NodeInternalDNSFlag,
+	NodeExternalDNSFlag,
+	ResolvConfFlag,
+	FlannelIfaceFlag,
+	FlannelConfFlag,
+	FlannelCniConfFileFlag,
+	VPNAuth,
+	VPNAuthFile,
+	ExtraKubeletArgs,
+	ExtraKubeProxyArgs,
+	ProtectKernelDefaultsFlag,
+	&cli.BoolFlag{
+		Name:        "secrets-encryption",
+		Usage:       "Enable secret encryption at rest",
+		Destination: &ServerConfig.EncryptSecrets,
+	},
+	// Experimental flags
+	EnablePProfFlag,
+	&cli.BoolFlag{
+		Name:        "rootless",
+		Usage:       "(experimental) Run rootless",
+		Destination: &ServerConfig.Rootless,
+	},
+	&cli.StringFlag{
+		Name:        "secrets-encryption-provider",
+		Usage:       "(experimental) Secret encryption provider (valid values: 'aescbc', 'secretbox')",
+		Destination: &ServerConfig.EncryptProvider,
+		Value:       "aescbc",
+	},
+	PreferBundledBin,
+	SELinuxFlag,
+	LBServerPortFlag,
+
+	// Hidden/Deprecated flags below
+
+	&cli.BoolFlag{
+		Name:        "disable-agent",
+		Usage:       "Do not run a local agent and register a local kubelet",
+		Hidden:      true,
+		Destination: &ServerConfig.DisableAgent,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-controller-arg",
+		Usage:       "(flags) Customized flag for kube-controller-manager process",
+		Destination: &ServerConfig.ExtraControllerArgs,
+	},
+	&cli.StringSliceFlag{
+		Hidden:      true,
+		Name:        "kube-cloud-controller-arg",
+		Usage:       "(flags) Customized flag for kube-cloud-controller-manager process",
+		Destination: &ServerConfig.ExtraCloudControllerArgs,
+	},
+}
+
+func NewServerCommand(action func(*cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "server",
+		Usage:     "Run management server",
+		UsageText: appName + " server [OPTIONS]",
+		Action:    action,
+		Flags:     ServerFlags,
+	}
+}

--- a/thirdparty-src/pins.json
+++ b/thirdparty-src/pins.json
@@ -1,0 +1,32 @@
+{
+  "distros": [
+    {
+      "name": "k3s",
+      "repo": "https://github.com/k3s-io/k3s",
+      "files": [
+        "pkg/cli/cmds/server.go",
+        "pkg/cli/cmds/agent.go"
+      ],
+      "tags": [
+        "v1.36.4+k3s1",
+        "v1.35.8+k3s1",
+        "v1.34.11+k3s1"
+      ]
+    },
+    {
+      "name": "rke2",
+      "repo": "https://github.com/rancher/rke2",
+      "files": [
+        "pkg/cli/cmds/server.go",
+        "pkg/cli/cmds/agent.go",
+        "pkg/cli/cmds/root.go",
+        "pkg/cli/cmds/k3sopts.go"
+      ],
+      "tags": [
+        "v1.36.4+rke2r1",
+        "v1.35.8+rke2r1",
+        "v1.34.11+rke2r1"
+      ]
+    }
+  ]
+}

--- a/thirdparty-src/rke2/v1_31/SOURCE.txt
+++ b/thirdparty-src/rke2/v1_31/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/rancher/rke2
+tag:    v1.31.14+rke2r1
+commit: a594ea8cf80ad7b2b55f1b0286b34c8af7d53c30
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go pkg/cli/cmds/root.go pkg/cli/cmds/k3sopts.go

--- a/thirdparty-src/rke2/v1_31/zz_agent.go
+++ b/thirdparty-src/rke2/v1_31/zz_agent.go
@@ -1,0 +1,109 @@
+package cmds
+
+import (
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/rke2/pkg/windows"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	k3sAgentBase = mustCmdFromK3S(cmds.NewAgentCommand(AgentRun), K3SFlagSet{
+		"config":          copyFlag,
+		"debug":           copyFlag,
+		"v":               hideFlag,
+		"vmodule":         hideFlag,
+		"log":             hideFlag,
+		"alsologtostderr": hideFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"disable-apiserver-lb":              dropFlag,
+		"private-registry":                  copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"server":                            copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"bind-address":                      copyFlag,
+		"enable-pprof":                      copyFlag,
+	})
+	deprecatedFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "system-default-registry",
+			Usage:   "(deprecated) This flag is no longer supported on agents",
+			EnvVars: []string{"RKE2_SYSTEM_DEFAULT_REGISTRY"},
+			Hidden:  true,
+		},
+	}
+)
+
+func NewAgentCommand() *cli.Command {
+	cmd := k3sAgentBase
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	cmd.Flags = append(cmd.Flags, deprecatedFlags...)
+	cmd.Subcommands = agentSubcommands()
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func agentSubcommands() []*cli.Command {
+	subcommands := []*cli.Command{
+		// subcommands used by both windows/linux, none yet
+	}
+
+	// linux/windows only subcommands
+	subcommands = append(subcommands, serviceSubcommand)
+
+	return subcommands
+}
+
+func AgentRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Agent)
+	validateProfile(clx, Agent)
+	isWinService, err := windows.StartService()
+	if err != nil {
+		return err
+	}
+
+	err = rke2.Agent(clx, config)
+	if isWinService {
+		windows.MonitorProcessExit()
+	}
+
+	return err
+}

--- a/thirdparty-src/rke2/v1_31/zz_k3sopts.go
+++ b/thirdparty-src/rke2/v1_31/zz_k3sopts.go
@@ -1,0 +1,153 @@
+package cmds
+
+import (
+	"fmt"
+	"strings"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/rancher/wrangler/v3/pkg/merr"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	copyFlag   = &K3SFlagOption{}
+	dropFlag   = &K3SFlagOption{Drop: true}
+	hideFlag   = &K3SFlagOption{Hide: true}
+	ignoreFlag = &K3SFlagOption{Ignore: true}
+)
+
+// K3SFlagOption describes how a CLI flag from K3s should be wrapped.
+type K3SFlagOption struct {
+	Hide    bool
+	Drop    bool
+	Ignore  bool
+	Usage   string
+	Default string
+}
+
+// K3SFlagSet is a map of flag names to options
+type K3SFlagSet map[string]*K3SFlagOption
+
+// CopyInto copies flags from a source set into the destination
+func (k K3SFlagSet) CopyInto(d K3SFlagSet) {
+	for key, val := range k {
+		d[key] = val
+	}
+}
+
+func mustCmdFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) *cli.Command {
+	cmd, err := commandFromK3S(cmd, flagOpts)
+	if err != nil {
+		panic(pkgerrors.WithMessagef(err, "failed to wrap command %q", cmd.Name))
+	}
+	return cmd
+}
+
+func commandFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) (*cli.Command, error) {
+	var (
+		newFlags []cli.Flag
+		seen     = map[string]bool{}
+		errs     merr.Errors
+	)
+
+	for _, flag := range cmd.Flags {
+		name := parseName(flag)
+		opt, ok := flagOpts[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("missing flag options for k3s flag %q", name))
+			continue
+		}
+		seen[name] = true
+		if opt == nil {
+			opt = &K3SFlagOption{}
+		}
+
+		if opt.Drop {
+			continue
+		}
+
+		if strFlag, ok := flag.(*cli.StringFlag); ok {
+			if opt.Usage != "" {
+				strFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				strFlag.Value = opt.Default
+			}
+			if opt.Hide {
+				strFlag.Hidden = true
+			}
+			flag = strFlag
+		} else if strSliceFlag, ok := flag.(*cli.StringSliceFlag); ok {
+			if opt.Usage != "" {
+				strSliceFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				slice := &cli.StringSlice{}
+				parts := strings.Split(opt.Default, ",")
+				for _, val := range parts {
+					slice.Set(val)
+				}
+				strSliceFlag.Value = slice
+			}
+			if opt.Hide {
+				strSliceFlag.Hidden = true
+			}
+			flag = strSliceFlag
+		} else if intFlag, ok := flag.(*cli.IntFlag); ok {
+			if opt.Usage != "" {
+				intFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				intFlag.Hidden = true
+			}
+			flag = intFlag
+		} else if boolFlag, ok := flag.(*cli.BoolFlag); ok {
+			if opt.Usage != "" {
+				boolFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				boolFlag.Hidden = true
+			}
+			flag = boolFlag
+		} else if durationFlag, ok := flag.(*cli.DurationFlag); ok {
+			if opt.Usage != "" {
+				durationFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				durationFlag.Hidden = true
+			}
+			flag = durationFlag
+		} else {
+			errs = append(errs, fmt.Errorf("unsupported type %T for flag %q", flag, name))
+		}
+
+		newFlags = append(newFlags, flag)
+	}
+
+	for k, v := range flagOpts {
+		if !seen[k] {
+			if v != nil && v.Ignore {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("got flag options for unknown k3s flag %q", k))
+			continue
+		}
+	}
+
+	cmd.Flags = newFlags
+	return cmd, errs.Err()
+}
+
+// parseName returns a single primary flag name.
+// Flags with short versions may be named "flag", "flag,f", "f,flag", "flag, f" and so on.
+// This returns just the first long version, or the short version if no long is available.
+func parseName(flag cli.Flag) string {
+	names := flag.Names()
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if len(n) > 1 {
+			return n
+		}
+	}
+	return strings.TrimSpace(names[0])
+}

--- a/thirdparty-src/rke2/v1_31/zz_root.go
+++ b/thirdparty-src/rke2/v1_31/zz_root.go
@@ -1,0 +1,253 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/podtemplate"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	appName    = filepath.Base(os.Args[0])
+	config     = rke2cli.Config{}
+	commonFlag = []cli.Flag{
+		&cli.StringFlag{
+			Name:        images.KubeAPIServer,
+			Usage:       "(image) Override image to use for kube-apiserver",
+			EnvVars:     []string{"RKE2_KUBE_APISERVER_IMAGE"},
+			Destination: &config.Images.KubeAPIServer,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeControllerManager,
+			Usage:       "(image) Override image to use for kube-controller-manager",
+			EnvVars:     []string{"RKE2_KUBE_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.KubeControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.CloudControllerManager,
+			Usage:       "(image) Override image to use for cloud-controller-manager",
+			EnvVars:     []string{"RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.CloudControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeProxy,
+			Usage:       "(image) Override image to use for kube-proxy",
+			EnvVars:     []string{"RKE2_KUBE_PROXY_IMAGE"},
+			Destination: &config.Images.KubeProxy,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeScheduler,
+			Usage:       "(image) Override image to use for kube-scheduler",
+			EnvVars:     []string{"RKE2_KUBE_SCHEDULER_IMAGE"},
+			Destination: &config.Images.KubeScheduler,
+		},
+		&cli.StringFlag{
+			Name:        images.Pause,
+			Usage:       "(image) Override image to use for pause",
+			EnvVars:     []string{"RKE2_PAUSE_IMAGE"},
+			Destination: &config.Images.Pause,
+		},
+		&cli.StringFlag{
+			Name:        images.Runtime,
+			Usage:       "(image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc)",
+			EnvVars:     []string{"RKE2_RUNTIME_IMAGE"},
+			Destination: &config.Images.Runtime,
+		},
+		&cli.StringFlag{
+			Name:        images.ETCD,
+			Usage:       "(image) Override image to use for etcd",
+			EnvVars:     []string{"RKE2_ETCD_IMAGE"},
+			Destination: &config.Images.ETCD,
+		},
+		&cli.StringFlag{
+			Name:        "kubelet-path",
+			Usage:       "(experimental/agent) Override kubelet binary path",
+			EnvVars:     []string{"RKE2_KUBELET_PATH"},
+			Destination: &config.KubeletPath,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-name",
+			Usage:       "(cloud provider) Cloud provider name",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_NAME"},
+			Destination: &config.CloudProviderName,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-config",
+			Usage:       "(cloud provider) Cloud provider configuration file path",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_CONFIG"},
+			Destination: &config.CloudProviderConfig,
+		},
+		&cli.BoolFlag{
+			Name:        "node-name-from-cloud-provider-metadata",
+			Usage:       "(cloud provider) Set node name from instance metadata service hostname",
+			EnvVars:     []string{"RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA"},
+			Destination: &config.CloudProviderMetadataHostname,
+		},
+		&cli.StringFlag{
+			Name:    "profile",
+			Usage:   "(security) Validate system configuration against the selected benchmark (valid items: cis, etcd)",
+			EnvVars: []string{"RKE2_CIS_PROFILE"},
+		},
+		&cli.StringFlag{
+			Name:        "audit-policy-file",
+			Usage:       "(security) Path to the file that defines the audit policy configuration",
+			EnvVars:     []string{"RKE2_AUDIT_POLICY_FILE"},
+			Destination: &config.AuditPolicyFile,
+		},
+		&cli.StringFlag{
+			Name:        "pod-security-admission-config-file",
+			Usage:       "(security) Path to the file that defines Pod Security Admission configuration",
+			EnvVars:     []string{"RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE"},
+			Destination: &config.PodSecurityAdmissionConfigFile,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-requests",
+			Usage:       "(components) Control Plane resource requests",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_REQUESTS"},
+			Destination: &config.ControlPlaneResourceRequests,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-limits",
+			Usage:       "(components) Control Plane resource limits",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_LIMITS"},
+			Destination: &config.ControlPlaneResourceLimits,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-probe-configuration",
+			Usage:       "(components) Control Plane Probe configuration",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_PROBE_CONFIGURATION"},
+			Destination: &config.ControlPlaneProbeConf,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-mount",
+			Usage:       "(components) " + podtemplate.Etcd + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.CloudControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-env",
+			Usage:       "(components) " + podtemplate.Etcd + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.CloudControllerManager,
+		},
+	}
+)
+
+type CLIRole int64
+
+const (
+	Agent CLIRole = iota
+	Server
+)
+
+func init() {
+	// hack - force "file,dns" lookup order if go dns is used
+	if os.Getenv("RES_OPTIONS") == "" {
+		os.Setenv("RES_OPTIONS", " ")
+	}
+}
+
+func validateCloudProviderName(clx *cli.Context, role CLIRole) {
+	cloudProvider := clx.String("cloud-provider-name")
+	cloudProviderDisables := map[string][]string{
+		"rancher-vsphere": {"rancher-vsphere-cpi", "rancher-vsphere-csi"},
+		"harvester":       {"harvester-cloud-provider", "harvester-csi-driver"},
+	}
+
+	for providerName, disables := range cloudProviderDisables {
+		if providerName == cloudProvider {
+			clx.Set("cloud-provider-name", "external")
+			if role == Server {
+				clx.Set("disable-cloud-controller", "true")
+			}
+		} else {
+			if role == Server {
+				for _, disable := range disables {
+					clx.Set("disable", disable)
+				}
+			}
+		}
+	}
+}
+
+func NewApp() *cli.App {
+	app := cli.NewApp()
+	app.Name = appName
+	app.EnableBashCompletion = true
+	app.DisableSliceFlagSeparator = true
+	app.Usage = "Rancher Kubernetes Engine 2"
+	app.Version = fmt.Sprintf("%s (%s)", version.Version, version.GitCommit)
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s version %s\n", app.Name, app.Version)
+		fmt.Printf("go version %s\n", runtime.Version())
+	}
+
+	return app
+}

--- a/thirdparty-src/rke2/v1_31/zz_server.go
+++ b/thirdparty-src/rke2/v1_31/zz_server.go
@@ -1,0 +1,273 @@
+package cmds
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/wrangler/v3/pkg/slice"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	rke2Path = "/var/lib/rancher/rke2"
+)
+
+var (
+	CNIFlag = &cli.StringSliceFlag{
+		Name:        "cni",
+		Usage:       "(networking) CNI Plugins to deploy, one of none, " + strings.Join(rke2cli.CNIItems, ", ") + "; optionally with multus as the first value to enable the multus meta-plugin",
+		EnvVars:     []string{"RKE2_CNI"},
+		Value:       cli.NewStringSlice("canal"),
+		Destination: &config.CNI,
+	}
+	IngressControllerFlag = &cli.StringSliceFlag{
+		Name:        "ingress-controller",
+		Usage:       "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
+		EnvVars:     []string{"RKE_INGRESS_CONTROLLER"},
+		Value:       cli.NewStringSlice("ingress-nginx"),
+		Destination: &config.IngressController,
+	}
+	ServiceLBFlag = &cli.BoolFlag{
+		Name:    "enable-servicelb",
+		Usage:   "(components) Enable rke2 default cloud controller manager's service controller",
+		EnvVars: []string{"RKE2_ENABLE_SERVICELB"},
+	}
+
+	serverFlag = []cli.Flag{
+		CNIFlag,
+		IngressControllerFlag,
+		ServiceLBFlag,
+	}
+
+	k3sServerBase = mustCmdFromK3S(cmds.NewServerCommand(ServerRun), K3SFlagSet{
+		"config":                 copyFlag,
+		"debug":                  copyFlag,
+		"v":                      hideFlag,
+		"vmodule":                hideFlag,
+		"log":                    hideFlag,
+		"alsologtostderr":        hideFlag,
+		"bind-address":           copyFlag,
+		"https-listen-port":      dropFlag,
+		"supervisor-port":        dropFlag,
+		"apiserver-port":         dropFlag,
+		"apiserver-bind-address": dropFlag,
+		"advertise-address":      copyFlag,
+		"advertise-port":         dropFlag,
+		"tls-san":                copyFlag,
+		"tls-san-security":       copyFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"disable-agent":                     hideFlag,
+		"cluster-cidr":                      copyFlag,
+		"service-cidr":                      copyFlag,
+		"cluster-init":                      dropFlag,
+		"cluster-reset":                     copyFlag,
+		"cluster-reset-restore-path":        copyFlag,
+		"cluster-dns":                       copyFlag,
+		"cluster-domain":                    copyFlag,
+		"flannel-backend":                   dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"write-kubeconfig":                  copyFlag,
+		"write-kubeconfig-mode":             copyFlag,
+		"write-kubeconfig-group":            copyFlag,
+		"kube-apiserver-arg":                copyFlag,
+		"etcd-arg":                          copyFlag,
+		"kube-scheduler-arg":                copyFlag,
+		"kube-controller-arg":               dropFlag, // deprecated version of kube-controller-manager-arg
+		"kube-controller-manager-arg":       copyFlag,
+		"kube-cloud-controller-manager-arg": copyFlag,
+		"kube-cloud-controller-arg":         dropFlag, // deprecated version of kube-cloud-controller-manager-arg
+		"datastore-endpoint":                copyFlag,
+		"datastore-cafile":                  copyFlag,
+		"datastore-certfile":                copyFlag,
+		"datastore-keyfile":                 copyFlag,
+		"kine-tls":                          dropFlag,
+		"default-local-storage-path":        dropFlag,
+		"disable": {
+			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + strings.Join(rke2cli.DisableItems, ", ") + ")",
+		},
+		"disable-scheduler":                 copyFlag,
+		"disable-cloud-controller":          copyFlag,
+		"disable-network-policy":            dropFlag,
+		"disable-kube-proxy":                copyFlag,
+		"disable-apiserver":                 copyFlag,
+		"disable-controller-manager":        copyFlag,
+		"disable-etcd":                      copyFlag,
+		"etcd-disable-snapshots":            copyFlag,
+		"etcd-snapshot-schedule-cron":       copyFlag,
+		"etcd-snapshot-reconcile-interval":  copyFlag,
+		"etcd-snapshot-retention":           copyFlag,
+		"etcd-snapshot-dir":                 copyFlag,
+		"etcd-snapshot-name":                copyFlag,
+		"etcd-snapshot-compress":            copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"embedded-registry":                 copyFlag,
+		"supervisor-metrics":                copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"private-registry":                  copyFlag,
+		"system-default-registry":           copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"flannel-ipv6-masq":                 dropFlag,
+		"flannel-external-ip":               dropFlag,
+		"egress-selector-mode":              copyFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"agent-token":                       copyFlag,
+		"agent-token-file":                  copyFlag,
+		"server":                            copyFlag,
+		"secrets-encryption":                hideFlag,
+		"secrets-encryption-provider":       copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"service-node-port-range":           copyFlag,
+		"etcd-expose-metrics":               copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"etcd-s3":                           copyFlag,
+		"etcd-s3-access-key":                copyFlag,
+		"etcd-s3-bucket":                    copyFlag,
+		"etcd-s3-bucket-lookup-type":        copyFlag,
+		"etcd-s3-config-secret":             copyFlag,
+		"etcd-s3-endpoint":                  copyFlag,
+		"etcd-s3-endpoint-ca":               copyFlag,
+		"etcd-s3-folder":                    copyFlag,
+		"etcd-s3-insecure":                  copyFlag,
+		"etcd-s3-proxy":                     copyFlag,
+		"etcd-s3-region":                    copyFlag,
+		"etcd-s3-secret-key":                copyFlag,
+		"etcd-s3-session-token":             copyFlag,
+		"etcd-s3-skip-ssl-verify":           copyFlag,
+		"etcd-s3-timeout":                   copyFlag,
+		"etcd-s3-retention":                 copyFlag,
+		"disable-helm-controller":           dropFlag,
+		"helm-job-image":                    copyFlag,
+		"enable-pprof":                      copyFlag,
+		"servicelb-namespace":               copyFlag,
+	})
+)
+
+func NewServerCommand() *cli.Command {
+	cmd := k3sServerBase
+	cmd.Flags = append(cmd.Flags, serverFlag...)
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func ServerRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Server)
+	validateProfile(clx, Server)
+	validateCNI(clx)
+	validateIngress(clx)
+	return rke2.Server(clx, config)
+}
+
+// validateCNI validates the CNI selection, and disables any un-selected CNI charts
+func validateCNI(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.CNIItems, CNIFlag, func(values []string) ([]string, error) {
+		switch len(values) {
+		case 0:
+			values = append(values, "canal")
+			fallthrough
+		case 1:
+			if values[0] == "multus" {
+				return nil, errors.New("multus must be used alongside another primary cni selection")
+			}
+			clx.Set("disable", "rke2-multus")
+		case 2:
+			if values[0] == "multus" {
+				values = values[1:]
+			} else {
+				return nil, errors.New("may only provide multiple values if multus is the first value")
+			}
+		default:
+			return nil, errors.New("must specify 1 or 2 values")
+		}
+		return values, nil
+	})
+}
+
+// validateCNI validates the ingress controller selection, and disables any un-selected ingress controller charts
+func validateIngress(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.IngressItems, IngressControllerFlag, func(values []string) ([]string, error) {
+		return values, nil
+	})
+}
+
+// disableExceptSelected takes a list of valid flag values, and a CLI StringSlice flag that holds the user's selected values.
+// Selected values are split to support comma-separated lists, in addition to repeated use of the same flag.
+// Once the list has been split, a validation function is called to allow for custom validation or defaulting of selected values.
+// Finally, charts for any valid items not selected are added to the --disable list.
+// A value of 'none' will cause all valid items to be disabled.
+// Errors from the validation function, or selection of a value not in the valid list, will cause a fatal error to be logged.
+func disableExceptSelected(clx *cli.Context, valid []string, flag *cli.StringSliceFlag, validateFunc func([]string) ([]string, error)) {
+	// split comma-separated values
+	values := []string{}
+	for _, v := range clx.StringSlice(flag.Name) {
+		values = append(values, strings.Split(v, ",")...)
+	}
+	// validate the flag after splitting values
+	if v, err := validateFunc(values); err != nil {
+		logrus.Fatalf("Failed to validate --%s flag: %v", flag.Name, err)
+	} else {
+		values = v
+	}
+
+	// prepare a list of items to disable, based on all valid components.
+	// we have to use an intermediate set because the flag interface
+	// doesn't allow us to remove flag values once added.
+	disabledCharts := sets.Set[string]{}
+	for _, d := range valid {
+		disabledCharts.Insert("rke2-"+d, "rke2-"+d+"-crd")
+	}
+
+	// re-enable components for any selected flag values
+	for _, d := range values {
+		switch {
+		case d == "none":
+			continue
+		case slice.ContainsString(valid, d):
+			disabledCharts.Delete("rke2-"+d, "rke2-"+d+"-crd")
+		default:
+			logrus.Fatalf("Invalid value %s for --%s flag: must be one of %s", d, flag.Name, strings.Join(valid, ","))
+		}
+	}
+
+	for _, c := range disabledCharts.UnsortedList() {
+		clx.Set("disable", c)
+	}
+}

--- a/thirdparty-src/rke2/v1_32/SOURCE.txt
+++ b/thirdparty-src/rke2/v1_32/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/rancher/rke2
+tag:    v1.32.13+rke2r1
+commit: a361386c83e8e581c2634a408bc7e4dd44fdcedc
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go pkg/cli/cmds/root.go pkg/cli/cmds/k3sopts.go

--- a/thirdparty-src/rke2/v1_32/zz_agent.go
+++ b/thirdparty-src/rke2/v1_32/zz_agent.go
@@ -1,0 +1,109 @@
+package cmds
+
+import (
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/rke2/pkg/windows"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	k3sAgentBase = mustCmdFromK3S(cmds.NewAgentCommand(AgentRun), K3SFlagSet{
+		"config":          copyFlag,
+		"debug":           copyFlag,
+		"v":               hideFlag,
+		"vmodule":         hideFlag,
+		"log":             hideFlag,
+		"alsologtostderr": hideFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"disable-apiserver-lb":              dropFlag,
+		"private-registry":                  copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"server":                            copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"bind-address":                      copyFlag,
+		"enable-pprof":                      copyFlag,
+	})
+	deprecatedFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "system-default-registry",
+			Usage:   "(deprecated) This flag is no longer supported on agents",
+			EnvVars: []string{"RKE2_SYSTEM_DEFAULT_REGISTRY"},
+			Hidden:  true,
+		},
+	}
+)
+
+func NewAgentCommand() *cli.Command {
+	cmd := k3sAgentBase
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	cmd.Flags = append(cmd.Flags, deprecatedFlags...)
+	cmd.Subcommands = agentSubcommands()
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func agentSubcommands() []*cli.Command {
+	subcommands := []*cli.Command{
+		// subcommands used by both windows/linux, none yet
+	}
+
+	// linux/windows only subcommands
+	subcommands = append(subcommands, serviceSubcommand)
+
+	return subcommands
+}
+
+func AgentRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Agent)
+	validateProfile(clx, Agent)
+	isWinService, err := windows.StartService()
+	if err != nil {
+		return err
+	}
+
+	err = rke2.Agent(clx, config)
+	if isWinService {
+		windows.MonitorProcessExit()
+	}
+
+	return err
+}

--- a/thirdparty-src/rke2/v1_32/zz_k3sopts.go
+++ b/thirdparty-src/rke2/v1_32/zz_k3sopts.go
@@ -1,0 +1,153 @@
+package cmds
+
+import (
+	"fmt"
+	"strings"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/rancher/wrangler/v3/pkg/merr"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	copyFlag   = &K3SFlagOption{}
+	dropFlag   = &K3SFlagOption{Drop: true}
+	hideFlag   = &K3SFlagOption{Hide: true}
+	ignoreFlag = &K3SFlagOption{Ignore: true}
+)
+
+// K3SFlagOption describes how a CLI flag from K3s should be wrapped.
+type K3SFlagOption struct {
+	Hide    bool
+	Drop    bool
+	Ignore  bool
+	Usage   string
+	Default string
+}
+
+// K3SFlagSet is a map of flag names to options
+type K3SFlagSet map[string]*K3SFlagOption
+
+// CopyInto copies flags from a source set into the destination
+func (k K3SFlagSet) CopyInto(d K3SFlagSet) {
+	for key, val := range k {
+		d[key] = val
+	}
+}
+
+func mustCmdFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) *cli.Command {
+	cmd, err := commandFromK3S(cmd, flagOpts)
+	if err != nil {
+		panic(pkgerrors.WithMessagef(err, "failed to wrap command %q", cmd.Name))
+	}
+	return cmd
+}
+
+func commandFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) (*cli.Command, error) {
+	var (
+		newFlags []cli.Flag
+		seen     = map[string]bool{}
+		errs     merr.Errors
+	)
+
+	for _, flag := range cmd.Flags {
+		name := parseName(flag)
+		opt, ok := flagOpts[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("missing flag options for k3s flag %q", name))
+			continue
+		}
+		seen[name] = true
+		if opt == nil {
+			opt = &K3SFlagOption{}
+		}
+
+		if opt.Drop {
+			continue
+		}
+
+		if strFlag, ok := flag.(*cli.StringFlag); ok {
+			if opt.Usage != "" {
+				strFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				strFlag.Value = opt.Default
+			}
+			if opt.Hide {
+				strFlag.Hidden = true
+			}
+			flag = strFlag
+		} else if strSliceFlag, ok := flag.(*cli.StringSliceFlag); ok {
+			if opt.Usage != "" {
+				strSliceFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				slice := &cli.StringSlice{}
+				parts := strings.Split(opt.Default, ",")
+				for _, val := range parts {
+					slice.Set(val)
+				}
+				strSliceFlag.Value = slice
+			}
+			if opt.Hide {
+				strSliceFlag.Hidden = true
+			}
+			flag = strSliceFlag
+		} else if intFlag, ok := flag.(*cli.IntFlag); ok {
+			if opt.Usage != "" {
+				intFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				intFlag.Hidden = true
+			}
+			flag = intFlag
+		} else if boolFlag, ok := flag.(*cli.BoolFlag); ok {
+			if opt.Usage != "" {
+				boolFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				boolFlag.Hidden = true
+			}
+			flag = boolFlag
+		} else if durationFlag, ok := flag.(*cli.DurationFlag); ok {
+			if opt.Usage != "" {
+				durationFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				durationFlag.Hidden = true
+			}
+			flag = durationFlag
+		} else {
+			errs = append(errs, fmt.Errorf("unsupported type %T for flag %q", flag, name))
+		}
+
+		newFlags = append(newFlags, flag)
+	}
+
+	for k, v := range flagOpts {
+		if !seen[k] {
+			if v != nil && v.Ignore {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("got flag options for unknown k3s flag %q", k))
+			continue
+		}
+	}
+
+	cmd.Flags = newFlags
+	return cmd, errs.Err()
+}
+
+// parseName returns a single primary flag name.
+// Flags with short versions may be named "flag", "flag,f", "f,flag", "flag, f" and so on.
+// This returns just the first long version, or the short version if no long is available.
+func parseName(flag cli.Flag) string {
+	names := flag.Names()
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if len(n) > 1 {
+			return n
+		}
+	}
+	return strings.TrimSpace(names[0])
+}

--- a/thirdparty-src/rke2/v1_32/zz_root.go
+++ b/thirdparty-src/rke2/v1_32/zz_root.go
@@ -1,0 +1,253 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/podtemplate"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	appName    = filepath.Base(os.Args[0])
+	config     = rke2cli.Config{}
+	commonFlag = []cli.Flag{
+		&cli.StringFlag{
+			Name:        images.KubeAPIServer,
+			Usage:       "(image) Override image to use for kube-apiserver",
+			EnvVars:     []string{"RKE2_KUBE_APISERVER_IMAGE"},
+			Destination: &config.Images.KubeAPIServer,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeControllerManager,
+			Usage:       "(image) Override image to use for kube-controller-manager",
+			EnvVars:     []string{"RKE2_KUBE_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.KubeControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.CloudControllerManager,
+			Usage:       "(image) Override image to use for cloud-controller-manager",
+			EnvVars:     []string{"RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.CloudControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeProxy,
+			Usage:       "(image) Override image to use for kube-proxy",
+			EnvVars:     []string{"RKE2_KUBE_PROXY_IMAGE"},
+			Destination: &config.Images.KubeProxy,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeScheduler,
+			Usage:       "(image) Override image to use for kube-scheduler",
+			EnvVars:     []string{"RKE2_KUBE_SCHEDULER_IMAGE"},
+			Destination: &config.Images.KubeScheduler,
+		},
+		&cli.StringFlag{
+			Name:        images.Pause,
+			Usage:       "(image) Override image to use for pause",
+			EnvVars:     []string{"RKE2_PAUSE_IMAGE"},
+			Destination: &config.Images.Pause,
+		},
+		&cli.StringFlag{
+			Name:        images.Runtime,
+			Usage:       "(image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc)",
+			EnvVars:     []string{"RKE2_RUNTIME_IMAGE"},
+			Destination: &config.Images.Runtime,
+		},
+		&cli.StringFlag{
+			Name:        images.ETCD,
+			Usage:       "(image) Override image to use for etcd",
+			EnvVars:     []string{"RKE2_ETCD_IMAGE"},
+			Destination: &config.Images.ETCD,
+		},
+		&cli.StringFlag{
+			Name:        "kubelet-path",
+			Usage:       "(experimental/agent) Override kubelet binary path",
+			EnvVars:     []string{"RKE2_KUBELET_PATH"},
+			Destination: &config.KubeletPath,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-name",
+			Usage:       "(cloud provider) Cloud provider name",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_NAME"},
+			Destination: &config.CloudProviderName,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-config",
+			Usage:       "(cloud provider) Cloud provider configuration file path",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_CONFIG"},
+			Destination: &config.CloudProviderConfig,
+		},
+		&cli.BoolFlag{
+			Name:        "node-name-from-cloud-provider-metadata",
+			Usage:       "(cloud provider) Set node name from instance metadata service hostname",
+			EnvVars:     []string{"RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA"},
+			Destination: &config.CloudProviderMetadataHostname,
+		},
+		&cli.StringFlag{
+			Name:    "profile",
+			Usage:   "(security) Validate system configuration against the selected benchmark (valid items: cis, etcd)",
+			EnvVars: []string{"RKE2_CIS_PROFILE"},
+		},
+		&cli.StringFlag{
+			Name:        "audit-policy-file",
+			Usage:       "(security) Path to the file that defines the audit policy configuration",
+			EnvVars:     []string{"RKE2_AUDIT_POLICY_FILE"},
+			Destination: &config.AuditPolicyFile,
+		},
+		&cli.StringFlag{
+			Name:        "pod-security-admission-config-file",
+			Usage:       "(security) Path to the file that defines Pod Security Admission configuration",
+			EnvVars:     []string{"RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE"},
+			Destination: &config.PodSecurityAdmissionConfigFile,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-requests",
+			Usage:       "(components) Control Plane resource requests",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_REQUESTS"},
+			Destination: &config.ControlPlaneResourceRequests,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-limits",
+			Usage:       "(components) Control Plane resource limits",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_LIMITS"},
+			Destination: &config.ControlPlaneResourceLimits,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-probe-configuration",
+			Usage:       "(components) Control Plane Probe configuration",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_PROBE_CONFIGURATION"},
+			Destination: &config.ControlPlaneProbeConf,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-mount",
+			Usage:       "(components) " + podtemplate.Etcd + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.CloudControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-env",
+			Usage:       "(components) " + podtemplate.Etcd + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.CloudControllerManager,
+		},
+	}
+)
+
+type CLIRole int64
+
+const (
+	Agent CLIRole = iota
+	Server
+)
+
+func init() {
+	// hack - force "file,dns" lookup order if go dns is used
+	if os.Getenv("RES_OPTIONS") == "" {
+		os.Setenv("RES_OPTIONS", " ")
+	}
+}
+
+func validateCloudProviderName(clx *cli.Context, role CLIRole) {
+	cloudProvider := clx.String("cloud-provider-name")
+	cloudProviderDisables := map[string][]string{
+		"rancher-vsphere": {"rancher-vsphere-cpi", "rancher-vsphere-csi"},
+		"harvester":       {"harvester-cloud-provider", "harvester-csi-driver"},
+	}
+
+	for providerName, disables := range cloudProviderDisables {
+		if providerName == cloudProvider {
+			clx.Set("cloud-provider-name", "external")
+			if role == Server {
+				clx.Set("disable-cloud-controller", "true")
+			}
+		} else {
+			if role == Server {
+				for _, disable := range disables {
+					clx.Set("disable", disable)
+				}
+			}
+		}
+	}
+}
+
+func NewApp() *cli.App {
+	app := cli.NewApp()
+	app.Name = appName
+	app.EnableBashCompletion = true
+	app.DisableSliceFlagSeparator = true
+	app.Usage = "Rancher Kubernetes Engine 2"
+	app.Version = fmt.Sprintf("%s (%s)", version.Version, version.GitCommit)
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s version %s\n", app.Name, app.Version)
+		fmt.Printf("go version %s\n", runtime.Version())
+	}
+
+	return app
+}

--- a/thirdparty-src/rke2/v1_32/zz_server.go
+++ b/thirdparty-src/rke2/v1_32/zz_server.go
@@ -1,0 +1,273 @@
+package cmds
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/wrangler/v3/pkg/slice"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	rke2Path = "/var/lib/rancher/rke2"
+)
+
+var (
+	CNIFlag = &cli.StringSliceFlag{
+		Name:        "cni",
+		Usage:       "(networking) CNI Plugins to deploy, one of none, " + strings.Join(rke2cli.CNIItems, ", ") + "; optionally with multus as the first value to enable the multus meta-plugin",
+		EnvVars:     []string{"RKE2_CNI"},
+		Value:       cli.NewStringSlice("canal"),
+		Destination: &config.CNI,
+	}
+	IngressControllerFlag = &cli.StringSliceFlag{
+		Name:        "ingress-controller",
+		Usage:       "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
+		EnvVars:     []string{"RKE_INGRESS_CONTROLLER"},
+		Value:       cli.NewStringSlice("ingress-nginx"),
+		Destination: &config.IngressController,
+	}
+	ServiceLBFlag = &cli.BoolFlag{
+		Name:    "enable-servicelb",
+		Usage:   "(components) Enable rke2 default cloud controller manager's service controller",
+		EnvVars: []string{"RKE2_ENABLE_SERVICELB"},
+	}
+
+	serverFlag = []cli.Flag{
+		CNIFlag,
+		IngressControllerFlag,
+		ServiceLBFlag,
+	}
+
+	k3sServerBase = mustCmdFromK3S(cmds.NewServerCommand(ServerRun), K3SFlagSet{
+		"config":                 copyFlag,
+		"debug":                  copyFlag,
+		"v":                      hideFlag,
+		"vmodule":                hideFlag,
+		"log":                    hideFlag,
+		"alsologtostderr":        hideFlag,
+		"bind-address":           copyFlag,
+		"https-listen-port":      dropFlag,
+		"supervisor-port":        dropFlag,
+		"apiserver-port":         dropFlag,
+		"apiserver-bind-address": dropFlag,
+		"advertise-address":      copyFlag,
+		"advertise-port":         dropFlag,
+		"tls-san":                copyFlag,
+		"tls-san-security":       copyFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"disable-agent":                     hideFlag,
+		"cluster-cidr":                      copyFlag,
+		"service-cidr":                      copyFlag,
+		"cluster-init":                      dropFlag,
+		"cluster-reset":                     copyFlag,
+		"cluster-reset-restore-path":        copyFlag,
+		"cluster-dns":                       copyFlag,
+		"cluster-domain":                    copyFlag,
+		"flannel-backend":                   dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"write-kubeconfig":                  copyFlag,
+		"write-kubeconfig-mode":             copyFlag,
+		"write-kubeconfig-group":            copyFlag,
+		"kube-apiserver-arg":                copyFlag,
+		"etcd-arg":                          copyFlag,
+		"kube-scheduler-arg":                copyFlag,
+		"kube-controller-arg":               dropFlag, // deprecated version of kube-controller-manager-arg
+		"kube-controller-manager-arg":       copyFlag,
+		"kube-cloud-controller-manager-arg": copyFlag,
+		"kube-cloud-controller-arg":         dropFlag, // deprecated version of kube-cloud-controller-manager-arg
+		"datastore-endpoint":                copyFlag,
+		"datastore-cafile":                  copyFlag,
+		"datastore-certfile":                copyFlag,
+		"datastore-keyfile":                 copyFlag,
+		"kine-tls":                          dropFlag,
+		"default-local-storage-path":        dropFlag,
+		"disable": {
+			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + strings.Join(rke2cli.DisableItems, ", ") + ")",
+		},
+		"disable-scheduler":                 copyFlag,
+		"disable-cloud-controller":          copyFlag,
+		"disable-network-policy":            dropFlag,
+		"disable-kube-proxy":                copyFlag,
+		"disable-apiserver":                 copyFlag,
+		"disable-controller-manager":        copyFlag,
+		"disable-etcd":                      copyFlag,
+		"etcd-disable-snapshots":            copyFlag,
+		"etcd-snapshot-schedule-cron":       copyFlag,
+		"etcd-snapshot-reconcile-interval":  copyFlag,
+		"etcd-snapshot-retention":           copyFlag,
+		"etcd-snapshot-dir":                 copyFlag,
+		"etcd-snapshot-name":                copyFlag,
+		"etcd-snapshot-compress":            copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"embedded-registry":                 copyFlag,
+		"supervisor-metrics":                copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"private-registry":                  copyFlag,
+		"system-default-registry":           copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"flannel-ipv6-masq":                 dropFlag,
+		"flannel-external-ip":               dropFlag,
+		"egress-selector-mode":              copyFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"agent-token":                       copyFlag,
+		"agent-token-file":                  copyFlag,
+		"server":                            copyFlag,
+		"secrets-encryption":                hideFlag,
+		"secrets-encryption-provider":       copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"service-node-port-range":           copyFlag,
+		"etcd-expose-metrics":               copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"etcd-s3":                           copyFlag,
+		"etcd-s3-access-key":                copyFlag,
+		"etcd-s3-bucket":                    copyFlag,
+		"etcd-s3-bucket-lookup-type":        copyFlag,
+		"etcd-s3-config-secret":             copyFlag,
+		"etcd-s3-endpoint":                  copyFlag,
+		"etcd-s3-endpoint-ca":               copyFlag,
+		"etcd-s3-folder":                    copyFlag,
+		"etcd-s3-insecure":                  copyFlag,
+		"etcd-s3-proxy":                     copyFlag,
+		"etcd-s3-region":                    copyFlag,
+		"etcd-s3-secret-key":                copyFlag,
+		"etcd-s3-session-token":             copyFlag,
+		"etcd-s3-skip-ssl-verify":           copyFlag,
+		"etcd-s3-timeout":                   copyFlag,
+		"etcd-s3-retention":                 copyFlag,
+		"disable-helm-controller":           dropFlag,
+		"helm-job-image":                    copyFlag,
+		"enable-pprof":                      copyFlag,
+		"servicelb-namespace":               copyFlag,
+	})
+)
+
+func NewServerCommand() *cli.Command {
+	cmd := k3sServerBase
+	cmd.Flags = append(cmd.Flags, serverFlag...)
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func ServerRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Server)
+	validateProfile(clx, Server)
+	validateCNI(clx)
+	validateIngress(clx)
+	return rke2.Server(clx, config)
+}
+
+// validateCNI validates the CNI selection, and disables any un-selected CNI charts
+func validateCNI(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.CNIItems, CNIFlag, func(values []string) ([]string, error) {
+		switch len(values) {
+		case 0:
+			values = append(values, "canal")
+			fallthrough
+		case 1:
+			if values[0] == "multus" {
+				return nil, errors.New("multus must be used alongside another primary cni selection")
+			}
+			clx.Set("disable", "rke2-multus")
+		case 2:
+			if values[0] == "multus" {
+				values = values[1:]
+			} else {
+				return nil, errors.New("may only provide multiple values if multus is the first value")
+			}
+		default:
+			return nil, errors.New("must specify 1 or 2 values")
+		}
+		return values, nil
+	})
+}
+
+// validateCNI validates the ingress controller selection, and disables any un-selected ingress controller charts
+func validateIngress(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.IngressItems, IngressControllerFlag, func(values []string) ([]string, error) {
+		return values, nil
+	})
+}
+
+// disableExceptSelected takes a list of valid flag values, and a CLI StringSlice flag that holds the user's selected values.
+// Selected values are split to support comma-separated lists, in addition to repeated use of the same flag.
+// Once the list has been split, a validation function is called to allow for custom validation or defaulting of selected values.
+// Finally, charts for any valid items not selected are added to the --disable list.
+// A value of 'none' will cause all valid items to be disabled.
+// Errors from the validation function, or selection of a value not in the valid list, will cause a fatal error to be logged.
+func disableExceptSelected(clx *cli.Context, valid []string, flag *cli.StringSliceFlag, validateFunc func([]string) ([]string, error)) {
+	// split comma-separated values
+	values := []string{}
+	for _, v := range clx.StringSlice(flag.Name) {
+		values = append(values, strings.Split(v, ",")...)
+	}
+	// validate the flag after splitting values
+	if v, err := validateFunc(values); err != nil {
+		logrus.Fatalf("Failed to validate --%s flag: %v", flag.Name, err)
+	} else {
+		values = v
+	}
+
+	// prepare a list of items to disable, based on all valid components.
+	// we have to use an intermediate set because the flag interface
+	// doesn't allow us to remove flag values once added.
+	disabledCharts := sets.Set[string]{}
+	for _, d := range valid {
+		disabledCharts.Insert("rke2-"+d, "rke2-"+d+"-crd")
+	}
+
+	// re-enable components for any selected flag values
+	for _, d := range values {
+		switch {
+		case d == "none":
+			continue
+		case slice.ContainsString(valid, d):
+			disabledCharts.Delete("rke2-"+d, "rke2-"+d+"-crd")
+		default:
+			logrus.Fatalf("Invalid value %s for --%s flag: must be one of %s", d, flag.Name, strings.Join(valid, ","))
+		}
+	}
+
+	for _, c := range disabledCharts.UnsortedList() {
+		clx.Set("disable", c)
+	}
+}

--- a/thirdparty-src/rke2/v1_33/SOURCE.txt
+++ b/thirdparty-src/rke2/v1_33/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/rancher/rke2
+tag:    v1.33.13+rke2r1
+commit: 879e8b14ad619278d61dd81c116e08f3e1885715
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go pkg/cli/cmds/root.go pkg/cli/cmds/k3sopts.go

--- a/thirdparty-src/rke2/v1_33/zz_agent.go
+++ b/thirdparty-src/rke2/v1_33/zz_agent.go
@@ -1,0 +1,109 @@
+package cmds
+
+import (
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/rke2/pkg/windows"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	k3sAgentBase = mustCmdFromK3S(cmds.NewAgentCommand(AgentRun), K3SFlagSet{
+		"config":          copyFlag,
+		"debug":           copyFlag,
+		"v":               hideFlag,
+		"vmodule":         hideFlag,
+		"log":             hideFlag,
+		"alsologtostderr": hideFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"disable-apiserver-lb":              dropFlag,
+		"private-registry":                  copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"server":                            copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"bind-address":                      copyFlag,
+		"enable-pprof":                      copyFlag,
+	})
+	deprecatedFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "system-default-registry",
+			Usage:   "(deprecated) This flag is no longer supported on agents",
+			EnvVars: []string{"RKE2_SYSTEM_DEFAULT_REGISTRY"},
+			Hidden:  true,
+		},
+	}
+)
+
+func NewAgentCommand() *cli.Command {
+	cmd := k3sAgentBase
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	cmd.Flags = append(cmd.Flags, deprecatedFlags...)
+	cmd.Subcommands = agentSubcommands()
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func agentSubcommands() []*cli.Command {
+	subcommands := []*cli.Command{
+		// subcommands used by both windows/linux, none yet
+	}
+
+	// linux/windows only subcommands
+	subcommands = append(subcommands, serviceSubcommand)
+
+	return subcommands
+}
+
+func AgentRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Agent)
+	validateProfile(clx, Agent)
+	isWinService, err := windows.StartService()
+	if err != nil {
+		return err
+	}
+
+	err = rke2.Agent(clx, config)
+	if isWinService {
+		windows.MonitorProcessExit()
+	}
+
+	return err
+}

--- a/thirdparty-src/rke2/v1_33/zz_k3sopts.go
+++ b/thirdparty-src/rke2/v1_33/zz_k3sopts.go
@@ -1,0 +1,153 @@
+package cmds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/util/errors"
+	"github.com/rancher/wrangler/v3/pkg/merr"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	copyFlag   = &K3SFlagOption{}
+	dropFlag   = &K3SFlagOption{Drop: true}
+	hideFlag   = &K3SFlagOption{Hide: true}
+	ignoreFlag = &K3SFlagOption{Ignore: true}
+)
+
+// K3SFlagOption describes how a CLI flag from K3s should be wrapped.
+type K3SFlagOption struct {
+	Hide    bool
+	Drop    bool
+	Ignore  bool
+	Usage   string
+	Default string
+}
+
+// K3SFlagSet is a map of flag names to options
+type K3SFlagSet map[string]*K3SFlagOption
+
+// CopyInto copies flags from a source set into the destination
+func (k K3SFlagSet) CopyInto(d K3SFlagSet) {
+	for key, val := range k {
+		d[key] = val
+	}
+}
+
+func mustCmdFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) *cli.Command {
+	cmd, err := commandFromK3S(cmd, flagOpts)
+	if err != nil {
+		panic(errors.WithMessagef(err, "failed to wrap command %q", cmd.Name))
+	}
+	return cmd
+}
+
+func commandFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) (*cli.Command, error) {
+	var (
+		newFlags []cli.Flag
+		seen     = map[string]bool{}
+		errs     merr.Errors
+	)
+
+	for _, flag := range cmd.Flags {
+		name := parseName(flag)
+		opt, ok := flagOpts[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("missing flag options for k3s flag %q", name))
+			continue
+		}
+		seen[name] = true
+		if opt == nil {
+			opt = &K3SFlagOption{}
+		}
+
+		if opt.Drop {
+			continue
+		}
+
+		if strFlag, ok := flag.(*cli.StringFlag); ok {
+			if opt.Usage != "" {
+				strFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				strFlag.Value = opt.Default
+			}
+			if opt.Hide {
+				strFlag.Hidden = true
+			}
+			flag = strFlag
+		} else if strSliceFlag, ok := flag.(*cli.StringSliceFlag); ok {
+			if opt.Usage != "" {
+				strSliceFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				slice := &cli.StringSlice{}
+				parts := strings.Split(opt.Default, ",")
+				for _, val := range parts {
+					slice.Set(val)
+				}
+				strSliceFlag.Value = slice
+			}
+			if opt.Hide {
+				strSliceFlag.Hidden = true
+			}
+			flag = strSliceFlag
+		} else if intFlag, ok := flag.(*cli.IntFlag); ok {
+			if opt.Usage != "" {
+				intFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				intFlag.Hidden = true
+			}
+			flag = intFlag
+		} else if boolFlag, ok := flag.(*cli.BoolFlag); ok {
+			if opt.Usage != "" {
+				boolFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				boolFlag.Hidden = true
+			}
+			flag = boolFlag
+		} else if durationFlag, ok := flag.(*cli.DurationFlag); ok {
+			if opt.Usage != "" {
+				durationFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				durationFlag.Hidden = true
+			}
+			flag = durationFlag
+		} else {
+			errs = append(errs, fmt.Errorf("unsupported type %T for flag %q", flag, name))
+		}
+
+		newFlags = append(newFlags, flag)
+	}
+
+	for k, v := range flagOpts {
+		if !seen[k] {
+			if v != nil && v.Ignore {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("got flag options for unknown k3s flag %q", k))
+			continue
+		}
+	}
+
+	cmd.Flags = newFlags
+	return cmd, errs.Err()
+}
+
+// parseName returns a single primary flag name.
+// Flags with short versions may be named "flag", "flag,f", "f,flag", "flag, f" and so on.
+// This returns just the first long version, or the short version if no long is available.
+func parseName(flag cli.Flag) string {
+	names := flag.Names()
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if len(n) > 1 {
+			return n
+		}
+	}
+	return strings.TrimSpace(names[0])
+}

--- a/thirdparty-src/rke2/v1_33/zz_root.go
+++ b/thirdparty-src/rke2/v1_33/zz_root.go
@@ -1,0 +1,253 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/podtemplate"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	appName    = filepath.Base(os.Args[0])
+	config     = rke2cli.Config{}
+	commonFlag = []cli.Flag{
+		&cli.StringFlag{
+			Name:        images.KubeAPIServer,
+			Usage:       "(image) Override image to use for kube-apiserver",
+			EnvVars:     []string{"RKE2_KUBE_APISERVER_IMAGE"},
+			Destination: &config.Images.KubeAPIServer,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeControllerManager,
+			Usage:       "(image) Override image to use for kube-controller-manager",
+			EnvVars:     []string{"RKE2_KUBE_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.KubeControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.CloudControllerManager,
+			Usage:       "(image) Override image to use for cloud-controller-manager",
+			EnvVars:     []string{"RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.CloudControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeProxy,
+			Usage:       "(image) Override image to use for kube-proxy",
+			EnvVars:     []string{"RKE2_KUBE_PROXY_IMAGE"},
+			Destination: &config.Images.KubeProxy,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeScheduler,
+			Usage:       "(image) Override image to use for kube-scheduler",
+			EnvVars:     []string{"RKE2_KUBE_SCHEDULER_IMAGE"},
+			Destination: &config.Images.KubeScheduler,
+		},
+		&cli.StringFlag{
+			Name:        images.Pause,
+			Usage:       "(image) Override image to use for pause",
+			EnvVars:     []string{"RKE2_PAUSE_IMAGE"},
+			Destination: &config.Images.Pause,
+		},
+		&cli.StringFlag{
+			Name:        images.Runtime,
+			Usage:       "(image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc)",
+			EnvVars:     []string{"RKE2_RUNTIME_IMAGE"},
+			Destination: &config.Images.Runtime,
+		},
+		&cli.StringFlag{
+			Name:        images.ETCD,
+			Usage:       "(image) Override image to use for etcd",
+			EnvVars:     []string{"RKE2_ETCD_IMAGE"},
+			Destination: &config.Images.ETCD,
+		},
+		&cli.StringFlag{
+			Name:        "kubelet-path",
+			Usage:       "(experimental/agent) Override kubelet binary path",
+			EnvVars:     []string{"RKE2_KUBELET_PATH"},
+			Destination: &config.KubeletPath,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-name",
+			Usage:       "(cloud provider) Cloud provider name",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_NAME"},
+			Destination: &config.CloudProviderName,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-config",
+			Usage:       "(cloud provider) Cloud provider configuration file path",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_CONFIG"},
+			Destination: &config.CloudProviderConfig,
+		},
+		&cli.BoolFlag{
+			Name:        "node-name-from-cloud-provider-metadata",
+			Usage:       "(cloud provider) Set node name from instance metadata service hostname",
+			EnvVars:     []string{"RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA"},
+			Destination: &config.CloudProviderMetadataHostname,
+		},
+		&cli.StringFlag{
+			Name:    "profile",
+			Usage:   "(security) Validate system configuration against the selected benchmark (valid items: cis, etcd)",
+			EnvVars: []string{"RKE2_CIS_PROFILE"},
+		},
+		&cli.StringFlag{
+			Name:        "audit-policy-file",
+			Usage:       "(security) Path to the file that defines the audit policy configuration",
+			EnvVars:     []string{"RKE2_AUDIT_POLICY_FILE"},
+			Destination: &config.AuditPolicyFile,
+		},
+		&cli.StringFlag{
+			Name:        "pod-security-admission-config-file",
+			Usage:       "(security) Path to the file that defines Pod Security Admission configuration",
+			EnvVars:     []string{"RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE"},
+			Destination: &config.PodSecurityAdmissionConfigFile,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-requests",
+			Usage:       "(components) Control Plane resource requests",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_REQUESTS"},
+			Destination: &config.ControlPlaneResourceRequests,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-limits",
+			Usage:       "(components) Control Plane resource limits",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_LIMITS"},
+			Destination: &config.ControlPlaneResourceLimits,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-probe-configuration",
+			Usage:       "(components) Control Plane Probe configuration",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_PROBE_CONFIGURATION"},
+			Destination: &config.ControlPlaneProbeConf,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-mount",
+			Usage:       "(components) " + podtemplate.Etcd + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.CloudControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-env",
+			Usage:       "(components) " + podtemplate.Etcd + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.CloudControllerManager,
+		},
+	}
+)
+
+type CLIRole int64
+
+const (
+	Agent CLIRole = iota
+	Server
+)
+
+func init() {
+	// hack - force "file,dns" lookup order if go dns is used
+	if os.Getenv("RES_OPTIONS") == "" {
+		os.Setenv("RES_OPTIONS", " ")
+	}
+}
+
+func validateCloudProviderName(clx *cli.Context, role CLIRole) {
+	cloudProvider := clx.String("cloud-provider-name")
+	cloudProviderDisables := map[string][]string{
+		"rancher-vsphere": {"rancher-vsphere-cpi", "rancher-vsphere-csi"},
+		"harvester":       {"harvester-cloud-provider", "harvester-csi-driver"},
+	}
+
+	for providerName, disables := range cloudProviderDisables {
+		if providerName == cloudProvider {
+			clx.Set("cloud-provider-name", "external")
+			if role == Server {
+				clx.Set("disable-cloud-controller", "true")
+			}
+		} else {
+			if role == Server {
+				for _, disable := range disables {
+					clx.Set("disable", disable)
+				}
+			}
+		}
+	}
+}
+
+func NewApp() *cli.App {
+	app := cli.NewApp()
+	app.Name = appName
+	app.EnableBashCompletion = true
+	app.DisableSliceFlagSeparator = true
+	app.Usage = "Rancher Kubernetes Engine 2"
+	app.Version = fmt.Sprintf("%s (%s)", version.Version, version.GitCommit)
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s version %s\n", app.Name, app.Version)
+		fmt.Printf("go version %s\n", runtime.Version())
+	}
+
+	return app
+}

--- a/thirdparty-src/rke2/v1_33/zz_server.go
+++ b/thirdparty-src/rke2/v1_33/zz_server.go
@@ -1,0 +1,283 @@
+package cmds
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/wrangler/v3/pkg/slice"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	rke2Path = "/var/lib/rancher/rke2"
+)
+
+var (
+	CNIFlag = &cli.StringSliceFlag{
+		Name:        "cni",
+		Usage:       "(networking) CNI Plugins to deploy, one of none, " + strings.Join(rke2cli.CNIItems, ", ") + "; optionally with multus as the first value to enable the multus meta-plugin",
+		EnvVars:     []string{"RKE2_CNI"},
+		Value:       cli.NewStringSlice("canal"),
+		Destination: &config.CNI,
+	}
+	IngressControllerFlag = &cli.StringSliceFlag{
+		Name:  "ingress-controller",
+		Usage: "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
+		// TODO: In v1.36, add warning about RKE_INGRESS_CONTROLLER deprecation
+		// In v1.37, add fatal error if RKE_INGRESS_CONTROLLER is used
+		// In v1.38, remove RKE_INGRESS_CONTROLLER entirely
+		EnvVars:     []string{"RKE2_INGRESS_CONTROLLER", "RKE_INGRESS_CONTROLLER"},
+		Value:       cli.NewStringSlice("ingress-nginx"),
+		Destination: &config.IngressController,
+	}
+	ServiceLBFlag = &cli.BoolFlag{
+		Name:    "enable-servicelb",
+		Usage:   "(components) Enable rke2 default cloud controller manager's service controller",
+		EnvVars: []string{"RKE2_ENABLE_SERVICELB"},
+	}
+	PrimeFlag = &cli.BoolFlag{
+		Name:    "prime",
+		Usage:   "Configures RKE2 to utilize the Rancher Prime Registry and features",
+		Hidden:  true,
+		EnvVars: []string{"RKE2_PRIME"},
+	}
+
+	serverFlag = []cli.Flag{
+		CNIFlag,
+		IngressControllerFlag,
+		ServiceLBFlag,
+		PrimeFlag,
+	}
+
+	k3sServerBase = mustCmdFromK3S(cmds.NewServerCommand(ServerRun), K3SFlagSet{
+		"config":                 copyFlag,
+		"debug":                  copyFlag,
+		"v":                      hideFlag,
+		"vmodule":                hideFlag,
+		"log":                    hideFlag,
+		"alsologtostderr":        hideFlag,
+		"bind-address":           copyFlag,
+		"https-listen-port":      dropFlag,
+		"supervisor-port":        dropFlag,
+		"apiserver-port":         dropFlag,
+		"apiserver-bind-address": dropFlag,
+		"advertise-address":      copyFlag,
+		"advertise-port":         dropFlag,
+		"tls-san":                copyFlag,
+		"tls-san-security":       copyFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"disable-agent":                     hideFlag,
+		"cluster-cidr":                      copyFlag,
+		"service-cidr":                      copyFlag,
+		"cluster-init":                      dropFlag,
+		"cluster-reset":                     copyFlag,
+		"cluster-reset-restore-path":        copyFlag,
+		"cluster-dns":                       copyFlag,
+		"cluster-domain":                    copyFlag,
+		"flannel-backend":                   dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"write-kubeconfig":                  copyFlag,
+		"write-kubeconfig-mode":             copyFlag,
+		"write-kubeconfig-group":            copyFlag,
+		"kube-apiserver-arg":                copyFlag,
+		"etcd-arg":                          copyFlag,
+		"kube-scheduler-arg":                copyFlag,
+		"kube-controller-arg":               dropFlag, // deprecated version of kube-controller-manager-arg
+		"kube-controller-manager-arg":       copyFlag,
+		"kube-cloud-controller-manager-arg": copyFlag,
+		"kube-cloud-controller-arg":         dropFlag, // deprecated version of kube-cloud-controller-manager-arg
+		"datastore-endpoint":                copyFlag,
+		"datastore-cafile":                  copyFlag,
+		"datastore-certfile":                copyFlag,
+		"datastore-keyfile":                 copyFlag,
+		"kine-tls":                          dropFlag,
+		"default-local-storage-path":        dropFlag,
+		"disable": {
+			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + strings.Join(rke2cli.DisableItems, ", ") + ")",
+		},
+		"disable-scheduler":                 copyFlag,
+		"disable-cloud-controller":          copyFlag,
+		"disable-network-policy":            dropFlag,
+		"disable-kube-proxy":                copyFlag,
+		"disable-apiserver":                 copyFlag,
+		"disable-controller-manager":        copyFlag,
+		"disable-etcd":                      copyFlag,
+		"etcd-disable-snapshots":            copyFlag,
+		"etcd-snapshot-schedule-cron":       copyFlag,
+		"etcd-snapshot-reconcile-interval":  copyFlag,
+		"etcd-snapshot-retention":           copyFlag,
+		"etcd-snapshot-dir":                 copyFlag,
+		"etcd-snapshot-name":                copyFlag,
+		"etcd-snapshot-compress":            copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"embedded-registry":                 copyFlag,
+		"supervisor-metrics":                copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"private-registry":                  copyFlag,
+		"system-default-registry":           copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"flannel-ipv6-masq":                 dropFlag,
+		"flannel-external-ip":               dropFlag,
+		"egress-selector-mode":              copyFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"agent-token":                       copyFlag,
+		"agent-token-file":                  copyFlag,
+		"server":                            copyFlag,
+		"secrets-encryption":                hideFlag,
+		"secrets-encryption-provider":       copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"service-node-port-range":           copyFlag,
+		"etcd-expose-metrics":               copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"etcd-s3":                           copyFlag,
+		"etcd-s3-access-key":                copyFlag,
+		"etcd-s3-bucket":                    copyFlag,
+		"etcd-s3-bucket-lookup-type":        copyFlag,
+		"etcd-s3-config-secret":             copyFlag,
+		"etcd-s3-endpoint":                  copyFlag,
+		"etcd-s3-endpoint-ca":               copyFlag,
+		"etcd-s3-folder":                    copyFlag,
+		"etcd-s3-insecure":                  copyFlag,
+		"etcd-s3-proxy":                     copyFlag,
+		"etcd-s3-region":                    copyFlag,
+		"etcd-s3-secret-key":                copyFlag,
+		"etcd-s3-session-token":             copyFlag,
+		"etcd-s3-skip-ssl-verify":           copyFlag,
+		"etcd-s3-timeout":                   copyFlag,
+		"etcd-s3-retention":                 copyFlag,
+		"disable-helm-controller":           dropFlag,
+		"helm-job-image":                    copyFlag,
+		"enable-pprof":                      copyFlag,
+		"servicelb-namespace":               copyFlag,
+	})
+)
+
+func NewServerCommand() *cli.Command {
+	cmd := k3sServerBase
+	cmd.Flags = append(cmd.Flags, serverFlag...)
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func ServerRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Server)
+	validateProfile(clx, Server)
+	validateCNI(clx)
+	validateIngress(clx)
+	return rke2.Server(clx, config)
+}
+
+// validateCNI validates the CNI selection, and disables any un-selected CNI charts
+func validateCNI(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.CNIItems, CNIFlag, func(values []string) ([]string, error) {
+		switch len(values) {
+		case 0:
+			values = append(values, "canal")
+			fallthrough
+		case 1:
+			if values[0] == "multus" {
+				return nil, errors.New("multus must be used alongside another primary cni selection")
+			}
+			clx.Set("disable", "rke2-multus")
+		case 2:
+			if values[0] == "multus" {
+				values = values[1:]
+			} else {
+				return nil, errors.New("may only provide multiple values if multus is the first value")
+			}
+		default:
+			return nil, errors.New("must specify 1 or 2 values")
+		}
+		return values, nil
+	})
+}
+
+// validateCNI validates the ingress controller selection, and disables any un-selected ingress controller charts
+func validateIngress(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.IngressItems, IngressControllerFlag, func(values []string) ([]string, error) {
+		return values, nil
+	})
+}
+
+// disableExceptSelected takes a list of valid flag values, and a CLI StringSlice flag that holds the user's selected values.
+// Selected values are split to support comma-separated lists, in addition to repeated use of the same flag.
+// Once the list has been split, a validation function is called to allow for custom validation or defaulting of selected values.
+// Finally, charts for any valid items not selected are added to the --disable list.
+// A value of 'none' will cause all valid items to be disabled.
+// Errors from the validation function, or selection of a value not in the valid list, will cause a fatal error to be logged.
+func disableExceptSelected(clx *cli.Context, valid []string, flag *cli.StringSliceFlag, validateFunc func([]string) ([]string, error)) {
+	// split comma-separated values
+	values := []string{}
+	for _, v := range clx.StringSlice(flag.Name) {
+		values = append(values, strings.Split(v, ",")...)
+	}
+	// validate the flag after splitting values
+	if v, err := validateFunc(values); err != nil {
+		logrus.Fatalf("Failed to validate --%s flag: %v", flag.Name, err)
+	} else {
+		values = v
+	}
+
+	// prepare a list of items to disable, based on all valid components.
+	// we have to use an intermediate set because the flag interface
+	// doesn't allow us to remove flag values once added.
+	disabledCharts := sets.Set[string]{}
+	for _, d := range valid {
+		disabledCharts.Insert("rke2-"+d, "rke2-"+d+"-crd")
+	}
+
+	// re-enable components for any selected flag values
+	for _, d := range values {
+		switch {
+		case d == "none":
+			continue
+		case slice.ContainsString(valid, d):
+			disabledCharts.Delete("rke2-"+d, "rke2-"+d+"-crd")
+		default:
+			logrus.Fatalf("Invalid value %s for --%s flag: must be one of %s", d, flag.Name, strings.Join(valid, ","))
+		}
+	}
+
+	for _, c := range disabledCharts.UnsortedList() {
+		clx.Set("disable", c)
+	}
+}

--- a/thirdparty-src/rke2/v1_34/SOURCE.txt
+++ b/thirdparty-src/rke2/v1_34/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/rancher/rke2
+tag:    v1.34.11+rke2r1
+commit: 2506fee512985398ca0b50d875c3df73069763ce
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go pkg/cli/cmds/root.go pkg/cli/cmds/k3sopts.go

--- a/thirdparty-src/rke2/v1_34/zz_agent.go
+++ b/thirdparty-src/rke2/v1_34/zz_agent.go
@@ -1,0 +1,109 @@
+package cmds
+
+import (
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/rke2/pkg/windows"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	k3sAgentBase = mustCmdFromK3S(cmds.NewAgentCommand(AgentRun), K3SFlagSet{
+		"config":          copyFlag,
+		"debug":           copyFlag,
+		"v":               hideFlag,
+		"vmodule":         hideFlag,
+		"log":             hideFlag,
+		"alsologtostderr": hideFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"disable-apiserver-lb":              dropFlag,
+		"private-registry":                  copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"server":                            copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"bind-address":                      copyFlag,
+		"enable-pprof":                      copyFlag,
+	})
+	deprecatedFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "system-default-registry",
+			Usage:   "(deprecated) This flag is no longer supported on agents",
+			EnvVars: []string{"RKE2_SYSTEM_DEFAULT_REGISTRY"},
+			Hidden:  true,
+		},
+	}
+)
+
+func NewAgentCommand() *cli.Command {
+	cmd := k3sAgentBase
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	cmd.Flags = append(cmd.Flags, deprecatedFlags...)
+	cmd.Subcommands = agentSubcommands()
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func agentSubcommands() []*cli.Command {
+	subcommands := []*cli.Command{
+		// subcommands used by both windows/linux, none yet
+	}
+
+	// linux/windows only subcommands
+	subcommands = append(subcommands, serviceSubcommand)
+
+	return subcommands
+}
+
+func AgentRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Agent)
+	validateProfile(clx, Agent)
+	isWinService, err := windows.StartService()
+	if err != nil {
+		return err
+	}
+
+	err = rke2.Agent(clx, config)
+	if isWinService {
+		windows.MonitorProcessExit()
+	}
+
+	return err
+}

--- a/thirdparty-src/rke2/v1_34/zz_k3sopts.go
+++ b/thirdparty-src/rke2/v1_34/zz_k3sopts.go
@@ -1,0 +1,153 @@
+package cmds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/util/errors"
+	"github.com/rancher/wrangler/v3/pkg/merr"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	copyFlag   = &K3SFlagOption{}
+	dropFlag   = &K3SFlagOption{Drop: true}
+	hideFlag   = &K3SFlagOption{Hide: true}
+	ignoreFlag = &K3SFlagOption{Ignore: true}
+)
+
+// K3SFlagOption describes how a CLI flag from K3s should be wrapped.
+type K3SFlagOption struct {
+	Hide    bool
+	Drop    bool
+	Ignore  bool
+	Usage   string
+	Default string
+}
+
+// K3SFlagSet is a map of flag names to options
+type K3SFlagSet map[string]*K3SFlagOption
+
+// CopyInto copies flags from a source set into the destination
+func (k K3SFlagSet) CopyInto(d K3SFlagSet) {
+	for key, val := range k {
+		d[key] = val
+	}
+}
+
+func mustCmdFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) *cli.Command {
+	cmd, err := commandFromK3S(cmd, flagOpts)
+	if err != nil {
+		panic(errors.WithMessagef(err, "failed to wrap command %q", cmd.Name))
+	}
+	return cmd
+}
+
+func commandFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) (*cli.Command, error) {
+	var (
+		newFlags []cli.Flag
+		seen     = map[string]bool{}
+		errs     merr.Errors
+	)
+
+	for _, flag := range cmd.Flags {
+		name := parseName(flag)
+		opt, ok := flagOpts[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("missing flag options for k3s flag %q", name))
+			continue
+		}
+		seen[name] = true
+		if opt == nil {
+			opt = &K3SFlagOption{}
+		}
+
+		if opt.Drop {
+			continue
+		}
+
+		if strFlag, ok := flag.(*cli.StringFlag); ok {
+			if opt.Usage != "" {
+				strFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				strFlag.Value = opt.Default
+			}
+			if opt.Hide {
+				strFlag.Hidden = true
+			}
+			flag = strFlag
+		} else if strSliceFlag, ok := flag.(*cli.StringSliceFlag); ok {
+			if opt.Usage != "" {
+				strSliceFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				slice := &cli.StringSlice{}
+				parts := strings.Split(opt.Default, ",")
+				for _, val := range parts {
+					slice.Set(val)
+				}
+				strSliceFlag.Value = slice
+			}
+			if opt.Hide {
+				strSliceFlag.Hidden = true
+			}
+			flag = strSliceFlag
+		} else if intFlag, ok := flag.(*cli.IntFlag); ok {
+			if opt.Usage != "" {
+				intFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				intFlag.Hidden = true
+			}
+			flag = intFlag
+		} else if boolFlag, ok := flag.(*cli.BoolFlag); ok {
+			if opt.Usage != "" {
+				boolFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				boolFlag.Hidden = true
+			}
+			flag = boolFlag
+		} else if durationFlag, ok := flag.(*cli.DurationFlag); ok {
+			if opt.Usage != "" {
+				durationFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				durationFlag.Hidden = true
+			}
+			flag = durationFlag
+		} else {
+			errs = append(errs, fmt.Errorf("unsupported type %T for flag %q", flag, name))
+		}
+
+		newFlags = append(newFlags, flag)
+	}
+
+	for k, v := range flagOpts {
+		if !seen[k] {
+			if v != nil && v.Ignore {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("got flag options for unknown k3s flag %q", k))
+			continue
+		}
+	}
+
+	cmd.Flags = newFlags
+	return cmd, errs.Err()
+}
+
+// parseName returns a single primary flag name.
+// Flags with short versions may be named "flag", "flag,f", "f,flag", "flag, f" and so on.
+// This returns just the first long version, or the short version if no long is available.
+func parseName(flag cli.Flag) string {
+	names := flag.Names()
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if len(n) > 1 {
+			return n
+		}
+	}
+	return strings.TrimSpace(names[0])
+}

--- a/thirdparty-src/rke2/v1_34/zz_root.go
+++ b/thirdparty-src/rke2/v1_34/zz_root.go
@@ -1,0 +1,253 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/podtemplate"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	appName    = filepath.Base(os.Args[0])
+	config     = rke2cli.Config{}
+	commonFlag = []cli.Flag{
+		&cli.StringFlag{
+			Name:        images.KubeAPIServer,
+			Usage:       "(image) Override image to use for kube-apiserver",
+			EnvVars:     []string{"RKE2_KUBE_APISERVER_IMAGE"},
+			Destination: &config.Images.KubeAPIServer,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeControllerManager,
+			Usage:       "(image) Override image to use for kube-controller-manager",
+			EnvVars:     []string{"RKE2_KUBE_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.KubeControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.CloudControllerManager,
+			Usage:       "(image) Override image to use for cloud-controller-manager",
+			EnvVars:     []string{"RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.CloudControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeProxy,
+			Usage:       "(image) Override image to use for kube-proxy",
+			EnvVars:     []string{"RKE2_KUBE_PROXY_IMAGE"},
+			Destination: &config.Images.KubeProxy,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeScheduler,
+			Usage:       "(image) Override image to use for kube-scheduler",
+			EnvVars:     []string{"RKE2_KUBE_SCHEDULER_IMAGE"},
+			Destination: &config.Images.KubeScheduler,
+		},
+		&cli.StringFlag{
+			Name:        images.Pause,
+			Usage:       "(image) Override image to use for pause",
+			EnvVars:     []string{"RKE2_PAUSE_IMAGE"},
+			Destination: &config.Images.Pause,
+		},
+		&cli.StringFlag{
+			Name:        images.Runtime,
+			Usage:       "(image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc)",
+			EnvVars:     []string{"RKE2_RUNTIME_IMAGE"},
+			Destination: &config.Images.Runtime,
+		},
+		&cli.StringFlag{
+			Name:        images.ETCD,
+			Usage:       "(image) Override image to use for etcd",
+			EnvVars:     []string{"RKE2_ETCD_IMAGE"},
+			Destination: &config.Images.ETCD,
+		},
+		&cli.StringFlag{
+			Name:        "kubelet-path",
+			Usage:       "(experimental/agent) Override kubelet binary path",
+			EnvVars:     []string{"RKE2_KUBELET_PATH"},
+			Destination: &config.KubeletPath,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-name",
+			Usage:       "(cloud provider) Cloud provider name",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_NAME"},
+			Destination: &config.CloudProviderName,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-config",
+			Usage:       "(cloud provider) Cloud provider configuration file path",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_CONFIG"},
+			Destination: &config.CloudProviderConfig,
+		},
+		&cli.BoolFlag{
+			Name:        "node-name-from-cloud-provider-metadata",
+			Usage:       "(cloud provider) Set node name from instance metadata service hostname",
+			EnvVars:     []string{"RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA"},
+			Destination: &config.CloudProviderMetadataHostname,
+		},
+		&cli.StringFlag{
+			Name:    "profile",
+			Usage:   "(security) Validate system configuration against the selected benchmark (valid items: cis, etcd)",
+			EnvVars: []string{"RKE2_CIS_PROFILE"},
+		},
+		&cli.StringFlag{
+			Name:        "audit-policy-file",
+			Usage:       "(security) Path to the file that defines the audit policy configuration",
+			EnvVars:     []string{"RKE2_AUDIT_POLICY_FILE"},
+			Destination: &config.AuditPolicyFile,
+		},
+		&cli.StringFlag{
+			Name:        "pod-security-admission-config-file",
+			Usage:       "(security) Path to the file that defines Pod Security Admission configuration",
+			EnvVars:     []string{"RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE"},
+			Destination: &config.PodSecurityAdmissionConfigFile,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-requests",
+			Usage:       "(components) Control Plane resource requests",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_REQUESTS"},
+			Destination: &config.ControlPlaneResourceRequests,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-limits",
+			Usage:       "(components) Control Plane resource limits",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_LIMITS"},
+			Destination: &config.ControlPlaneResourceLimits,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-probe-configuration",
+			Usage:       "(components) Control Plane Probe configuration",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_PROBE_CONFIGURATION"},
+			Destination: &config.ControlPlaneProbeConf,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-mount",
+			Usage:       "(components) " + podtemplate.Etcd + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.CloudControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-env",
+			Usage:       "(components) " + podtemplate.Etcd + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.CloudControllerManager,
+		},
+	}
+)
+
+type CLIRole int64
+
+const (
+	Agent CLIRole = iota
+	Server
+)
+
+func init() {
+	// hack - force "file,dns" lookup order if go dns is used
+	if os.Getenv("RES_OPTIONS") == "" {
+		os.Setenv("RES_OPTIONS", " ")
+	}
+}
+
+func validateCloudProviderName(clx *cli.Context, role CLIRole) {
+	cloudProvider := clx.String("cloud-provider-name")
+	cloudProviderDisables := map[string][]string{
+		"rancher-vsphere": {"rancher-vsphere-cpi", "rancher-vsphere-csi"},
+		"harvester":       {"harvester-cloud-provider", "harvester-csi-driver"},
+	}
+
+	for providerName, disables := range cloudProviderDisables {
+		if providerName == cloudProvider {
+			clx.Set("cloud-provider-name", "external")
+			if role == Server {
+				clx.Set("disable-cloud-controller", "true")
+			}
+		} else {
+			if role == Server {
+				for _, disable := range disables {
+					clx.Set("disable", disable)
+				}
+			}
+		}
+	}
+}
+
+func NewApp() *cli.App {
+	app := cli.NewApp()
+	app.Name = appName
+	app.EnableBashCompletion = true
+	app.DisableSliceFlagSeparator = true
+	app.Usage = "Rancher Kubernetes Engine 2"
+	app.Version = fmt.Sprintf("%s (%s)", version.Version, version.GitCommit)
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s version %s\n", app.Name, app.Version)
+		fmt.Printf("go version %s\n", runtime.Version())
+	}
+
+	return app
+}

--- a/thirdparty-src/rke2/v1_34/zz_server.go
+++ b/thirdparty-src/rke2/v1_34/zz_server.go
@@ -1,0 +1,284 @@
+package cmds
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/wrangler/v3/pkg/slice"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	rke2Path = "/var/lib/rancher/rke2"
+)
+
+var (
+	CNIFlag = &cli.StringSliceFlag{
+		Name:        "cni",
+		Usage:       "(networking) CNI Plugins to deploy, one of none, " + strings.Join(rke2cli.CNIItems, ", ") + "; optionally with multus as the first value to enable the multus meta-plugin",
+		EnvVars:     []string{"RKE2_CNI"},
+		Value:       cli.NewStringSlice("canal"),
+		Destination: &config.CNI,
+	}
+	IngressControllerFlag = &cli.StringSliceFlag{
+		Name:  "ingress-controller",
+		Usage: "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
+		// TODO: In v1.36, add warning about RKE_INGRESS_CONTROLLER deprecation
+		// In v1.37, add fatal error if RKE_INGRESS_CONTROLLER is used
+		// In v1.38, remove RKE_INGRESS_CONTROLLER entirely
+		EnvVars:     []string{"RKE2_INGRESS_CONTROLLER", "RKE_INGRESS_CONTROLLER"},
+		Value:       cli.NewStringSlice("ingress-nginx"),
+		Destination: &config.IngressController,
+	}
+	ServiceLBFlag = &cli.BoolFlag{
+		Name:    "enable-servicelb",
+		Usage:   "(components) Enable rke2 default cloud controller manager's service controller",
+		EnvVars: []string{"RKE2_ENABLE_SERVICELB"},
+	}
+	PrimeFlag = &cli.BoolFlag{
+		Name:    "prime",
+		Usage:   "Configures RKE2 to utilize the Rancher Prime Registry and features",
+		Hidden:  true,
+		EnvVars: []string{"RKE2_PRIME"},
+	}
+
+	serverFlag = []cli.Flag{
+		CNIFlag,
+		IngressControllerFlag,
+		ServiceLBFlag,
+		PrimeFlag,
+	}
+
+	k3sServerBase = mustCmdFromK3S(cmds.NewServerCommand(ServerRun), K3SFlagSet{
+		"config":                 copyFlag,
+		"debug":                  copyFlag,
+		"v":                      hideFlag,
+		"vmodule":                hideFlag,
+		"log":                    hideFlag,
+		"alsologtostderr":        hideFlag,
+		"bind-address":           copyFlag,
+		"https-listen-port":      dropFlag,
+		"supervisor-port":        dropFlag,
+		"apiserver-port":         dropFlag,
+		"apiserver-bind-address": dropFlag,
+		"advertise-address":      copyFlag,
+		"advertise-port":         dropFlag,
+		"tls-san":                copyFlag,
+		"tls-san-security":       copyFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"disable-agent":                     hideFlag,
+		"cluster-cidr":                      copyFlag,
+		"service-cidr":                      copyFlag,
+		"cluster-init":                      dropFlag,
+		"cluster-reset":                     copyFlag,
+		"cluster-reset-restore-path":        copyFlag,
+		"cluster-dns":                       copyFlag,
+		"cluster-domain":                    copyFlag,
+		"flannel-backend":                   dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"write-kubeconfig":                  copyFlag,
+		"write-kubeconfig-mode":             copyFlag,
+		"write-kubeconfig-group":            copyFlag,
+		"kube-apiserver-arg":                copyFlag,
+		"etcd-arg":                          copyFlag,
+		"kube-scheduler-arg":                copyFlag,
+		"kube-controller-arg":               dropFlag, // deprecated version of kube-controller-manager-arg
+		"kube-controller-manager-arg":       copyFlag,
+		"kube-cloud-controller-manager-arg": copyFlag,
+		"kube-cloud-controller-arg":         dropFlag, // deprecated version of kube-cloud-controller-manager-arg
+		"datastore-endpoint":                copyFlag,
+		"datastore-cafile":                  copyFlag,
+		"datastore-certfile":                copyFlag,
+		"datastore-keyfile":                 copyFlag,
+		"kine-tls":                          dropFlag,
+		"default-local-storage-path":        dropFlag,
+		"disable": {
+			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + strings.Join(rke2cli.DisableItems, ", ") + ")",
+		},
+		"disable-scheduler":                 copyFlag,
+		"disable-cloud-controller":          copyFlag,
+		"disable-network-policy":            dropFlag,
+		"disable-kube-proxy":                copyFlag,
+		"disable-apiserver":                 copyFlag,
+		"disable-controller-manager":        copyFlag,
+		"disable-etcd":                      copyFlag,
+		"etcd-disable-snapshots":            copyFlag,
+		"etcd-snapshot-schedule-cron":       copyFlag,
+		"etcd-snapshot-reconcile-interval":  copyFlag,
+		"etcd-snapshot-retention":           copyFlag,
+		"etcd-snapshot-dir":                 copyFlag,
+		"etcd-snapshot-name":                copyFlag,
+		"etcd-snapshot-compress":            copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"embedded-registry":                 copyFlag,
+		"supervisor-metrics":                copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"private-registry":                  copyFlag,
+		"system-default-registry":           copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"flannel-ipv6-masq":                 dropFlag,
+		"flannel-external-ip":               dropFlag,
+		"egress-selector-mode":              copyFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"agent-token":                       copyFlag,
+		"agent-token-file":                  copyFlag,
+		"server":                            copyFlag,
+		"secrets-encryption":                hideFlag,
+		"secrets-encryption-provider":       copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"service-node-port-range":           copyFlag,
+		"etcd-expose-metrics":               copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"etcd-s3":                           copyFlag,
+		"etcd-s3-access-key":                copyFlag,
+		"etcd-s3-bucket":                    copyFlag,
+		"etcd-s3-bucket-lookup-type":        copyFlag,
+		"etcd-s3-config-secret":             copyFlag,
+		"etcd-s3-endpoint":                  copyFlag,
+		"etcd-s3-endpoint-ca":               copyFlag,
+		"etcd-s3-folder":                    copyFlag,
+		"etcd-s3-insecure":                  copyFlag,
+		"etcd-s3-proxy":                     copyFlag,
+		"etcd-s3-region":                    copyFlag,
+		"etcd-s3-secret-key":                copyFlag,
+		"etcd-s3-session-token":             copyFlag,
+		"etcd-s3-skip-ssl-verify":           copyFlag,
+		"etcd-s3-timeout":                   copyFlag,
+		"etcd-s3-retention":                 copyFlag,
+		"disable-helm-controller":           dropFlag,
+		"helm-job-image":                    copyFlag,
+		"helm-controller-arg":               copyFlag,
+		"enable-pprof":                      copyFlag,
+		"servicelb-namespace":               copyFlag,
+	})
+)
+
+func NewServerCommand() *cli.Command {
+	cmd := k3sServerBase
+	cmd.Flags = append(cmd.Flags, serverFlag...)
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func ServerRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Server)
+	validateProfile(clx, Server)
+	validateCNI(clx)
+	validateIngress(clx)
+	return rke2.Server(clx, config)
+}
+
+// validateCNI validates the CNI selection, and disables any un-selected CNI charts
+func validateCNI(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.CNIItems, CNIFlag, func(values []string) ([]string, error) {
+		switch len(values) {
+		case 0:
+			values = append(values, "canal")
+			fallthrough
+		case 1:
+			if values[0] == "multus" {
+				return nil, errors.New("multus must be used alongside another primary cni selection")
+			}
+			clx.Set("disable", "rke2-multus")
+		case 2:
+			if values[0] == "multus" {
+				values = values[1:]
+			} else {
+				return nil, errors.New("may only provide multiple values if multus is the first value")
+			}
+		default:
+			return nil, errors.New("must specify 1 or 2 values")
+		}
+		return values, nil
+	})
+}
+
+// validateCNI validates the ingress controller selection, and disables any un-selected ingress controller charts
+func validateIngress(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.IngressItems, IngressControllerFlag, func(values []string) ([]string, error) {
+		return values, nil
+	})
+}
+
+// disableExceptSelected takes a list of valid flag values, and a CLI StringSlice flag that holds the user's selected values.
+// Selected values are split to support comma-separated lists, in addition to repeated use of the same flag.
+// Once the list has been split, a validation function is called to allow for custom validation or defaulting of selected values.
+// Finally, charts for any valid items not selected are added to the --disable list.
+// A value of 'none' will cause all valid items to be disabled.
+// Errors from the validation function, or selection of a value not in the valid list, will cause a fatal error to be logged.
+func disableExceptSelected(clx *cli.Context, valid []string, flag *cli.StringSliceFlag, validateFunc func([]string) ([]string, error)) {
+	// split comma-separated values
+	values := []string{}
+	for _, v := range clx.StringSlice(flag.Name) {
+		values = append(values, strings.Split(v, ",")...)
+	}
+	// validate the flag after splitting values
+	if v, err := validateFunc(values); err != nil {
+		logrus.Fatalf("Failed to validate --%s flag: %v", flag.Name, err)
+	} else {
+		values = v
+	}
+
+	// prepare a list of items to disable, based on all valid components.
+	// we have to use an intermediate set because the flag interface
+	// doesn't allow us to remove flag values once added.
+	disabledCharts := sets.Set[string]{}
+	for _, d := range valid {
+		disabledCharts.Insert("rke2-"+d, "rke2-"+d+"-crd")
+	}
+
+	// re-enable components for any selected flag values
+	for _, d := range values {
+		switch {
+		case d == "none":
+			continue
+		case slice.ContainsString(valid, d):
+			disabledCharts.Delete("rke2-"+d, "rke2-"+d+"-crd")
+		default:
+			logrus.Fatalf("Invalid value %s for --%s flag: must be one of %s", d, flag.Name, strings.Join(valid, ","))
+		}
+	}
+
+	for _, c := range disabledCharts.UnsortedList() {
+		clx.Set("disable", c)
+	}
+}

--- a/thirdparty-src/rke2/v1_35/SOURCE.txt
+++ b/thirdparty-src/rke2/v1_35/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/rancher/rke2
+tag:    v1.35.8+rke2r1
+commit: 0fec82ea2fa6c7b25b7a3fe3cd990fbecc07e1bb
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go pkg/cli/cmds/root.go pkg/cli/cmds/k3sopts.go

--- a/thirdparty-src/rke2/v1_35/zz_agent.go
+++ b/thirdparty-src/rke2/v1_35/zz_agent.go
@@ -1,0 +1,109 @@
+package cmds
+
+import (
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/rke2/pkg/windows"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	k3sAgentBase = mustCmdFromK3S(cmds.NewAgentCommand(AgentRun), K3SFlagSet{
+		"config":          copyFlag,
+		"debug":           copyFlag,
+		"v":               hideFlag,
+		"vmodule":         hideFlag,
+		"log":             hideFlag,
+		"alsologtostderr": hideFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"disable-apiserver-lb":              dropFlag,
+		"private-registry":                  copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"server":                            copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"bind-address":                      copyFlag,
+		"enable-pprof":                      copyFlag,
+	})
+	deprecatedFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "system-default-registry",
+			Usage:   "(deprecated) This flag is no longer supported on agents",
+			EnvVars: []string{"RKE2_SYSTEM_DEFAULT_REGISTRY"},
+			Hidden:  true,
+		},
+	}
+)
+
+func NewAgentCommand() *cli.Command {
+	cmd := k3sAgentBase
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	cmd.Flags = append(cmd.Flags, deprecatedFlags...)
+	cmd.Subcommands = agentSubcommands()
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func agentSubcommands() []*cli.Command {
+	subcommands := []*cli.Command{
+		// subcommands used by both windows/linux, none yet
+	}
+
+	// linux/windows only subcommands
+	subcommands = append(subcommands, serviceSubcommand)
+
+	return subcommands
+}
+
+func AgentRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Agent)
+	validateProfile(clx, Agent)
+	isWinService, err := windows.StartService()
+	if err != nil {
+		return err
+	}
+
+	err = rke2.Agent(clx, config)
+	if isWinService {
+		windows.MonitorProcessExit()
+	}
+
+	return err
+}

--- a/thirdparty-src/rke2/v1_35/zz_k3sopts.go
+++ b/thirdparty-src/rke2/v1_35/zz_k3sopts.go
@@ -1,0 +1,153 @@
+package cmds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/util/errors"
+	"github.com/rancher/wrangler/v3/pkg/merr"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	copyFlag   = &K3SFlagOption{}
+	dropFlag   = &K3SFlagOption{Drop: true}
+	hideFlag   = &K3SFlagOption{Hide: true}
+	ignoreFlag = &K3SFlagOption{Ignore: true}
+)
+
+// K3SFlagOption describes how a CLI flag from K3s should be wrapped.
+type K3SFlagOption struct {
+	Hide    bool
+	Drop    bool
+	Ignore  bool
+	Usage   string
+	Default string
+}
+
+// K3SFlagSet is a map of flag names to options
+type K3SFlagSet map[string]*K3SFlagOption
+
+// CopyInto copies flags from a source set into the destination
+func (k K3SFlagSet) CopyInto(d K3SFlagSet) {
+	for key, val := range k {
+		d[key] = val
+	}
+}
+
+func mustCmdFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) *cli.Command {
+	cmd, err := commandFromK3S(cmd, flagOpts)
+	if err != nil {
+		panic(errors.WithMessagef(err, "failed to wrap command %q", cmd.Name))
+	}
+	return cmd
+}
+
+func commandFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) (*cli.Command, error) {
+	var (
+		newFlags []cli.Flag
+		seen     = map[string]bool{}
+		errs     merr.Errors
+	)
+
+	for _, flag := range cmd.Flags {
+		name := parseName(flag)
+		opt, ok := flagOpts[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("missing flag options for k3s flag %q", name))
+			continue
+		}
+		seen[name] = true
+		if opt == nil {
+			opt = &K3SFlagOption{}
+		}
+
+		if opt.Drop {
+			continue
+		}
+
+		if strFlag, ok := flag.(*cli.StringFlag); ok {
+			if opt.Usage != "" {
+				strFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				strFlag.Value = opt.Default
+			}
+			if opt.Hide {
+				strFlag.Hidden = true
+			}
+			flag = strFlag
+		} else if strSliceFlag, ok := flag.(*cli.StringSliceFlag); ok {
+			if opt.Usage != "" {
+				strSliceFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				slice := &cli.StringSlice{}
+				parts := strings.Split(opt.Default, ",")
+				for _, val := range parts {
+					slice.Set(val)
+				}
+				strSliceFlag.Value = slice
+			}
+			if opt.Hide {
+				strSliceFlag.Hidden = true
+			}
+			flag = strSliceFlag
+		} else if intFlag, ok := flag.(*cli.IntFlag); ok {
+			if opt.Usage != "" {
+				intFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				intFlag.Hidden = true
+			}
+			flag = intFlag
+		} else if boolFlag, ok := flag.(*cli.BoolFlag); ok {
+			if opt.Usage != "" {
+				boolFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				boolFlag.Hidden = true
+			}
+			flag = boolFlag
+		} else if durationFlag, ok := flag.(*cli.DurationFlag); ok {
+			if opt.Usage != "" {
+				durationFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				durationFlag.Hidden = true
+			}
+			flag = durationFlag
+		} else {
+			errs = append(errs, fmt.Errorf("unsupported type %T for flag %q", flag, name))
+		}
+
+		newFlags = append(newFlags, flag)
+	}
+
+	for k, v := range flagOpts {
+		if !seen[k] {
+			if v != nil && v.Ignore {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("got flag options for unknown k3s flag %q", k))
+			continue
+		}
+	}
+
+	cmd.Flags = newFlags
+	return cmd, errs.Err()
+}
+
+// parseName returns a single primary flag name.
+// Flags with short versions may be named "flag", "flag,f", "f,flag", "flag, f" and so on.
+// This returns just the first long version, or the short version if no long is available.
+func parseName(flag cli.Flag) string {
+	names := flag.Names()
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if len(n) > 1 {
+			return n
+		}
+	}
+	return strings.TrimSpace(names[0])
+}

--- a/thirdparty-src/rke2/v1_35/zz_root.go
+++ b/thirdparty-src/rke2/v1_35/zz_root.go
@@ -1,0 +1,253 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/podtemplate"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	appName    = filepath.Base(os.Args[0])
+	config     = rke2cli.Config{}
+	commonFlag = []cli.Flag{
+		&cli.StringFlag{
+			Name:        images.KubeAPIServer,
+			Usage:       "(image) Override image to use for kube-apiserver",
+			EnvVars:     []string{"RKE2_KUBE_APISERVER_IMAGE"},
+			Destination: &config.Images.KubeAPIServer,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeControllerManager,
+			Usage:       "(image) Override image to use for kube-controller-manager",
+			EnvVars:     []string{"RKE2_KUBE_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.KubeControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.CloudControllerManager,
+			Usage:       "(image) Override image to use for cloud-controller-manager",
+			EnvVars:     []string{"RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.CloudControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeProxy,
+			Usage:       "(image) Override image to use for kube-proxy",
+			EnvVars:     []string{"RKE2_KUBE_PROXY_IMAGE"},
+			Destination: &config.Images.KubeProxy,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeScheduler,
+			Usage:       "(image) Override image to use for kube-scheduler",
+			EnvVars:     []string{"RKE2_KUBE_SCHEDULER_IMAGE"},
+			Destination: &config.Images.KubeScheduler,
+		},
+		&cli.StringFlag{
+			Name:        images.Pause,
+			Usage:       "(image) Override image to use for pause",
+			EnvVars:     []string{"RKE2_PAUSE_IMAGE"},
+			Destination: &config.Images.Pause,
+		},
+		&cli.StringFlag{
+			Name:        images.Runtime,
+			Usage:       "(image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc)",
+			EnvVars:     []string{"RKE2_RUNTIME_IMAGE"},
+			Destination: &config.Images.Runtime,
+		},
+		&cli.StringFlag{
+			Name:        images.ETCD,
+			Usage:       "(image) Override image to use for etcd",
+			EnvVars:     []string{"RKE2_ETCD_IMAGE"},
+			Destination: &config.Images.ETCD,
+		},
+		&cli.StringFlag{
+			Name:        "kubelet-path",
+			Usage:       "(experimental/agent) Override kubelet binary path",
+			EnvVars:     []string{"RKE2_KUBELET_PATH"},
+			Destination: &config.KubeletPath,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-name",
+			Usage:       "(cloud provider) Cloud provider name",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_NAME"},
+			Destination: &config.CloudProviderName,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-config",
+			Usage:       "(cloud provider) Cloud provider configuration file path",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_CONFIG"},
+			Destination: &config.CloudProviderConfig,
+		},
+		&cli.BoolFlag{
+			Name:        "node-name-from-cloud-provider-metadata",
+			Usage:       "(cloud provider) Set node name from instance metadata service hostname",
+			EnvVars:     []string{"RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA"},
+			Destination: &config.CloudProviderMetadataHostname,
+		},
+		&cli.StringFlag{
+			Name:    "profile",
+			Usage:   "(security) Validate system configuration against the selected benchmark (valid items: cis, etcd)",
+			EnvVars: []string{"RKE2_CIS_PROFILE"},
+		},
+		&cli.StringFlag{
+			Name:        "audit-policy-file",
+			Usage:       "(security) Path to the file that defines the audit policy configuration",
+			EnvVars:     []string{"RKE2_AUDIT_POLICY_FILE"},
+			Destination: &config.AuditPolicyFile,
+		},
+		&cli.StringFlag{
+			Name:        "pod-security-admission-config-file",
+			Usage:       "(security) Path to the file that defines Pod Security Admission configuration",
+			EnvVars:     []string{"RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE"},
+			Destination: &config.PodSecurityAdmissionConfigFile,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-requests",
+			Usage:       "(components) Control Plane resource requests",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_REQUESTS"},
+			Destination: &config.ControlPlaneResourceRequests,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-limits",
+			Usage:       "(components) Control Plane resource limits",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_LIMITS"},
+			Destination: &config.ControlPlaneResourceLimits,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-probe-configuration",
+			Usage:       "(components) Control Plane Probe configuration",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_PROBE_CONFIGURATION"},
+			Destination: &config.ControlPlaneProbeConf,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-mount",
+			Usage:       "(components) " + podtemplate.Etcd + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.CloudControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-env",
+			Usage:       "(components) " + podtemplate.Etcd + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.CloudControllerManager,
+		},
+	}
+)
+
+type CLIRole int64
+
+const (
+	Agent CLIRole = iota
+	Server
+)
+
+func init() {
+	// hack - force "file,dns" lookup order if go dns is used
+	if os.Getenv("RES_OPTIONS") == "" {
+		os.Setenv("RES_OPTIONS", " ")
+	}
+}
+
+func validateCloudProviderName(clx *cli.Context, role CLIRole) {
+	cloudProvider := clx.String("cloud-provider-name")
+	cloudProviderDisables := map[string][]string{
+		"rancher-vsphere": {"rancher-vsphere-cpi", "rancher-vsphere-csi"},
+		"harvester":       {"harvester-cloud-provider", "harvester-csi-driver"},
+	}
+
+	for providerName, disables := range cloudProviderDisables {
+		if providerName == cloudProvider {
+			clx.Set("cloud-provider-name", "external")
+			if role == Server {
+				clx.Set("disable-cloud-controller", "true")
+			}
+		} else {
+			if role == Server {
+				for _, disable := range disables {
+					clx.Set("disable", disable)
+				}
+			}
+		}
+	}
+}
+
+func NewApp() *cli.App {
+	app := cli.NewApp()
+	app.Name = appName
+	app.EnableBashCompletion = true
+	app.DisableSliceFlagSeparator = true
+	app.Usage = "Rancher Kubernetes Engine 2"
+	app.Version = fmt.Sprintf("%s (%s)", version.Version, version.GitCommit)
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s version %s\n", app.Name, app.Version)
+		fmt.Printf("go version %s\n", runtime.Version())
+	}
+
+	return app
+}

--- a/thirdparty-src/rke2/v1_35/zz_server.go
+++ b/thirdparty-src/rke2/v1_35/zz_server.go
@@ -1,0 +1,284 @@
+package cmds
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/wrangler/v3/pkg/slice"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	rke2Path = "/var/lib/rancher/rke2"
+)
+
+var (
+	CNIFlag = &cli.StringSliceFlag{
+		Name:        "cni",
+		Usage:       "(networking) CNI Plugins to deploy, one of none, " + strings.Join(rke2cli.CNIItems, ", ") + "; optionally with multus as the first value to enable the multus meta-plugin",
+		EnvVars:     []string{"RKE2_CNI"},
+		Value:       cli.NewStringSlice("canal"),
+		Destination: &config.CNI,
+	}
+	IngressControllerFlag = &cli.StringSliceFlag{
+		Name:  "ingress-controller",
+		Usage: "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
+		// TODO: In v1.36, add warning about RKE_INGRESS_CONTROLLER deprecation
+		// In v1.37, add fatal error if RKE_INGRESS_CONTROLLER is used
+		// In v1.38, remove RKE_INGRESS_CONTROLLER entirely
+		EnvVars:     []string{"RKE2_INGRESS_CONTROLLER", "RKE_INGRESS_CONTROLLER"},
+		Value:       cli.NewStringSlice("ingress-nginx"),
+		Destination: &config.IngressController,
+	}
+	ServiceLBFlag = &cli.BoolFlag{
+		Name:    "enable-servicelb",
+		Usage:   "(components) Enable rke2 default cloud controller manager's service controller",
+		EnvVars: []string{"RKE2_ENABLE_SERVICELB"},
+	}
+	PrimeFlag = &cli.BoolFlag{
+		Name:    "prime",
+		Usage:   "Configures RKE2 to utilize the Rancher Prime Registry and features",
+		Hidden:  true,
+		EnvVars: []string{"RKE2_PRIME"},
+	}
+
+	serverFlag = []cli.Flag{
+		CNIFlag,
+		IngressControllerFlag,
+		ServiceLBFlag,
+		PrimeFlag,
+	}
+
+	k3sServerBase = mustCmdFromK3S(cmds.NewServerCommand(ServerRun), K3SFlagSet{
+		"config":                 copyFlag,
+		"debug":                  copyFlag,
+		"v":                      hideFlag,
+		"vmodule":                hideFlag,
+		"log":                    hideFlag,
+		"alsologtostderr":        hideFlag,
+		"bind-address":           copyFlag,
+		"https-listen-port":      dropFlag,
+		"supervisor-port":        dropFlag,
+		"apiserver-port":         dropFlag,
+		"apiserver-bind-address": dropFlag,
+		"advertise-address":      copyFlag,
+		"advertise-port":         dropFlag,
+		"tls-san":                copyFlag,
+		"tls-san-security":       copyFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"disable-agent":                     hideFlag,
+		"cluster-cidr":                      copyFlag,
+		"service-cidr":                      copyFlag,
+		"cluster-init":                      dropFlag,
+		"cluster-reset":                     copyFlag,
+		"cluster-reset-restore-path":        copyFlag,
+		"cluster-dns":                       copyFlag,
+		"cluster-domain":                    copyFlag,
+		"flannel-backend":                   dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"write-kubeconfig":                  copyFlag,
+		"write-kubeconfig-mode":             copyFlag,
+		"write-kubeconfig-group":            copyFlag,
+		"kube-apiserver-arg":                copyFlag,
+		"etcd-arg":                          copyFlag,
+		"kube-scheduler-arg":                copyFlag,
+		"kube-controller-arg":               dropFlag, // deprecated version of kube-controller-manager-arg
+		"kube-controller-manager-arg":       copyFlag,
+		"kube-cloud-controller-manager-arg": copyFlag,
+		"kube-cloud-controller-arg":         dropFlag, // deprecated version of kube-cloud-controller-manager-arg
+		"datastore-endpoint":                copyFlag,
+		"datastore-cafile":                  copyFlag,
+		"datastore-certfile":                copyFlag,
+		"datastore-keyfile":                 copyFlag,
+		"kine-tls":                          dropFlag,
+		"default-local-storage-path":        dropFlag,
+		"disable": {
+			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + strings.Join(rke2cli.DisableItems, ", ") + ")",
+		},
+		"disable-scheduler":                 copyFlag,
+		"disable-cloud-controller":          copyFlag,
+		"disable-network-policy":            dropFlag,
+		"disable-kube-proxy":                copyFlag,
+		"disable-apiserver":                 copyFlag,
+		"disable-controller-manager":        copyFlag,
+		"disable-etcd":                      copyFlag,
+		"etcd-disable-snapshots":            copyFlag,
+		"etcd-snapshot-schedule-cron":       copyFlag,
+		"etcd-snapshot-reconcile-interval":  copyFlag,
+		"etcd-snapshot-retention":           copyFlag,
+		"etcd-snapshot-dir":                 copyFlag,
+		"etcd-snapshot-name":                copyFlag,
+		"etcd-snapshot-compress":            copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"embedded-registry":                 copyFlag,
+		"supervisor-metrics":                copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"private-registry":                  copyFlag,
+		"system-default-registry":           copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"flannel-ipv6-masq":                 dropFlag,
+		"flannel-external-ip":               dropFlag,
+		"egress-selector-mode":              copyFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"agent-token":                       copyFlag,
+		"agent-token-file":                  copyFlag,
+		"server":                            copyFlag,
+		"secrets-encryption":                hideFlag,
+		"secrets-encryption-provider":       copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"service-node-port-range":           copyFlag,
+		"etcd-expose-metrics":               copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"etcd-s3":                           copyFlag,
+		"etcd-s3-access-key":                copyFlag,
+		"etcd-s3-bucket":                    copyFlag,
+		"etcd-s3-bucket-lookup-type":        copyFlag,
+		"etcd-s3-config-secret":             copyFlag,
+		"etcd-s3-endpoint":                  copyFlag,
+		"etcd-s3-endpoint-ca":               copyFlag,
+		"etcd-s3-folder":                    copyFlag,
+		"etcd-s3-insecure":                  copyFlag,
+		"etcd-s3-proxy":                     copyFlag,
+		"etcd-s3-region":                    copyFlag,
+		"etcd-s3-secret-key":                copyFlag,
+		"etcd-s3-session-token":             copyFlag,
+		"etcd-s3-skip-ssl-verify":           copyFlag,
+		"etcd-s3-timeout":                   copyFlag,
+		"etcd-s3-retention":                 copyFlag,
+		"disable-helm-controller":           dropFlag,
+		"helm-job-image":                    copyFlag,
+		"helm-controller-arg":               copyFlag,
+		"enable-pprof":                      copyFlag,
+		"servicelb-namespace":               copyFlag,
+	})
+)
+
+func NewServerCommand() *cli.Command {
+	cmd := k3sServerBase
+	cmd.Flags = append(cmd.Flags, serverFlag...)
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func ServerRun(clx *cli.Context) error {
+	validateCloudProviderName(clx, Server)
+	validateProfile(clx, Server)
+	validateCNI(clx)
+	validateIngress(clx)
+	return rke2.Server(clx, config)
+}
+
+// validateCNI validates the CNI selection, and disables any un-selected CNI charts
+func validateCNI(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.CNIItems, CNIFlag, func(values []string) ([]string, error) {
+		switch len(values) {
+		case 0:
+			values = append(values, "canal")
+			fallthrough
+		case 1:
+			if values[0] == "multus" {
+				return nil, errors.New("multus must be used alongside another primary cni selection")
+			}
+			clx.Set("disable", "rke2-multus")
+		case 2:
+			if values[0] == "multus" {
+				values = values[1:]
+			} else {
+				return nil, errors.New("may only provide multiple values if multus is the first value")
+			}
+		default:
+			return nil, errors.New("must specify 1 or 2 values")
+		}
+		return values, nil
+	})
+}
+
+// validateCNI validates the ingress controller selection, and disables any un-selected ingress controller charts
+func validateIngress(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.IngressItems, IngressControllerFlag, func(values []string) ([]string, error) {
+		return values, nil
+	})
+}
+
+// disableExceptSelected takes a list of valid flag values, and a CLI StringSlice flag that holds the user's selected values.
+// Selected values are split to support comma-separated lists, in addition to repeated use of the same flag.
+// Once the list has been split, a validation function is called to allow for custom validation or defaulting of selected values.
+// Finally, charts for any valid items not selected are added to the --disable list.
+// A value of 'none' will cause all valid items to be disabled.
+// Errors from the validation function, or selection of a value not in the valid list, will cause a fatal error to be logged.
+func disableExceptSelected(clx *cli.Context, valid []string, flag *cli.StringSliceFlag, validateFunc func([]string) ([]string, error)) {
+	// split comma-separated values
+	values := []string{}
+	for _, v := range clx.StringSlice(flag.Name) {
+		values = append(values, strings.Split(v, ",")...)
+	}
+	// validate the flag after splitting values
+	if v, err := validateFunc(values); err != nil {
+		logrus.Fatalf("Failed to validate --%s flag: %v", flag.Name, err)
+	} else {
+		values = v
+	}
+
+	// prepare a list of items to disable, based on all valid components.
+	// we have to use an intermediate set because the flag interface
+	// doesn't allow us to remove flag values once added.
+	disabledCharts := sets.Set[string]{}
+	for _, d := range valid {
+		disabledCharts.Insert("rke2-"+d, "rke2-"+d+"-crd")
+	}
+
+	// re-enable components for any selected flag values
+	for _, d := range values {
+		switch {
+		case d == "none":
+			continue
+		case slice.ContainsString(valid, d):
+			disabledCharts.Delete("rke2-"+d, "rke2-"+d+"-crd")
+		default:
+			logrus.Fatalf("Invalid value %s for --%s flag: must be one of %s", d, flag.Name, strings.Join(valid, ","))
+		}
+	}
+
+	for _, c := range disabledCharts.UnsortedList() {
+		clx.Set("disable", c)
+	}
+}

--- a/thirdparty-src/rke2/v1_36/SOURCE.txt
+++ b/thirdparty-src/rke2/v1_36/SOURCE.txt
@@ -1,0 +1,4 @@
+repo:   https://github.com/rancher/rke2
+tag:    v1.36.4+rke2r1
+commit: 7479a59cdd2c8ce0b8871699a24daa4b7c28cc64
+files:  pkg/cli/cmds/server.go pkg/cli/cmds/agent.go pkg/cli/cmds/root.go pkg/cli/cmds/k3sopts.go

--- a/thirdparty-src/rke2/v1_36/zz_agent.go
+++ b/thirdparty-src/rke2/v1_36/zz_agent.go
@@ -1,0 +1,111 @@
+package cmds
+
+import (
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/rke2/pkg/windows"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	k3sAgentBase = mustCmdFromK3S(cmds.NewAgentCommand(AgentRun), K3SFlagSet{
+		"config":          copyFlag,
+		"debug":           copyFlag,
+		"v":               hideFlag,
+		"vmodule":         hideFlag,
+		"log":             hideFlag,
+		"alsologtostderr": hideFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"disable-apiserver-lb":              dropFlag,
+		"private-registry":                  copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"server":                            copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"bind-address":                      copyFlag,
+		"enable-pprof":                      copyFlag,
+	})
+	deprecatedFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "system-default-registry",
+			Usage:   "(deprecated) This flag is no longer supported on agents",
+			EnvVars: []string{"RKE2_SYSTEM_DEFAULT_REGISTRY"},
+			Hidden:  true,
+		},
+	}
+)
+
+func NewAgentCommand() *cli.Command {
+	cmd := k3sAgentBase
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	cmd.Flags = append(cmd.Flags, deprecatedFlags...)
+	cmd.Subcommands = agentSubcommands()
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func agentSubcommands() []*cli.Command {
+	subcommands := []*cli.Command{
+		// subcommands used by both windows/linux, none yet
+	}
+
+	// linux/windows only subcommands
+	subcommands = append(subcommands, serviceSubcommand)
+
+	return subcommands
+}
+
+func AgentRun(clx *cli.Context) error {
+	if err := validateCloudProvider(clx, Agent); err != nil {
+		return err
+	}
+	validateProfile(clx, Agent)
+	isWinService, err := windows.StartService()
+	if err != nil {
+		return err
+	}
+
+	err = rke2.Agent(clx, config)
+	if isWinService {
+		windows.MonitorProcessExit()
+	}
+
+	return err
+}

--- a/thirdparty-src/rke2/v1_36/zz_k3sopts.go
+++ b/thirdparty-src/rke2/v1_36/zz_k3sopts.go
@@ -1,0 +1,153 @@
+package cmds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/util/errors"
+	"github.com/rancher/wrangler/v3/pkg/merr"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	copyFlag   = &K3SFlagOption{}
+	dropFlag   = &K3SFlagOption{Drop: true}
+	hideFlag   = &K3SFlagOption{Hide: true}
+	ignoreFlag = &K3SFlagOption{Ignore: true}
+)
+
+// K3SFlagOption describes how a CLI flag from K3s should be wrapped.
+type K3SFlagOption struct {
+	Hide    bool
+	Drop    bool
+	Ignore  bool
+	Usage   string
+	Default string
+}
+
+// K3SFlagSet is a map of flag names to options
+type K3SFlagSet map[string]*K3SFlagOption
+
+// CopyInto copies flags from a source set into the destination
+func (k K3SFlagSet) CopyInto(d K3SFlagSet) {
+	for key, val := range k {
+		d[key] = val
+	}
+}
+
+func mustCmdFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) *cli.Command {
+	cmd, err := commandFromK3S(cmd, flagOpts)
+	if err != nil {
+		panic(errors.WithMessagef(err, "failed to wrap command %q", cmd.Name))
+	}
+	return cmd
+}
+
+func commandFromK3S(cmd *cli.Command, flagOpts K3SFlagSet) (*cli.Command, error) {
+	var (
+		newFlags []cli.Flag
+		seen     = map[string]bool{}
+		errs     merr.Errors
+	)
+
+	for _, flag := range cmd.Flags {
+		name := parseName(flag)
+		opt, ok := flagOpts[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("missing flag options for k3s flag %q", name))
+			continue
+		}
+		seen[name] = true
+		if opt == nil {
+			opt = &K3SFlagOption{}
+		}
+
+		if opt.Drop {
+			continue
+		}
+
+		if strFlag, ok := flag.(*cli.StringFlag); ok {
+			if opt.Usage != "" {
+				strFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				strFlag.Value = opt.Default
+			}
+			if opt.Hide {
+				strFlag.Hidden = true
+			}
+			flag = strFlag
+		} else if strSliceFlag, ok := flag.(*cli.StringSliceFlag); ok {
+			if opt.Usage != "" {
+				strSliceFlag.Usage = opt.Usage
+			}
+			if opt.Default != "" {
+				slice := &cli.StringSlice{}
+				parts := strings.Split(opt.Default, ",")
+				for _, val := range parts {
+					slice.Set(val)
+				}
+				strSliceFlag.Value = slice
+			}
+			if opt.Hide {
+				strSliceFlag.Hidden = true
+			}
+			flag = strSliceFlag
+		} else if intFlag, ok := flag.(*cli.IntFlag); ok {
+			if opt.Usage != "" {
+				intFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				intFlag.Hidden = true
+			}
+			flag = intFlag
+		} else if boolFlag, ok := flag.(*cli.BoolFlag); ok {
+			if opt.Usage != "" {
+				boolFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				boolFlag.Hidden = true
+			}
+			flag = boolFlag
+		} else if durationFlag, ok := flag.(*cli.DurationFlag); ok {
+			if opt.Usage != "" {
+				durationFlag.Usage = opt.Usage
+			}
+			if opt.Hide {
+				durationFlag.Hidden = true
+			}
+			flag = durationFlag
+		} else {
+			errs = append(errs, fmt.Errorf("unsupported type %T for flag %q", flag, name))
+		}
+
+		newFlags = append(newFlags, flag)
+	}
+
+	for k, v := range flagOpts {
+		if !seen[k] {
+			if v != nil && v.Ignore {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("got flag options for unknown k3s flag %q", k))
+			continue
+		}
+	}
+
+	cmd.Flags = newFlags
+	return cmd, errs.Err()
+}
+
+// parseName returns a single primary flag name.
+// Flags with short versions may be named "flag", "flag,f", "f,flag", "flag, f" and so on.
+// This returns just the first long version, or the short version if no long is available.
+func parseName(flag cli.Flag) string {
+	names := flag.Names()
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if len(n) > 1 {
+			return n
+		}
+	}
+	return strings.TrimSpace(names[0])
+}

--- a/thirdparty-src/rke2/v1_36/zz_root.go
+++ b/thirdparty-src/rke2/v1_36/zz_root.go
@@ -1,0 +1,288 @@
+package cmds
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/version"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/images"
+	"github.com/rancher/rke2/pkg/podtemplate"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	appName    = filepath.Base(os.Args[0])
+	config     = rke2cli.Config{}
+	commonFlag = []cli.Flag{
+		&cli.StringFlag{
+			Name:        images.KubeAPIServer,
+			Usage:       "(image) Override image to use for kube-apiserver",
+			EnvVars:     []string{"RKE2_KUBE_APISERVER_IMAGE"},
+			Destination: &config.Images.KubeAPIServer,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeControllerManager,
+			Usage:       "(image) Override image to use for kube-controller-manager",
+			EnvVars:     []string{"RKE2_KUBE_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.KubeControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.CloudControllerManager,
+			Usage:       "(image) Override image to use for cloud-controller-manager",
+			EnvVars:     []string{"RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE"},
+			Destination: &config.Images.CloudControllerManager,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeProxy,
+			Usage:       "(image) Override image to use for kube-proxy",
+			EnvVars:     []string{"RKE2_KUBE_PROXY_IMAGE"},
+			Destination: &config.Images.KubeProxy,
+		},
+		&cli.StringFlag{
+			Name:        images.KubeScheduler,
+			Usage:       "(image) Override image to use for kube-scheduler",
+			EnvVars:     []string{"RKE2_KUBE_SCHEDULER_IMAGE"},
+			Destination: &config.Images.KubeScheduler,
+		},
+		&cli.StringFlag{
+			Name:        images.Pause,
+			Usage:       "(image) Override image to use for pause",
+			EnvVars:     []string{"RKE2_PAUSE_IMAGE"},
+			Destination: &config.Images.Pause,
+		},
+		&cli.StringFlag{
+			Name:        images.Runtime,
+			Usage:       "(image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc)",
+			EnvVars:     []string{"RKE2_RUNTIME_IMAGE"},
+			Destination: &config.Images.Runtime,
+		},
+		&cli.StringFlag{
+			Name:        images.ETCD,
+			Usage:       "(image) Override image to use for etcd",
+			EnvVars:     []string{"RKE2_ETCD_IMAGE"},
+			Destination: &config.Images.ETCD,
+		},
+		&cli.StringFlag{
+			Name:        "kubelet-path",
+			Usage:       "(experimental/agent) Override kubelet binary path",
+			EnvVars:     []string{"RKE2_KUBELET_PATH"},
+			Destination: &config.KubeletPath,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-name",
+			Usage:       "(cloud provider) Cloud provider name",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_NAME"},
+			Destination: &config.CloudProviderName,
+		},
+		&cli.StringFlag{
+			Name:        "cloud-provider-config",
+			Usage:       "(cloud provider) Cloud provider configuration file path",
+			EnvVars:     []string{"RKE2_CLOUD_PROVIDER_CONFIG"},
+			Destination: &config.CloudProviderConfig,
+		},
+		&cli.BoolFlag{
+			Name:        "node-name-from-cloud-provider-metadata",
+			Usage:       "(cloud provider) Set node name from instance metadata service hostname",
+			EnvVars:     []string{"RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA"},
+			Destination: &config.CloudProviderMetadataHostname,
+		},
+		&cli.StringFlag{
+			Name:    "profile",
+			Usage:   "(security) Validate system configuration against the selected benchmark (valid items: cis, etcd)",
+			EnvVars: []string{"RKE2_CIS_PROFILE"},
+		},
+		&cli.StringFlag{
+			Name:        "audit-policy-file",
+			Usage:       "(security) Path to the file that defines the audit policy configuration",
+			EnvVars:     []string{"RKE2_AUDIT_POLICY_FILE"},
+			Destination: &config.AuditPolicyFile,
+		},
+		&cli.StringFlag{
+			Name:        "pod-security-admission-config-file",
+			Usage:       "(security) Path to the file that defines Pod Security Admission configuration",
+			EnvVars:     []string{"RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE"},
+			Destination: &config.PodSecurityAdmissionConfigFile,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-requests",
+			Usage:       "(components) Control Plane resource requests",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_REQUESTS"},
+			Destination: &config.ControlPlaneResourceRequests,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-resource-limits",
+			Usage:       "(components) Control Plane resource limits",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_RESOURCE_LIMITS"},
+			Destination: &config.ControlPlaneResourceLimits,
+		},
+		&cli.StringSliceFlag{
+			Name:        "control-plane-probe-configuration",
+			Usage:       "(components) Control Plane Probe configuration",
+			EnvVars:     []string{"RKE2_CONTROL_PLANE_PROBE_CONFIGURATION"},
+			Destination: &config.ControlPlaneProbeConf,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-mount",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-mount",
+			Usage:       "(components) " + podtemplate.Etcd + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-mount",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra volume mounts",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_MOUNT"},
+			Destination: &config.ExtraMounts.CloudControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeAPIServer + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeAPIServer + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeAPIServer, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeAPIServer,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeScheduler + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeScheduler + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeScheduler, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeScheduler,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeControllerManager,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.KubeProxy + "-extra-env",
+			Usage:       "(components) " + podtemplate.KubeProxy + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.KubeProxy, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.KubeProxy,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.Etcd + "-extra-env",
+			Usage:       "(components) " + podtemplate.Etcd + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.Etcd, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.Etcd,
+		},
+		&cli.StringSliceFlag{
+			Name:        podtemplate.CloudControllerManager + "-extra-env",
+			Usage:       "(components) " + podtemplate.CloudControllerManager + " extra environment variables",
+			EnvVars:     []string{"RKE2_" + strings.ToUpper(strings.ReplaceAll(podtemplate.CloudControllerManager, "-", "_")) + "_EXTRA_ENV"},
+			Destination: &config.ExtraEnv.CloudControllerManager,
+		},
+	}
+)
+
+type CLIRole int64
+
+const (
+	Agent CLIRole = iota
+	Server
+)
+
+func init() {
+	// hack - force "file,dns" lookup order if go dns is used
+	if os.Getenv("RES_OPTIONS") == "" {
+		os.Setenv("RES_OPTIONS", " ")
+	}
+}
+
+// bundled cloud-providers (as supported by setting cloud-provider-name)
+// usually include both a CPI and CSI chart, but this is not required.
+// If the cloud-provider is CSI only, we leave the RKE2 embedded cloud provider
+// enabled.
+type bundledCloudProvider struct {
+	name string
+	csi  string
+	cpi  string
+}
+
+var cloudProviders = []bundledCloudProvider{
+	{
+		name: "rancher-vsphere",
+		csi:  "rancher-vsphere-csi",
+		cpi:  "rancher-vsphere-cpi",
+	},
+	{
+		name: "harvester",
+		csi:  "harvester-csi-driver",
+		cpi:  "harvester-cloud-provider",
+	},
+	{
+		name: "ovirt",
+		csi:  "rke2-ovirt-csi-driver",
+	},
+}
+
+func validateCloudProvider(clx *cli.Context, role CLIRole) error {
+	cloudProvider := clx.String("cloud-provider-name")
+
+	if clx.IsSet("cloud-provider-name") || clx.IsSet("cloud-provider-config") {
+		if clx.IsSet("node-external-ip") {
+			return errors.New("can't set node-external-ip while using cloud provider")
+		}
+	}
+
+	for _, provider := range cloudProviders {
+		if provider.name == cloudProvider {
+			clx.Set("cloud-provider-name", "external")
+			if role == Server && provider.cpi != "" {
+				clx.Set("disable-cloud-controller", "true")
+			}
+		} else {
+			if role == Server {
+				if provider.csi != "" {
+					clx.Set("disable", provider.csi)
+				}
+				if provider.cpi != "" {
+					clx.Set("disable", provider.cpi)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func NewApp() *cli.App {
+	app := cli.NewApp()
+	app.Name = appName
+	app.EnableBashCompletion = true
+	app.DisableSliceFlagSeparator = true
+	app.Usage = "Rancher Kubernetes Engine 2"
+	app.Version = fmt.Sprintf("%s (%s)", version.Version, version.GitCommit)
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s version %s\n", app.Name, app.Version)
+		fmt.Printf("go version %s\n", runtime.Version())
+	}
+
+	return app
+}

--- a/thirdparty-src/rke2/v1_36/zz_server.go
+++ b/thirdparty-src/rke2/v1_36/zz_server.go
@@ -1,0 +1,277 @@
+package cmds
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/k3s-io/k3s/pkg/cli/cmds"
+	"github.com/k3s-io/k3s/pkg/configfilearg"
+	rke2cli "github.com/rancher/rke2/pkg/cli"
+	"github.com/rancher/rke2/pkg/rke2"
+	"github.com/rancher/wrangler/v3/pkg/slice"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	rke2Path = "/var/lib/rancher/rke2"
+)
+
+var (
+	CNIFlag = &cli.StringSliceFlag{
+		Name:        "cni",
+		Usage:       "(networking) CNI Plugins to deploy, one of none, " + strings.Join(rke2cli.CNIItems, ", ") + "; optionally with multus as the first value to enable the multus meta-plugin",
+		EnvVars:     []string{"RKE2_CNI"},
+		Value:       cli.NewStringSlice("canal"),
+		Destination: &config.CNI,
+	}
+	IngressControllerFlag = &cli.StringSliceFlag{
+		Name:  "ingress-controller",
+		Usage: "(networking) Ingress Controllers to deploy, one of none, " + strings.Join(rke2cli.IngressItems, ", ") + "; the first value will be set as the default ingress class",
+		// TODO: In v1.36, add warning about RKE_INGRESS_CONTROLLER deprecation
+		// In v1.37, add fatal error if RKE_INGRESS_CONTROLLER is used
+		// In v1.38, remove RKE_INGRESS_CONTROLLER entirely
+		EnvVars:     []string{"RKE2_INGRESS_CONTROLLER", "RKE_INGRESS_CONTROLLER"},
+		Destination: &config.IngressController,
+	}
+	ServiceLBFlag = &cli.BoolFlag{
+		Name:    "enable-servicelb",
+		Usage:   "(components) Enable rke2 default cloud controller manager's service controller",
+		EnvVars: []string{"RKE2_ENABLE_SERVICELB"},
+	}
+	PrimeFlag = &cli.BoolFlag{
+		Name:    "prime",
+		Usage:   "Configures RKE2 to utilize the Rancher Prime Registry and features",
+		Hidden:  true,
+		EnvVars: []string{"RKE2_PRIME"},
+	}
+
+	serverFlag = []cli.Flag{
+		CNIFlag,
+		IngressControllerFlag,
+		ServiceLBFlag,
+		PrimeFlag,
+	}
+
+	k3sServerBase = mustCmdFromK3S(cmds.NewServerCommand(ServerRun), K3SFlagSet{
+		"config":                 copyFlag,
+		"debug":                  copyFlag,
+		"v":                      hideFlag,
+		"vmodule":                hideFlag,
+		"log":                    hideFlag,
+		"alsologtostderr":        hideFlag,
+		"bind-address":           copyFlag,
+		"https-listen-port":      dropFlag,
+		"supervisor-port":        dropFlag,
+		"apiserver-port":         dropFlag,
+		"apiserver-bind-address": dropFlag,
+		"advertise-address":      copyFlag,
+		"advertise-port":         dropFlag,
+		"tls-san":                copyFlag,
+		"tls-san-security":       copyFlag,
+		"data-dir": {
+			Usage:   "(data) Folder to hold state",
+			Default: rke2Path,
+		},
+		"disable-agent":                     hideFlag,
+		"cluster-cidr":                      copyFlag,
+		"service-cidr":                      copyFlag,
+		"cluster-init":                      dropFlag,
+		"cluster-reset":                     copyFlag,
+		"cluster-reset-restore-path":        copyFlag,
+		"cluster-dns":                       copyFlag,
+		"cluster-domain":                    copyFlag,
+		"flannel-backend":                   dropFlag,
+		"vpn-auth":                          dropFlag,
+		"vpn-auth-file":                     dropFlag,
+		"token":                             copyFlag,
+		"token-file":                        copyFlag,
+		"write-kubeconfig":                  copyFlag,
+		"write-kubeconfig-mode":             copyFlag,
+		"write-kubeconfig-group":            copyFlag,
+		"kube-apiserver-arg":                copyFlag,
+		"etcd-arg":                          copyFlag,
+		"kube-scheduler-arg":                copyFlag,
+		"kube-controller-arg":               dropFlag, // deprecated version of kube-controller-manager-arg
+		"kube-controller-manager-arg":       copyFlag,
+		"kube-cloud-controller-manager-arg": copyFlag,
+		"kube-cloud-controller-arg":         dropFlag, // deprecated version of kube-cloud-controller-manager-arg
+		"datastore-endpoint":                copyFlag,
+		"datastore-cafile":                  copyFlag,
+		"datastore-certfile":                copyFlag,
+		"datastore-keyfile":                 copyFlag,
+		"kine-tls":                          dropFlag,
+		"default-local-storage-path":        dropFlag,
+		"disable": {
+			Usage: "(components) Do not deploy packaged components and delete any deployed components (valid items: " + strings.Join(rke2cli.DisableItems, ", ") + ")",
+		},
+		"disable-scheduler":                 copyFlag,
+		"disable-cloud-controller":          copyFlag,
+		"disable-network-policy":            dropFlag,
+		"disable-kube-proxy":                copyFlag,
+		"disable-apiserver":                 copyFlag,
+		"disable-controller-manager":        copyFlag,
+		"disable-etcd":                      copyFlag,
+		"etcd-disable-snapshots":            copyFlag,
+		"etcd-snapshot-schedule-cron":       copyFlag,
+		"etcd-snapshot-reconcile-interval":  copyFlag,
+		"etcd-snapshot-retention":           copyFlag,
+		"etcd-snapshot-dir":                 copyFlag,
+		"etcd-snapshot-name":                copyFlag,
+		"etcd-snapshot-compress":            copyFlag,
+		"node-name":                         copyFlag,
+		"with-node-id":                      copyFlag,
+		"node-label":                        copyFlag,
+		"node-taint":                        copyFlag,
+		"image-credential-provider-bin-dir": copyFlag,
+		"image-credential-provider-config":  copyFlag,
+		"docker":                            dropFlag,
+		"container-runtime-endpoint": {
+			Usage: "(agent/runtime) Disable embedded containerd and use the CRI socket at the given path",
+		},
+		"disable-default-registry-endpoint": copyFlag,
+		"nonroot-devices":                   copyFlag,
+		"embedded-registry":                 copyFlag,
+		"supervisor-metrics":                copyFlag,
+		"image-service-endpoint":            dropFlag,
+		"pause-image":                       dropFlag,
+		"default-runtime":                   copyFlag,
+		"private-registry":                  copyFlag,
+		"system-default-registry":           copyFlag,
+		"node-ip":                           copyFlag,
+		"node-external-ip":                  copyFlag,
+		"node-internal-dns":                 copyFlag,
+		"node-external-dns":                 copyFlag,
+		"resolv-conf":                       copyFlag,
+		"flannel-iface":                     dropFlag,
+		"flannel-conf":                      dropFlag,
+		"flannel-cni-conf":                  dropFlag,
+		"flannel-ipv6-masq":                 dropFlag,
+		"flannel-external-ip":               dropFlag,
+		"egress-selector-mode":              copyFlag,
+		"kubelet-arg":                       copyFlag,
+		"kube-proxy-arg":                    copyFlag,
+		"rootless":                          dropFlag,
+		"prefer-bundled-bin":                dropFlag,
+		"agent-token":                       copyFlag,
+		"agent-token-file":                  copyFlag,
+		"server":                            copyFlag,
+		"secrets-encryption":                hideFlag,
+		"secrets-encryption-provider":       copyFlag,
+		"protect-kernel-defaults":           copyFlag,
+		"snapshotter":                       copyFlag,
+		"selinux":                           copyFlag,
+		"lb-server-port":                    copyFlag,
+		"service-node-port-range":           copyFlag,
+		"etcd-expose-metrics":               copyFlag,
+		"airgap-extra-registry":             copyFlag,
+		"etcd-s3":                           copyFlag,
+		"etcd-s3-access-key":                copyFlag,
+		"etcd-s3-bucket":                    copyFlag,
+		"etcd-s3-bucket-lookup-type":        copyFlag,
+		"etcd-s3-config-secret":             copyFlag,
+		"etcd-s3-endpoint":                  copyFlag,
+		"etcd-s3-endpoint-ca":               copyFlag,
+		"etcd-s3-folder":                    copyFlag,
+		"etcd-s3-insecure":                  copyFlag,
+		"etcd-s3-proxy":                     copyFlag,
+		"etcd-s3-region":                    copyFlag,
+		"etcd-s3-secret-key":                copyFlag,
+		"etcd-s3-session-token":             copyFlag,
+		"etcd-s3-skip-ssl-verify":           copyFlag,
+		"etcd-s3-timeout":                   copyFlag,
+		"etcd-s3-retention":                 copyFlag,
+		"disable-helm-controller":           dropFlag,
+		"helm-job-image":                    copyFlag,
+		"helm-controller-arg":               copyFlag,
+		"enable-pprof":                      copyFlag,
+		"servicelb-namespace":               copyFlag,
+	})
+)
+
+func NewServerCommand() *cli.Command {
+	cmd := k3sServerBase
+	cmd.Flags = append(cmd.Flags, serverFlag...)
+	cmd.Flags = append(cmd.Flags, commonFlag...)
+	configfilearg.DefaultParser.ValidFlags[cmd.Name] = cmd.Flags
+	return cmd
+}
+
+func ServerRun(clx *cli.Context) error {
+	if err := validateCloudProvider(clx, Server); err != nil {
+		return err
+	}
+	validateProfile(clx, Server)
+	validateCNI(clx)
+	return rke2.Server(clx, config)
+}
+
+// validateCNI validates the CNI selection, and disables any un-selected CNI charts
+func validateCNI(clx *cli.Context) {
+	disableExceptSelected(clx, rke2cli.CNIItems, CNIFlag, func(values []string) ([]string, error) {
+		switch len(values) {
+		case 0:
+			values = append(values, "canal")
+			fallthrough
+		case 1:
+			if values[0] == "multus" {
+				return nil, errors.New("multus must be used alongside another primary cni selection")
+			}
+			clx.Set("disable", "rke2-multus")
+		case 2:
+			if values[0] == "multus" {
+				values = values[1:]
+			} else {
+				return nil, errors.New("may only provide multiple values if multus is the first value")
+			}
+		default:
+			return nil, errors.New("must specify 1 or 2 values")
+		}
+		return values, nil
+	})
+}
+
+// disableExceptSelected takes a list of valid flag values, and a CLI StringSlice flag that holds the user's selected values.
+// Selected values are split to support comma-separated lists, in addition to repeated use of the same flag.
+// Once the list has been split, a validation function is called to allow for custom validation or defaulting of selected values.
+// Finally, charts for any valid items not selected are added to the --disable list.
+// A value of 'none' will cause all valid items to be disabled.
+// Errors from the validation function, or selection of a value not in the valid list, will cause a fatal error to be logged.
+func disableExceptSelected(clx *cli.Context, valid []string, flag *cli.StringSliceFlag, validateFunc func([]string) ([]string, error)) {
+	// split comma-separated values
+	values := []string{}
+	for _, v := range clx.StringSlice(flag.Name) {
+		values = append(values, strings.Split(v, ",")...)
+	}
+	// validate the flag after splitting values
+	if v, err := validateFunc(values); err != nil {
+		logrus.Fatalf("Failed to validate --%s flag: %v", flag.Name, err)
+	} else {
+		values = v
+	}
+
+	// prepare a list of items to disable, based on all valid components.
+	// we have to use an intermediate set because the flag interface
+	// doesn't allow us to remove flag values once added.
+	disabledCharts := sets.Set[string]{}
+	for _, d := range valid {
+		disabledCharts.Insert("rke2-"+d, "rke2-"+d+"-crd")
+	}
+
+	// re-enable components for any selected flag values
+	for _, d := range values {
+		switch {
+		case d == "none":
+			continue
+		case slice.ContainsString(valid, d):
+			disabledCharts.Delete("rke2-"+d, "rke2-"+d+"-crd")
+		default:
+			logrus.Fatalf("Invalid value %s for --%s flag: must be one of %s", d, flag.Name, strings.Join(valid, ","))
+		}
+	}
+
+	for _, c := range disabledCharts.UnsortedList() {
+		clx.Set("disable", c)
+	}
+}


### PR DESCRIPTION
## Description

Split out of #216 (3 of 6). Contains PR #224's commit until that merges. **Merge after #224.**

Adds the machinery that vendors upstream k3s/RKE2 flag definitions so later work can parse them offline. Nothing consumes the pulled source yet — that is PR 4.

- `mage generate:pullEngineSource` copies `pkg/cli/cmds/{server,agent}.go` (plus RKE2's `root.go` and `k3sopts.go`) at the tags pinned in `thirdparty-src/pins.json` into `thirdparty-src/<distro>/<minor>/` as plain text. The files are never imported or compiled: k3s's `go.mod` `replace` directives make it unsafe to depend on as a library, so `thirdparty-src/` carries its own `go.mod` to keep the main module's build, vet, and lint tooling from descending into it.
- `mage generate:latestTag <k3s|rke2> <v1.MM>` resolves the newest non-RC tag on a minor line via `git ls-remote --tags`, writes it to `pins.json`, and re-pulls that version when the pin moves, so the pins and the vendored source cannot disagree. A prefix that isn't pinned yet is appended rather than replacing one, which is how a new minor line gets added.
- `mage generate:updatePins` runs `latestTag` over every line already pinned.

`addlicense` and `gopls` skip `thirdparty-src/`, and `.gitattributes` marks it `linguist-vendored` so it collapses in review. See `docs/dev/thirdparty-src.md`.

Roughly 11k of the ~11.5k lines here are pulled upstream source.

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
