### PR TITLE
ci: add commit hash

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,8 @@ builds:
     ldflags:
       - -s
       - -w
-      - -X github.com/colonel-byte/cargoship/src/config.CLIVersion={{.Version}}
+      - -X github.com/colonel-byte/cargoship/src/config.CLIVersion={{ .Version }}
+      - -X github.com/colonel-byte/cargoship/src/config.CLICommit={{ .ShortCommit }}
     gcflags:
       - all=-l -B -C
     env:


### PR DESCRIPTION
## Description

GoReleaser builds were only stamping `config.CLIVersion`, so released binaries reported the fallback `UnsetCLICommit` value from `src/config/common.go` instead of the commit they were actually built from.

This adds a `-X .../src/config.CLICommit={{ .ShortCommit }}` ldflag to the `cargoship` build, matching what the dagger build (`.dagger/build-local.go` via `utils.LDFlags`) and the local host build (`magefiles/utils.go`) already do. `cargoship version` now reports the correct commit for release artifacts.

Verified with `goreleaser check`.

## Related Issue

Relates to N/A

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed