### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,13 +34,22 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install dependencies
-        run: go mod download
-
       - name: Build
-        run: go build -mod=vendor -a -trimpath -gcflags=all="-l -B -C" -ldflags="-s -w" -v -o cargoship main.go
+        run: |
+          go build -mod=vendor -a -trimpath \
+            -gcflags=all="-l -B -C" \
+            -ldflags="-s -w \
+              -X github.com/colonel-byte/cargoship/src/config.CLIVersion=0.0.0 \
+              -X github.com/colonel-byte/cargoship/src/config.CLICommit=${GITHUB_SHA::8}" \
+            -v -o cargoship main.go
         env:
           CGO_ENABLED: 0
+          # Everything the build needs is vendored, so make any accidental network
+          # access fail fast. Matches .dagger/build-local.go and magefiles/utils.go.
+          GOFLAGS: -mod=vendor
+          GOPROXY: "off"
+          GOSUMDB: "off"
+          GOTOOLCHAIN: local
 
       - name: Upload binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Description

The e2e build step didn't use the same build environment as the rest of the project's build paths, so the binary it produces (and the size comparison built on top of it) didn't reflect what an actual build yields.

Changes to `.github/workflows/e2e.yaml`:

- Set the network-isolation environment used by the Dagger and host builds: `GOFLAGS=-mod=vendor`, `GOPROXY=off`, `GOSUMDB=off`, `GOTOOLCHAIN=local`. Everything the build needs is vendored, so accidental network access now fails fast instead of silently succeeding. See `.dagger/build-local.go` and `docs/dev/fips-build.md`.
- Stamp `config.CLIVersion` and `config.CLICommit` via ldflags, matching `magefiles/utils.go` (`LDFlags("0.0.0", commit)`). The e2e binary previously reported the unset placeholder values from `src/config/common.go`.
- Drop the `go mod download` step. Dependencies are vendored, and the step would fail under `GOPROXY=off`.

Verified by running the same build command locally under those environment variables: it builds clean, and `cargoship version` reports `0.0.0`.

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed