### PR TITLE
test: e2e non-cluster

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,6 +57,37 @@ jobs:
           name: cargoship
           path: cargoship
 
+  # Run the e2e group that needs no cluster: the misc and package command groups, which live
+  # in their own package so this job never compiles or runs anything bootloose-backed.
+  # -short additionally skips the example packages, which pull ~1.5GB of engine artifacts
+  # and images. The cluster group is not run here; it needs Docker and several minutes.
+  e2e-noncluster:
+    needs: build-e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup golang
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download PR binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cargoship
+          path: pr-binary
+
+      - name: Stage binary where the suite looks for it
+        run: |
+          mkdir -p build
+          mv pr-binary/cargoship "build/cargoship_$(go env GOOS)_$(go env GOARCH)"
+          chmod +x "build/cargoship_$(go env GOOS)_$(go env GOARCH)"
+
+      - name: Test
+        run: go test -mod=vendor -timeout 30m -count=1 -v -short ./src/test/e2e/noncluster/...
+
   # Compare the PR binary's size against the latest released binary and comment the diff on the PR
   binary-size:
     needs: build-e2e

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,19 @@
   ],
   "git.ignoreLimitWarning": true,
   "gopls": {
-    "directoryFilters": ["-thirdparty-src"]
+    "directoryFilters": [
+      "-thirdparty-src",
+      "-build",
+      "-vendor"
+    ]
   },
+  "files.watcherExclude": {
+    "**/build/**": true,
+    "**/vendor/**": true,
+    "**/*.zst": true
+  },
+  "search.exclude": {
+    "**/build": true,
+    "**/vendor": true
+  }
 }

--- a/build/tmp/.gitignore
+++ b/build/tmp/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -47,6 +47,7 @@
 
 - [build-flags](dev/build-flags.md)
 - [dagger](dev/dagger.md)
+- [e2e-tests](dev/e2e-tests.md)
 - [mage](dev/mage.md)
 - [thirdparty-src](dev/thirdparty-src.md)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -55,6 +55,7 @@
 
 # Agent
 
+- [choice-in-memory-oci-registry](agent/choice-in-memory-oci-registry.md)
 - [choice-vault-library](agent/choice-vault-library.md)
 - [design-config-codegen](agent/design-config-codegen.md)
 

--- a/docs/agent/choice-in-memory-oci-registry.md
+++ b/docs/agent/choice-in-memory-oci-registry.md
@@ -1,0 +1,14 @@
+# Why google/go-containerregistry and not distribution/distribution for the in-memory test registry
+
+Cargoship's e2e suite needs a real OCI registry to publish/pull against without a network dependency or a live registry container. `src/test/registry.go` provides `test.SetupInMemoryRegistry(t)`, which starts one in-process on a random localhost port and tears it down via `t.Cleanup`.
+
+ORAS (`oras.land/oras-go/v2`) isn't a candidate here at all -- it's the *client* library Cargoship already uses in `src/pkg/coci` to talk to registries. It has no server implementation, so it can't be "the registry" in a test; it's what the CLI uses to talk to whichever registry the test stands up.
+
+The zarf project's own `src/test/testutil/registry.go` (this package is modeled on it) uses [`github.com/distribution/distribution/v3`](https://github.com/distribution/distribution) -- the reference registry server implementation -- with its `inmemory` storage driver. That was the first thing tried here, and it was rejected:
+
+- **Dependency weight.** `distribution/distribution/v3` wasn't a dependency of Cargoship at all before this (only present transitively in `go.sum`, unused). Adding it as a direct import and running `go mod tidy` pulled in a large new indirect tree: Redis and Prometheus clients, several `go.opentelemetry.io/otel/exporters/*` packages, logging bridges, etc. -- dependencies of the registry's optional storage/metrics backends that Cargoship will never use for an in-memory test double.
+- **It broke the build.** That new tree included `go.opentelemetry.io/otel/log v0.21.0`, which is not API-compatible with the `go.opentelemetry.io/otel v1.45.0` core Cargoship already pins elsewhere. `go build ./...` failed inside `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` (`undefined: log.Value`, `v.Kind undefined`, etc.) -- a version-skew problem with no clean fix short of forcing otel versions across the whole module.
+
+[`github.com/google/go-containerregistry`](https://github.com/google/go-containerregistry)'s `pkg/registry` package was used instead. It's the same kind of thing Cargoship's own crane-adjacent tooling already depends on transitively (it was in `go.sum` already, unused), so promoting it to a direct dependency added exactly one new package to `vendor/` and nothing else -- `go mod tidy` only moved the existing entry from indirect to direct. `pkg/registry.New()` returns a plain `http.Handler` with no storage-backend options to drag in a dependency tree: wrap it in a stock `net/http.Server`, `Listen` on `:0`, done.
+
+Net effect: same job (an in-memory OCI-compliant registry for tests), zero new transitive dependencies, no build breakage.

--- a/docs/dev/e2e-tests.md
+++ b/docs/dev/e2e-tests.md
@@ -1,0 +1,96 @@
+# Running the End-to-End Tests
+
+The e2e suites drive the **built `cargoship` binary** as a subprocess, the same way a user would. They do not import the command packages, so what they prove is that the shipped binary behaves, not that the internals compile. Everything below is a plain `go test` invocation, which is what you want when a test fails and you need to poke at it.
+
+## Layout
+
+```
+src/test/e2e/noncluster/   misc + package command groups: version, sha256sum, vault-encrypt, create, publish, pull, sign
+src/test/common.go         the CargoE2ETest harness (e2e.Cargoship) shared by the suites
+src/test/bootstrap.go      TestMain's chdir-to-repo-root and binary lookup
+src/test/registry.go       in-process OCI registry used by the publish/pull/sign tests
+```
+
+The suites are separate Go packages so that a group can be selected by package path rather than by test-name filters. The `noncluster` package starts no containers and makes no network calls: it needs nothing but the binary.
+
+## Prerequisites
+
+Build the binary first. The suites look for it at `build/cargoship_<goos>_<goarch>` and `TestMain` aborts immediately if it is missing:
+
+```console
+$ go build -mod=vendor -o "build/cargoship_$(go env GOOS)_$(go env GOARCH)" main.go
+```
+
+This is enough for the tests. A build without the release linker flags leaves `cargoship version` reporting the unset placeholder values, which the tests tolerate — they assert the fields are present and non-empty, not what they contain.
+
+The binary is **not** rebuilt by `go test`. After changing anything under `src/`, rebuild it, or you will be testing the previous binary against the new expectations.
+
+## Running
+
+```console
+$ go test -mod=vendor -count=1 ./src/test/e2e/noncluster/...            # the whole group, about 6 seconds
+$ go test -mod=vendor -count=1 -short ./src/test/e2e/noncluster/...     # same, minus the real example package
+$ go test -mod=vendor -count=1 -v -timeout=30m ./src/test/e2e/noncluster/...
+```
+
+*   `-count=1` disables the test result cache. Without it, a green run is cached and a rebuilt binary will not re-trigger it, since the binary is not one of the inputs `go test` hashes.
+*   `-short` skips `TestCargoshipCreateExample`, which builds `example/rke2-cilium` for real and downloads roughly 1.5GB of engine artifacts and images. Everything else uses `testdata/minimal`, an image-free distro that builds into a 386-byte package in milliseconds.
+*   `-timeout` defaults to 10 minutes, which is ample for a `-short` run and not necessarily enough for a full one on a cold cache.
+
+### One test, or one subtest
+
+Subtests are named as sentences, and `go test` replaces spaces with underscores in the `-run` pattern:
+
+```console
+$ go test -mod=vendor -count=1 -v -run TestCargoshipSign ./src/test/e2e/noncluster/...
+$ go test -mod=vendor -count=1 -v -run 'TestCargoshipSign/re-signing_requires_overwrite' ./src/test/e2e/noncluster/...
+```
+
+`-run` takes a regular expression matched against each path element, so `-run 'TestCargoship(Publish|Pull)'` selects a couple of suites and `-run 'TestCargoshipSign/.*overwrite.*'` selects by substring when the exact name is a mouthful.
+
+Those patterns are unanchored, which bites here because several suite names are prefixes of others: `-run TestCargoshipSign` also runs `TestCargoshipSignedRoundTrip`, and `-run TestCargoshipPull` also runs `TestCargoshipPullHTTP`. Anchor both elements to isolate exactly one subtest:
+
+```console
+$ go test -mod=vendor -count=1 -v -run '^TestCargoshipSign$/^re-signing_requires_overwrite$' ./src/test/e2e/noncluster/...
+```
+
+## Environment variables
+
+*   **`CARGOSHIP_E2E_TMPDIR`** — parent directory for the temp dirs the harness creates, one per `e2e.Cargoship` call, plus the shared minimal package. Unset means the system temp directory. Point it at `build/tmp` to keep all test scratch inside the repo, which makes it easy to see what a run left behind: `CARGOSHIP_E2E_TMPDIR=$PWD/build/tmp TMPDIR=$PWD/build/tmp go test ...`.
+*   **`TMPDIR`** — respected by the binary itself for anything it does not put under its own `--tmpdir`. Worth setting alongside the above for the same reason.
+*   **`CARGOSHIP_E2E_KEEP_REGISTRY_LOG`** — set to any non-empty value to keep the in-memory registry's request log for passing tests as well as failing ones. See "Artifacts and logs" below.
+*   **`CARGOSHIP_CONFIG`** — the config file the binary loads. Only `TestCargoshipCreateExample` sets it (to `src/test/e2e/cargoship-config.yaml`); every other test passes flags explicitly so that what is being tested is visible in the test.
+
+## Seeing what the binary actually did
+
+`e2e.Cargoship` runs the binary with `exec.PrintCfg()`, so its stdout and stderr are written through to the test process's stdout and stderr, not into `t.Log`. `go test` buffers that per package and prints it only when the package fails; add `-v` to see it as it happens.
+
+Two flags are appended to every invocation automatically: `--no-color`, so assertions are matching plain text, and `--tmpdir <fresh dir>`, removed when the call returns.
+
+## Artifacts and logs
+
+*   **In-memory registry log.** The registry used by the publish, pull and sign tests writes one line per HTTP request to a file under the user cache directory, `~/.cache/cargoship/e2e-logs/registry-<timestamp>.log` (`$XDG_CACHE_HOME/cargoship/e2e-logs` if that is set), named the way the CLI names its own log files in `logs/`, rather than to stderr where it would bury the test output. A passing test deletes its log; a failing one keeps it and prints the path in the failure output. Set `CARGOSHIP_E2E_KEEP_REGISTRY_LOG=1` to keep the logs of passing tests too — the path is then printed by `go test -v` for every test that started a registry. That log is usually what explains a publish or pull that failed for a non-obvious reason.
+*   **Example packages.** `TestCargoshipCreateExample` writes where `src/test/e2e/cargoship-config.yaml` points it, `src/test/e2e/`. Those `.tar.zst` files are gitignored, and they are large — delete them when done.
+*   **Per-call temp dirs** are removed when each `e2e.Cargoship` call returns, including on failure, so nothing the binary wrote under `--tmpdir` survives for inspection. To keep it, reproduce the command by hand as described below.
+
+## Debugging a failure
+
+The most useful property of this suite is that every test is a CLI invocation. When one fails, take the command from the test output and run it yourself against the same binary:
+
+```console
+$ ./build/cargoship_linux_amd64 sign path/to/package.tar.zst --signing-key cosign.key --verify=always -k cosign.pub --log-level debug
+```
+
+Now nothing is cleaned up, `--log-level debug` is available, and you can iterate without recompiling anything.
+
+A few things that have cost time before:
+
+*   **`--verify` needs its value attached.** It is declared with a cobra `NoOptDefVal`, so `--verify always` parses `always` as a positional argument and fails with `accepts 1 arg(s), received 2`. Use `--verify=always`.
+*   **A stale binary** produces failures that make no sense against the source you are reading. Rebuild, then rerun with `-count=1`.
+*   **Signing keys are generated per test**, so two calls to the keypair helper deliberately produce unrelated keys. A "verification failed" in a test that expects success usually means the wrong pair was threaded through.
+
+To step through the harness itself (not the binary, which is a separate process), delve works on the test package as usual:
+
+```console
+$ dlv test ./src/test/e2e/noncluster -- -test.run 'TestCargoshipPull' -test.v
+```

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/gabriel-vasile/mimetype v1.4.15
 	github.com/goccy/go-yaml v1.19.2
+	github.com/google/go-containerregistry v0.21.9
 	github.com/invopop/jsonschema v0.14.0
 	github.com/k0sproject/dig v0.4.0
 	github.com/k0sproject/rig v0.21.11
@@ -23,6 +24,7 @@ require (
 	github.com/otiai10/copy v1.14.1
 	github.com/pb33f/ordered-map/v2 v2.3.1
 	github.com/pterm/pterm v0.12.83
+	github.com/sigstore/cosign/v3 v3.1.3
 	github.com/sosedoff/ansible-vault-go v0.2.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -217,7 +219,6 @@ require (
 	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/go-containerregistry v0.21.9 // indirect
 	github.com/google/go-github/v88 v88.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
@@ -331,7 +332,6 @@ require (
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
-	github.com/sigstore/cosign/v3 v3.1.3 // indirect
 	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/rekor v1.5.4 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.3.0 // indirect

--- a/magefiles/dagger.go
+++ b/magefiles/dagger.go
@@ -77,7 +77,7 @@ func (Dagger) All() error {
 	return sh.RunV(
 		"dagger",
 		"call",
-		"--progress=tty",
+		daggerProgressFlag(),
 		"--interactive=false",
 		"build",
 		"export",

--- a/magefiles/dev.go
+++ b/magefiles/dev.go
@@ -20,9 +20,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -32,8 +29,7 @@ import (
 )
 
 type (
-	Dev  mg.Namespace
-	Test mg.Namespace
+	Dev mg.Namespace
 )
 
 // Clean removes build artifacts
@@ -94,41 +90,4 @@ func (Dev) Digest(ctx context.Context) error {
 	fmt.Print(desc.Digest)
 
 	return nil
-}
-
-// EndToEnd runs the whole e2e suite, including the example packages that pull ~1.5GB of
-// engine artifacts and images.
-func (Test) EndToEnd() error {
-	return runE2E("1h", "github.com/colonel-byte/cargoship/src/test/e2e/...")
-}
-
-// EndToEndNonCluster runs the group that needs no cluster: the misc and package command
-// groups. -short additionally skips the example packages, so this finishes in seconds.
-// Mirrors the e2e-noncluster CI job.
-func (Test) EndToEndNonCluster() error {
-	return runE2E("30m", "github.com/colonel-byte/cargoship/src/test/e2e/noncluster/...", "-short")
-}
-
-// runE2E builds the binary the e2e suites drive, then runs go test against pkg with the
-// temp directory both the suites and the binary under test write into.
-func runE2E(timeout string, pkg string, extra ...string) error {
-	if err := daggerBuildLocal(runtime.GOOS, runtime.GOARCH); err != nil {
-		return err
-	}
-	e2eTmpDir, err := filepath.Abs(filepath.Join(buildDir, "tmp"))
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(e2eTmpDir, 0o755); err != nil {
-		return err
-	}
-	args := append([]string{"test", "-timeout=" + timeout, pkg, "-count=1", "-v"}, extra...)
-	return sh.RunWithV(
-		map[string]string{
-			"CARGOSHIP_E2E_TMPDIR": e2eTmpDir,
-			"TMPDIR":               e2eTmpDir,
-		},
-		"go",
-		args...,
-	)
 }

--- a/magefiles/dev.go
+++ b/magefiles/dev.go
@@ -20,6 +20,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/magefile/mage/mg"
@@ -94,17 +96,39 @@ func (Dev) Digest(ctx context.Context) error {
 	return nil
 }
 
-// EndToEnd runs the go testing the e2e suite
+// EndToEnd runs the whole e2e suite, including the example packages that pull ~1.5GB of
+// engine artifacts and images.
 func (Test) EndToEnd() error {
+	return runE2E("1h", "github.com/colonel-byte/cargoship/src/test/e2e/...")
+}
+
+// EndToEndNonCluster runs the group that needs no cluster: the misc and package command
+// groups. -short additionally skips the example packages, so this finishes in seconds.
+// Mirrors the e2e-noncluster CI job.
+func (Test) EndToEndNonCluster() error {
+	return runE2E("30m", "github.com/colonel-byte/cargoship/src/test/e2e/noncluster/...", "-short")
+}
+
+// runE2E builds the binary the e2e suites drive, then runs go test against pkg with the
+// temp directory both the suites and the binary under test write into.
+func runE2E(timeout string, pkg string, extra ...string) error {
 	if err := daggerBuildLocal(runtime.GOOS, runtime.GOARCH); err != nil {
 		return err
 	}
-	return sh.RunV(
+	e2eTmpDir, err := filepath.Abs(filepath.Join(buildDir, "tmp"))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(e2eTmpDir, 0o755); err != nil {
+		return err
+	}
+	args := append([]string{"test", "-timeout=" + timeout, pkg, "-count=1", "-v"}, extra...)
+	return sh.RunWithV(
+		map[string]string{
+			"CARGOSHIP_E2E_TMPDIR": e2eTmpDir,
+			"TMPDIR":               e2eTmpDir,
+		},
 		"go",
-		"test",
-		"-timeout=1h",
-		"github.com/colonel-byte/cargoship/src/test/e2e",
-		"-count=1",
-		"-v",
+		args...,
 	)
 }

--- a/magefiles/test-common.go
+++ b/magefiles/test-common.go
@@ -1,0 +1,55 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+type (
+	Test mg.Namespace
+)
+
+// runE2E builds the binary the e2e suites drive, then runs go test against pkg with the
+// temp directory both the suites and the binary under test write into.
+func runE2E(timeout string, pkg string, extra ...string) error {
+	if err := daggerBuildLocal(runtime.GOOS, runtime.GOARCH); err != nil {
+		return err
+	}
+	e2eTmpDir, err := filepath.Abs(filepath.Join(buildDir, "tmp"))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(e2eTmpDir, 0o755); err != nil {
+		return err
+	}
+	args := append([]string{"test", "-timeout=" + timeout, pkg, "-count=1", "-v"}, extra...)
+	return sh.RunWithV(
+		map[string]string{
+			"CARGOSHIP_E2E_TMPDIR": e2eTmpDir,
+			"TMPDIR":               e2eTmpDir,
+		},
+		"go",
+		args...,
+	)
+}

--- a/magefiles/test-e2e-noncluster.go
+++ b/magefiles/test-e2e-noncluster.go
@@ -1,0 +1,25 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build mage
+// +build mage
+
+package main
+
+// EndToEndNonCluster runs the group that needs no cluster: the misc and package command
+// groups. -short additionally skips the example packages, so this finishes in seconds.
+// Mirrors the e2e-noncluster CI job.
+func (Test) EndToEndNonCluster() error {
+	return runE2E("30m", "github.com/colonel-byte/cargoship/src/test/e2e/noncluster/...", "-short")
+}

--- a/magefiles/test-e2e.go
+++ b/magefiles/test-e2e.go
@@ -1,0 +1,24 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build mage
+// +build mage
+
+package main
+
+// EndToEnd runs the whole e2e suite, including the example packages that pull ~1.5GB of
+// engine artifacts and images.
+func (Test) EndToEnd() error {
+	return runE2E("1h", "github.com/colonel-byte/cargoship/src/test/e2e/...")
+}

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -23,7 +23,18 @@ import (
 
 	"github.com/colonel-byte/cargoship/src/pkg/utils/build"
 	"github.com/magefile/mage/sh"
+	"golang.org/x/term"
 )
+
+// daggerProgressFlag picks a tty progress bar when stdout is an actual terminal, falling
+// back to dagger's plain log output otherwise (e.g. CI, or any other non-interactive shell)
+// where a tty renderer would just error out with "no tty available".
+func daggerProgressFlag() string {
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		return "--progress=tty"
+	}
+	return "--progress=plain"
+}
 
 func daggerBuildLocal(oper string, arch string) error {
 	bin := fmt.Sprintf("build/cargoship_%s_%s", oper, arch)
@@ -36,7 +47,7 @@ func daggerBuildLocal(oper string, arch string) error {
 	return sh.RunV(
 		"dagger",
 		"call",
-		"--progress=tty",
+		daggerProgressFlag(),
 		"--interactive=false",
 		"build-local",
 		"--os="+oper,

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -343,9 +343,9 @@ func setupLogger(level, format string, isColor bool, logFilePath string) (*slog.
 }
 
 // defaultLogFilePath returns where the always-on debug log file is written: under the same
-// cache directory cargoship already uses for OCI artifacts, named to the second. Invocations
-// started within the same second share/append to the same file since the name carries no PID
-// or other disambiguator.
+// cache directory cargoship already uses for OCI artifacts, named to the hundredth of a
+// second. Invocations started within the same hundredth of a second share/append to the same
+// file since the name carries no PID or other disambiguator.
 func defaultLogFilePath() string {
 	cacheDir, err := config.GetAbsCachePath()
 	if err != nil || cacheDir == "" {

--- a/src/pkg/utils/files.go
+++ b/src/pkg/utils/files.go
@@ -23,7 +23,8 @@ package utils
 import "os"
 
 const (
-	tmpPathPrefix = "cargoship-"
+	// TmpPathPrefix is the shared prefix used for all temporary directories
+	TmpPathPrefix = "cargoship-"
 
 	// ReadWriteExecuteUser is used for any directory or executable not normally used by the end user or containing sensitive data
 	ReadWriteExecuteUser = 0700
@@ -36,7 +37,7 @@ func MakeTempDir(basePath string) (string, error) {
 			return "", err
 		}
 	}
-	tmp, err := os.MkdirTemp(basePath, tmpPathPrefix)
+	tmp, err := os.MkdirTemp(basePath, TmpPathPrefix)
 	if err != nil {
 		return "", err
 	}

--- a/src/test/bootstrap.go
+++ b/src/test/bootstrap.go
@@ -1,0 +1,66 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	zconfig "github.com/zarf-dev/zarf/src/config"
+)
+
+// Bootstrap chdirs into the repo root and returns a CargoE2ETest pointed at the binary
+// built for this platform, along with the root it moved into. Each e2e suite calls this
+// from TestMain: the suites spell every path (example distros, config files, testdata)
+// relative to the repo root, and the binary under test is looked up under build/.
+func Bootstrap() (CargoE2ETest, string, error) {
+	root, err := RepoRoot()
+	if err != nil {
+		return CargoE2ETest{}, "", err
+	}
+	if err := os.Chdir(root); err != nil {
+		return CargoE2ETest{}, "", err
+	}
+
+	e2e := CargoE2ETest{
+		Arch:         zconfig.GetArch(),
+		CargoBinPath: filepath.Join(root, "build", GetCLIName()),
+	}
+	if _, err := os.Stat(e2e.CargoBinPath); err != nil {
+		return CargoE2ETest{}, "", fmt.Errorf("cargoship binary %s not found, build it first: %w", e2e.CargoBinPath, err)
+	}
+
+	return e2e, root, nil
+}
+
+// RepoRoot walks up from the working directory to the directory holding go.mod, so a
+// suite can sit at any depth under src/test/e2e without hard-coding how far up the root is.
+func RepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod found in any parent of %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/src/test/common.go
+++ b/src/test/common.go
@@ -1,0 +1,70 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test provides e2e tests for Cargoship
+package test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/colonel-byte/cargoship/src/pkg/utils"
+	"github.com/zarf-dev/zarf/src/pkg/utils/exec"
+)
+
+// CargoE2ETest Struct holding common fields most of the tests will utilize.
+type CargoE2ETest struct {
+	CargoBinPath      string
+	Arch              string
+	ApplianceMode     bool
+	ApplianceModeKeep bool
+	// ClusterConfigPath is the absolute path to the generated ZarfCluster inventory YAML
+	// pointing at the bootloose-provisioned test cluster. Empty if no cluster was set up.
+	ClusterConfigPath string
+}
+
+// Cargoship executes a Cargoship command.
+func (e2e *CargoE2ETest) Cargoship(t *testing.T, args ...string) (_ string, _ string, err error) {
+	return e2e.CargoInDir(t, "", args...)
+}
+
+// CargoInDir executes a Cargoship command in specific directory.
+func (e2e *CargoE2ETest) CargoInDir(t *testing.T, dir string, args ...string) (_ string, _ string, err error) {
+	if !slices.Contains(args, "--no-color") {
+		args = append(args, "--no-color")
+	}
+	if !slices.Contains(args, "--tmpdir") {
+		tmpdir, err := os.MkdirTemp(os.Getenv("CARGOSHIP_E2E_TMPDIR"), utils.TmpPathPrefix)
+		if err != nil {
+			return "", "", err
+		}
+		defer func(path string) {
+			errRemove := os.RemoveAll(path)
+			err = errors.Join(err, errRemove)
+		}(tmpdir)
+		args = append(args, "--tmpdir", tmpdir)
+	}
+	cfg := exec.PrintCfg()
+	cfg.Dir = dir
+	return exec.CmdWithTesting(t, cfg, e2e.CargoBinPath, args...)
+}
+
+// GetCLIName looks at the OS and CPU architecture to determine which Cargoship binary needs to be run.
+func GetCLIName() string {
+	return fmt.Sprintf("cargoship_%s_%s", runtime.GOOS, runtime.GOARCH)
+}

--- a/src/test/e2e/cargoship-config.yaml
+++ b/src/test/e2e/cargoship-config.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=../../../schema/zarf-config-distro-schema.json
+log_level: debug
+no_color: true
+log_format: console
+tmp_dir: /tmp
+zarf_cache: ~/.zarf-cache
+timeout: 20m
+distro:
+  type: rke2
+  oci_concurrency: 10
+  concurrency: 300
+  worker_concurrency: 5
+  host_update: true
+  firewall_update: true
+  fapolicy: true
+  output: src/test/e2e

--- a/src/test/e2e/noncluster/00_cargoship_version_test.go
+++ b/src/test/e2e/noncluster/00_cargoship_version_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test provides e2e tests for cargoship
+package noncluster
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	goyaml "github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/require"
+)
+
+// versionOutput mirrors the structure `version -o json|yaml` prints.
+type versionOutput struct {
+	Build        map[string]string `json:"build" yaml:"build"`
+	Dependencies map[string]string `json:"dependencies" yaml:"dependencies"`
+}
+
+// TestCargoshipVersion exercises the `version` command's plain output, its `v` alias, both
+// structured output formats, and the unsupported-format error path.
+func TestCargoshipVersion(t *testing.T) {
+	t.Run("prints the CLI version", func(t *testing.T) {
+		stdout, _, err := e2e.Cargoship(t, "version")
+		require.NoError(t, err)
+		require.NotEmpty(t, strings.TrimSpace(stdout))
+	})
+
+	t.Run("v alias prints the same version", func(t *testing.T) {
+		want, _, err := e2e.Cargoship(t, "version")
+		require.NoError(t, err)
+
+		stdout, _, err := e2e.Cargoship(t, "v")
+		require.NoError(t, err)
+		require.Equal(t, strings.TrimSpace(want), strings.TrimSpace(stdout))
+	})
+
+	t.Run("json output carries build info and dependencies", func(t *testing.T) {
+		stdout, _, err := e2e.Cargoship(t, "version", "-o", "json")
+		require.NoError(t, err)
+
+		var got versionOutput
+		require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+		requireBuildInfo(t, got)
+	})
+
+	t.Run("yaml output carries build info and dependencies", func(t *testing.T) {
+		stdout, _, err := e2e.Cargoship(t, "version", "--output", "yaml")
+		require.NoError(t, err)
+
+		var got versionOutput
+		require.NoError(t, goyaml.Unmarshal([]byte(stdout), &got))
+		requireBuildInfo(t, got)
+	})
+
+	t.Run("unsupported output format errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "version", "-o", "xml")
+		require.Error(t, err)
+	})
+}
+
+func requireBuildInfo(t *testing.T, got versionOutput) {
+	t.Helper()
+
+	for _, key := range []string{"version", "commit", "platform", "go"} {
+		require.NotEmpty(t, got.Build[key], "build.%s must be set", key)
+	}
+	require.NotEmpty(t, got.Dependencies, "dependencies must not be empty")
+}

--- a/src/test/e2e/noncluster/01_cargoship_sha_test.go
+++ b/src/test/e2e/noncluster/01_cargoship_sha_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test provides e2e tests for cargoship
+package noncluster
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/archive"
+)
+
+// TestCargoshipSha256Sum exercises the `sha256sum` command against a plain file, a URL, its
+// `sum` alias, extracting a member out of an archive, and its error paths.
+func TestCargoshipSha256Sum(t *testing.T) {
+	t.Run("hashes a plain file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hello.txt")
+		require.NoError(t, os.WriteFile(path, []byte("hello cargoship\n"), 0o644))
+
+		stdout, _, err := e2e.Cargoship(t, "sha256sum", path)
+		require.NoError(t, err)
+		require.Equal(t, sha256File(t, path), strings.TrimSpace(stdout))
+	})
+
+	t.Run("sum alias produces the same hash", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hello.txt")
+		require.NoError(t, os.WriteFile(path, []byte("same result via alias\n"), 0o644))
+
+		stdout, _, err := e2e.Cargoship(t, "sum", path)
+		require.NoError(t, err)
+		require.Equal(t, sha256File(t, path), strings.TrimSpace(stdout))
+	})
+
+	t.Run("hashes a remote file over http", func(t *testing.T) {
+		const body = "downloaded by the sha256sum url branch\n"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			//nolint:errcheck // test server write to an in-process client
+			w.Write([]byte(body))
+		}))
+		t.Cleanup(srv.Close)
+
+		sum := sha256.Sum256([]byte(body))
+
+		stdout, _, err := e2e.Cargoship(t, "sha256sum", srv.URL+"/artifact.txt")
+		require.NoError(t, err)
+		require.Equal(t, hex.EncodeToString(sum[:]), strings.TrimSpace(stdout))
+	})
+
+	t.Run("extract path hashes a file inside the archive", func(t *testing.T) {
+		archivePath := minimalPackage(t)
+
+		extractDir := t.TempDir()
+		require.NoError(t, archive.Decompress(t.Context(), archivePath, extractDir, archive.DecompressOpts{
+			Files: []string{"checksums.txt"},
+		}))
+		want := sha256File(t, filepath.Join(extractDir, "checksums.txt"))
+
+		stdout, _, err := e2e.Cargoship(t, "sha256sum", "--extract-path", "checksums.txt", archivePath)
+		require.NoError(t, err)
+		require.Equal(t, want, strings.TrimSpace(stdout))
+	})
+
+	t.Run("-e shorthand hashes the same member", func(t *testing.T) {
+		archivePath := minimalPackage(t)
+
+		want, _, err := e2e.Cargoship(t, "sha256sum", "--extract-path", "distro.yaml", archivePath)
+		require.NoError(t, err)
+
+		stdout, _, err := e2e.Cargoship(t, "sha256sum", "-e", "distro.yaml", archivePath)
+		require.NoError(t, err)
+		require.Equal(t, strings.TrimSpace(want), strings.TrimSpace(stdout))
+	})
+
+	t.Run("extract path naming a missing member errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "sha256sum", "--extract-path", "not-in-the-archive.txt", minimalPackage(t))
+		require.Error(t, err)
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "sha256sum", filepath.Join(t.TempDir(), "does-not-exist"))
+		require.Error(t, err)
+	})
+
+	t.Run("no args errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "sha256sum")
+		require.Error(t, err)
+	})
+}
+
+func sha256File(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/src/test/e2e/noncluster/02_cargoship_vault_test.go
+++ b/src/test/e2e/noncluster/02_cargoship_vault_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test provides e2e tests for cargoship
+package noncluster
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	vault "github.com/sosedoff/ansible-vault-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCargoshipVaultEncrypt exercises the `vault-encrypt` command with a value
+// argument, a value piped over stdin, and its error paths.
+func TestCargoshipVaultEncrypt(t *testing.T) {
+	passwordFile := filepath.Join(t.TempDir(), "vault-password")
+	const password = "supersecret"
+	require.NoError(t, os.WriteFile(passwordFile, []byte(password), 0o600))
+
+	t.Run("encrypts a value argument, round-trips with vault password", func(t *testing.T) {
+		const value = "hello world"
+
+		stdout, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", passwordFile, value)
+		require.NoError(t, err)
+
+		encrypted := strings.TrimSpace(stdout)
+		require.True(t, strings.HasPrefix(encrypted, "$ANSIBLE_VAULT"))
+
+		decrypted, err := vault.Decrypt(encrypted, password)
+		require.NoError(t, err)
+		require.Equal(t, value, decrypted)
+	})
+
+	t.Run("encrypts a value piped over stdin", func(t *testing.T) {
+		const value = "piped-secret"
+
+		cmd := exec.CommandContext(t.Context(), e2e.CargoBinPath, "vault-encrypt", "--vault-password-file", passwordFile, "--no-color")
+		cmd.Stdin = strings.NewReader(value + "\n")
+		out, err := cmd.Output()
+		require.NoError(t, err)
+
+		encrypted := strings.TrimSpace(string(out))
+		require.True(t, strings.HasPrefix(encrypted, "$ANSIBLE_VAULT"))
+
+		decrypted, err := vault.Decrypt(encrypted, password)
+		require.NoError(t, err)
+		require.Equal(t, value, decrypted)
+	})
+
+	t.Run("CARGOSHIP_VAULT_PASSWORD is used when the password file is empty", func(t *testing.T) {
+		const value = "env-password-secret"
+		t.Setenv("CARGOSHIP_VAULT_PASSWORD", password)
+
+		// The flag is marked required, so it still has to be present -- an empty value
+		// hands ResolveVaultPassword the fall-through to the environment.
+		stdout, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", "", value)
+		require.NoError(t, err)
+
+		decrypted, err := vault.Decrypt(strings.TrimSpace(stdout), password)
+		require.NoError(t, err)
+		require.Equal(t, value, decrypted)
+	})
+
+	t.Run("ANSIBLE_VAULT_PASSWORD is used when CARGOSHIP_VAULT_PASSWORD is unset", func(t *testing.T) {
+		const value = "ansible-env-password-secret"
+		t.Setenv("CARGOSHIP_VAULT_PASSWORD", "")
+		t.Setenv("ANSIBLE_VAULT_PASSWORD", password)
+
+		stdout, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", "", value)
+		require.NoError(t, err)
+
+		decrypted, err := vault.Decrypt(strings.TrimSpace(stdout), password)
+		require.NoError(t, err)
+		require.Equal(t, value, decrypted)
+	})
+
+	t.Run("no password anywhere errors", func(t *testing.T) {
+		t.Setenv("CARGOSHIP_VAULT_PASSWORD", "")
+		t.Setenv("ANSIBLE_VAULT_PASSWORD", "")
+
+		_, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", "", "value")
+		require.Error(t, err)
+	})
+
+	t.Run("empty stdin errors", func(t *testing.T) {
+		cmd := exec.CommandContext(t.Context(), e2e.CargoBinPath, "vault-encrypt", "--vault-password-file", passwordFile, "--no-color")
+		cmd.Stdin = strings.NewReader("")
+		require.Error(t, cmd.Run())
+	})
+
+	t.Run("missing password file errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", filepath.Join(t.TempDir(), "does-not-exist"), "value")
+		require.Error(t, err)
+	})
+
+	// --vault-password-file is marked required, so omitting it fails in cobra before
+	// ResolveVaultPassword ever consults the environment.
+	t.Run("missing password flag errors even with the env var set", func(t *testing.T) {
+		t.Setenv("CARGOSHIP_VAULT_PASSWORD", password)
+
+		_, _, err := e2e.Cargoship(t, "vault-encrypt", "value")
+		require.Error(t, err)
+	})
+
+	t.Run("too many args errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", passwordFile, "one", "two")
+		require.Error(t, err)
+	})
+}

--- a/src/test/e2e/noncluster/10_cargoship_create_test.go
+++ b/src/test/e2e/noncluster/10_cargoship_create_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test provides e2e tests for cargoship
+package noncluster
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/archive"
+)
+
+// TestCargoshipCreate exercises the `create` command against the image-free testdata
+// package: output location, reproducible builds, signing, registry-override parsing, and
+// the argument error paths. The real distros under example/ are covered by
+// TestCargoshipCreateExample, which is skipped in -short mode.
+func TestCargoshipCreate(t *testing.T) {
+	t.Run("creates a package named after its metadata", func(t *testing.T) {
+		outDir := t.TempDir()
+		_, _, err := e2e.Cargoship(t, "create", minimalDistroDir, "-o", outDir)
+		require.NoError(t, err)
+
+		matches, err := filepath.Glob(filepath.Join(outDir, "*.tar.zst"))
+		require.NoError(t, err)
+		require.Len(t, matches, 1)
+		require.Equal(t, "cargoship-e2e-minimal-"+e2e.Arch+"-0.0.1.tar.zst", filepath.Base(matches[0]))
+
+		// The archive must carry the package definition and its checksum manifest.
+		extractDir := t.TempDir()
+		require.NoError(t, archive.Decompress(t.Context(), matches[0], extractDir, archive.DecompressOpts{
+			Files: []string{"distro.yaml"},
+		}))
+		distroYAML, err := os.ReadFile(filepath.Join(extractDir, "distro.yaml"))
+		require.NoError(t, err)
+		require.Contains(t, string(distroYAML), "name: e2e-minimal")
+	})
+
+	t.Run("reproducible builds are byte-identical", func(t *testing.T) {
+		first := t.TempDir()
+		second := t.TempDir()
+
+		_, _, err := e2e.Cargoship(t, "create", minimalDistroDir, "-o", first, "--reproducible")
+		require.NoError(t, err)
+		_, _, err = e2e.Cargoship(t, "create", minimalDistroDir, "-o", second, "--reproducible")
+		require.NoError(t, err)
+
+		firstBytes := readSinglePackage(t, first)
+		secondBytes := readSinglePackage(t, second)
+		require.Equal(t, firstBytes, secondBytes, "--reproducible must pin the build timestamp")
+	})
+
+	t.Run("signing key produces a signed package", func(t *testing.T) {
+		privPath, _ := cosignKeyPair(t)
+		outDir := t.TempDir()
+
+		_, _, err := e2e.Cargoship(t, "create", minimalDistroDir, "-o", outDir,
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword)
+		require.NoError(t, err)
+
+		matches, err := filepath.Glob(filepath.Join(outDir, "*.tar.zst"))
+		require.NoError(t, err)
+		require.Len(t, matches, 1)
+
+		// A signed package carries the cosign bundle alongside a distro.yaml marked
+		// build.signed, and verifies against the matching public key.
+		extractDir := t.TempDir()
+		require.NoError(t, archive.Decompress(t.Context(), matches[0], extractDir, archive.DecompressOpts{
+			Files: []string{"distro.bundle.sig", "distro.yaml"},
+		}))
+		distroYAML, err := os.ReadFile(filepath.Join(extractDir, "distro.yaml"))
+		require.NoError(t, err)
+		require.Contains(t, string(distroYAML), "signed: true")
+		// The signature itself is verified cryptographically in TestCargoshipSign.
+	})
+
+	t.Run("registry override without an equals sign errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "create", minimalDistroDir, "-o", t.TempDir(),
+			"--registry-override", "docker.io")
+		require.Error(t, err)
+	})
+
+	t.Run("registry override with an empty source errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "create", minimalDistroDir, "-o", t.TempDir(),
+			"--registry-override", "=registry.example.com")
+		require.Error(t, err)
+	})
+
+	t.Run("registry override with a duplicate source errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "create", minimalDistroDir, "-o", t.TempDir(),
+			"--registry-override", "docker.io=a.example.com,docker.io=b.example.com")
+		require.Error(t, err)
+	})
+
+	t.Run("nonexistent directory errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "create", filepath.Join(t.TempDir(), "nope"), "-o", t.TempDir())
+		require.Error(t, err)
+	})
+
+	t.Run("too many args errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "create", minimalDistroDir, minimalDistroDir, "-o", t.TempDir())
+		require.Error(t, err)
+	})
+}
+
+// TestCargoshipCreateExample builds a real distro from example/, which downloads the rke2
+// release tarball and every pinned image -- roughly 1.5GB. Skipped under -short so PR CI
+// can run the rest of the suite in seconds.
+func TestCargoshipCreateExample(t *testing.T) {
+	if testing.Short() {
+		t.Skip("example packages download ~1.5GB of engine artifacts and images")
+	}
+	t.Setenv("CARGOSHIP_CONFIG", "src/test/e2e/cargoship-config.yaml")
+
+	_, _, err := e2e.Cargoship(t, "create", "example/rke2-cilium/v1_35/v1.35.0-rke2r1")
+	require.NoError(t, err)
+}
+
+// readSinglePackage returns the bytes of the one archive expected in dir.
+func readSinglePackage(t *testing.T, dir string) []byte {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*.tar.zst"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	data, err := os.ReadFile(matches[0])
+	require.NoError(t, err)
+
+	return data
+}

--- a/src/test/e2e/noncluster/11_cargoship_publish_pull_test.go
+++ b/src/test/e2e/noncluster/11_cargoship_publish_pull_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noncluster
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/colonel-byte/cargoship/src/test"
+	"github.com/stretchr/testify/require"
+)
+
+// Publish always tags the package as "<repository>/<metadata.name>:<metadata.version>"
+// regardless of the reference passed on the CLI, so these are the coordinates the testdata
+// package lands under.
+const (
+	minimalPackageName    = "e2e-minimal"
+	minimalPackageVersion = "0.0.1"
+)
+
+// TestCargoshipPublishPullRoundTrip exercises the built cargoship binary's "publish" and
+// "pull" commands end-to-end against an in-memory OCI registry, avoiding any dependency on
+// a real registry or network access for the OCI transport itself.
+func TestCargoshipPublishPullRoundTrip(t *testing.T) {
+	pkgPath := minimalPackage(t)
+	addr := test.SetupInMemoryRegistry(t)
+	dst, src := ociRefs(addr, "e2e-test")
+
+	_, _, err := e2e.Cargoship(t, "publish", pkgPath, dst, "--plain-http", "--confirm")
+	require.NoError(t, err)
+
+	pullDir := t.TempDir()
+	_, _, err = e2e.Cargoship(t, "pull", src, "--plain-http", "-o", pullDir)
+	require.NoError(t, err)
+
+	pulled, err := filepath.Glob(filepath.Join(pullDir, "*.tar.zst"))
+	require.NoError(t, err)
+	require.Len(t, pulled, 1, "expected exactly one package pulled back")
+
+	wantBytes, err := os.ReadFile(pkgPath)
+	require.NoError(t, err)
+	gotBytes, err := os.ReadFile(pulled[0])
+	require.NoError(t, err)
+	require.Equal(t, wantBytes, gotBytes, "pulled package must be byte-identical to the published one")
+}
+
+// TestCargoshipPublish covers publish's argument validation.
+func TestCargoshipPublish(t *testing.T) {
+	t.Run("destination without an oci:// prefix errors", func(t *testing.T) {
+		addr := test.SetupInMemoryRegistry(t)
+
+		_, _, err := e2e.Cargoship(t, "publish", minimalPackage(t), addr+"/e2e-test", "--plain-http", "--confirm")
+		require.Error(t, err)
+	})
+
+	t.Run("missing source package errors", func(t *testing.T) {
+		addr := test.SetupInMemoryRegistry(t)
+		dst, _ := ociRefs(addr, "e2e-test")
+
+		_, _, err := e2e.Cargoship(t, "publish", filepath.Join(t.TempDir(), "nope.tar.zst"), dst, "--plain-http", "--confirm")
+		require.Error(t, err)
+	})
+
+	t.Run("one arg errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "publish", minimalPackage(t))
+		require.Error(t, err)
+	})
+}
+
+// TestCargoshipPull covers pull's shasum check and its error paths.
+func TestCargoshipPull(t *testing.T) {
+	pkgPath := minimalPackage(t)
+	addr := test.SetupInMemoryRegistry(t)
+	dst, src := ociRefs(addr, "e2e-test")
+
+	_, _, err := e2e.Cargoship(t, "publish", pkgPath, dst, "--plain-http", "--confirm")
+	require.NoError(t, err)
+
+	// For OCI sources --shasum is the manifest digest, which the CLI appends to the
+	// reference as "<ref>@sha256:<shasum>".
+	t.Run("matching manifest digest succeeds", func(t *testing.T) {
+		pullDir := t.TempDir()
+		_, _, err := e2e.Cargoship(t, "pull", src, "--plain-http", "-o", pullDir,
+			"--shasum", manifestDigest(t, addr, "e2e-test/"+minimalPackageName, minimalPackageVersion))
+		require.NoError(t, err)
+		requireSinglePackage(t, pullDir)
+	})
+
+	t.Run("mismatched manifest digest errors", func(t *testing.T) {
+		wrong := sha256.Sum256([]byte("not the manifest"))
+
+		_, _, err := e2e.Cargoship(t, "pull", src, "--plain-http", "-o", t.TempDir(),
+			"--shasum", hex.EncodeToString(wrong[:]))
+		require.Error(t, err)
+	})
+
+	t.Run("unknown tag errors", func(t *testing.T) {
+		missing := fmt.Sprintf("oci://%s/e2e-test/%s:9.9.9", addr, minimalPackageName)
+
+		_, _, err := e2e.Cargoship(t, "pull", missing, "--plain-http", "-o", t.TempDir())
+		require.Error(t, err)
+	})
+
+	t.Run("no args errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "pull")
+		require.Error(t, err)
+	})
+}
+
+// TestCargoshipPullHTTP covers pull's http(s) source branch, where --shasum is the SHA256
+// of the package file itself and is mandatory.
+func TestCargoshipPullHTTP(t *testing.T) {
+	pkgPath := minimalPackage(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, pkgPath)
+	}))
+	t.Cleanup(srv.Close)
+	srcURL := srv.URL + "/" + filepath.Base(pkgPath)
+
+	t.Run("matching shasum succeeds", func(t *testing.T) {
+		pullDir := t.TempDir()
+		_, _, err := e2e.Cargoship(t, "pull", srcURL, "-o", pullDir, "--shasum", sha256File(t, pkgPath))
+		require.NoError(t, err)
+		requireSinglePackage(t, pullDir)
+	})
+
+	t.Run("mismatched shasum errors", func(t *testing.T) {
+		wrong := sha256.Sum256([]byte("not the package"))
+
+		_, _, err := e2e.Cargoship(t, "pull", srcURL, "-o", t.TempDir(), "--shasum", hex.EncodeToString(wrong[:]))
+		require.Error(t, err)
+	})
+
+	t.Run("missing shasum errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "pull", srcURL, "-o", t.TempDir())
+		require.Error(t, err)
+	})
+}
+
+// manifestDigest asks the registry for the manifest digest behind repo:tag and returns it
+// without the "sha256:" prefix, which is the form --shasum expects.
+func manifestDigest(t *testing.T, addr string, repo string, tag string) string {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodHead,
+		fmt.Sprintf("http://%s/v2/%s/manifests/%s", addr, repo, tag), nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "application/vnd.oci.image.manifest.v1+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	digest := resp.Header.Get("Docker-Content-Digest")
+	require.NotEmpty(t, digest, "registry did not report a manifest digest")
+
+	return strings.TrimPrefix(digest, "sha256:")
+}
+
+// ociRefs returns the publish destination and the resulting pull source for the testdata
+// package in the given repository namespace.
+func ociRefs(addr string, namespace string) (dst string, src string) {
+	dst = fmt.Sprintf("oci://%s/%s", addr, strings.Trim(namespace, "/"))
+	src = fmt.Sprintf("%s/%s:%s", dst, minimalPackageName, minimalPackageVersion)
+
+	return dst, src
+}

--- a/src/test/e2e/noncluster/12_cargoship_sign_test.go
+++ b/src/test/e2e/noncluster/12_cargoship_sign_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test provides e2e tests for cargoship
+package noncluster
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/colonel-byte/cargoship/src/test"
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/archive"
+)
+
+// TestCargoshipSign exercises the `sign` command against a local package: producing a
+// signature, refusing to re-sign without --overwrite, verifying an existing signature via
+// --verify, and its flag error paths.
+//
+// Signing keys are generated per subtest by cosignKeyPair, so nothing is committed and the
+// "wrong key" cases get genuinely unrelated material.
+func TestCargoshipSign(t *testing.T) {
+	t.Run("signs a local package into an output directory", func(t *testing.T) {
+		privPath, _ := cosignKeyPair(t)
+		outDir := t.TempDir()
+
+		_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t),
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", outDir)
+		require.NoError(t, err)
+
+		signed := requireSinglePackage(t, outDir)
+		extractDir := t.TempDir()
+		require.NoError(t, archive.Decompress(t.Context(), signed, extractDir, archive.DecompressOpts{
+			Files: []string{"distro.bundle.sig", "distro.yaml"},
+		}))
+		distroYAML, err := os.ReadFile(filepath.Join(extractDir, "distro.yaml"))
+		require.NoError(t, err)
+		require.Contains(t, string(distroYAML), "signed: true")
+	})
+
+	t.Run("defaults the output to the source directory", func(t *testing.T) {
+		privPath, _ := cosignKeyPair(t)
+		// Copy first: signing in place rewrites the package next to the source.
+		pkgPath := copyPackage(t, minimalPackage(t))
+		before, err := os.ReadFile(pkgPath)
+		require.NoError(t, err)
+
+		_, _, err = e2e.Cargoship(t, "sign", pkgPath,
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword)
+		require.NoError(t, err)
+
+		after, err := os.ReadFile(pkgPath)
+		require.NoError(t, err)
+		require.NotEqual(t, before, after, "signing in place must rewrite the source package")
+	})
+
+	t.Run("re-signing requires overwrite", func(t *testing.T) {
+		privPath, pubPath := cosignKeyPair(t)
+		signedDir := t.TempDir()
+
+		_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t),
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", signedDir)
+		require.NoError(t, err)
+		signed := requireSinglePackage(t, signedDir)
+
+		_, _, err = e2e.Cargoship(t, "sign", signed,
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", t.TempDir())
+		require.Error(t, err, "an already-signed package must refuse a re-sign without --overwrite")
+
+		// --verify=always makes the CLI check the existing signature before re-signing, so
+		// this run only succeeds if the signature validates against the matching key.
+		// The flag takes an optional value, so it must be passed as --verify=always.
+		_, _, err = e2e.Cargoship(t, "sign", signed,
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", t.TempDir(),
+			"--overwrite", "--verify=always", "-k", pubPath)
+		require.NoError(t, err)
+	})
+
+	t.Run("verification against an unrelated key fails", func(t *testing.T) {
+		privPath, _ := cosignKeyPair(t)
+		_, otherPubPath := cosignKeyPair(t)
+		signedDir := t.TempDir()
+
+		_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t),
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", signedDir)
+		require.NoError(t, err)
+
+		_, _, err = e2e.Cargoship(t, "sign", requireSinglePackage(t, signedDir),
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", t.TempDir(),
+			"--overwrite", "--verify=always", "-k", otherPubPath)
+		require.Error(t, err)
+	})
+
+	t.Run("wrong key password errors", func(t *testing.T) {
+		privPath, _ := cosignKeyPair(t)
+
+		_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t),
+			"--signing-key", privPath, "--signing-key-pass", "not-the-password", "-o", t.TempDir())
+		require.Error(t, err)
+	})
+
+	t.Run("no signing key and no keyless errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t), "-o", t.TempDir())
+		require.Error(t, err)
+	})
+
+	t.Run("keyless and signing-key are mutually exclusive", func(t *testing.T) {
+		privPath, _ := cosignKeyPair(t)
+
+		_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t), "--keyless",
+			"--signing-key", privPath, "-o", t.TempDir())
+		require.Error(t, err)
+	})
+
+	t.Run("missing source package errors", func(t *testing.T) {
+		privPath, _ := cosignKeyPair(t)
+
+		_, _, err := e2e.Cargoship(t, "sign", filepath.Join(t.TempDir(), "nope.tar.zst"),
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", t.TempDir())
+		require.Error(t, err)
+	})
+
+	t.Run("no args errors", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "sign")
+		require.Error(t, err)
+	})
+}
+
+// TestCargoshipSignedRoundTrip signs a package, publishes it to an in-memory registry, and
+// pulls it back with signature verification enforced -- the only path where the CLI both
+// fetches and cryptographically verifies a signature.
+func TestCargoshipSignedRoundTrip(t *testing.T) {
+	privPath, pubPath := cosignKeyPair(t)
+	_, otherPubPath := cosignKeyPair(t)
+
+	signedDir := t.TempDir()
+	_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t),
+		"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", signedDir)
+	require.NoError(t, err)
+	signed := requireSinglePackage(t, signedDir)
+
+	addr := test.SetupInMemoryRegistry(t)
+	dst, src := ociRefs(addr, "e2e-signed")
+
+	_, _, err = e2e.Cargoship(t, "publish", signed, dst, "--plain-http", "--confirm")
+	require.NoError(t, err)
+
+	t.Run("pull verifies against the signing key", func(t *testing.T) {
+		pullDir := t.TempDir()
+		_, _, err := e2e.Cargoship(t, "pull", src, "--plain-http", "-o", pullDir, "--verify=always", "-k", pubPath)
+		require.NoError(t, err)
+		requireSinglePackage(t, pullDir)
+	})
+
+	t.Run("signing straight to an OCI destination publishes a verifiable package", func(t *testing.T) {
+		ociDst, ociSrc := ociRefs(addr, "e2e-sign-to-oci")
+
+		_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t), "-o", ociDst, "--plain-http",
+			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword)
+		require.NoError(t, err)
+
+		pullDir := t.TempDir()
+		_, _, err = e2e.Cargoship(t, "pull", ociSrc, "--plain-http", "-o", pullDir, "--verify=always", "-k", pubPath)
+		require.NoError(t, err)
+		requireSinglePackage(t, pullDir)
+	})
+
+	t.Run("pull rejects an unrelated key", func(t *testing.T) {
+		_, _, err := e2e.Cargoship(t, "pull", src, "--plain-http", "-o", t.TempDir(), "--verify=always", "-k", otherPubPath)
+		require.Error(t, err)
+	})
+}
+
+// requireSinglePackage asserts dir holds exactly one package archive and returns its path.
+func requireSinglePackage(t *testing.T, dir string) string {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*.tar.zst"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+
+	return matches[0]
+}

--- a/src/test/e2e/noncluster/helpers_test.go
+++ b/src/test/e2e/noncluster/helpers_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noncluster
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalDistroDir is the tiny, image-free distro definition used by the package-group
+// tests. Paths are relative to the repo root, which TestMain chdirs into.
+const minimalDistroDir = "src/test/e2e/noncluster/testdata/minimal"
+
+// cosignKeyPassword is the passphrase protecting the ephemeral signing keys handed out
+// by cosignKeyPair.
+const cosignKeyPassword = "e2e-password"
+
+var (
+	minimalPkgOnce sync.Once //nolint:gochecknoglobals
+	minimalPkgDir  string    //nolint:gochecknoglobals
+	minimalPkgPath string    //nolint:gochecknoglobals
+	minimalPkgErr  error     //nolint:gochecknoglobals
+)
+
+// minimalPackage builds testdata/minimal once per test binary and returns the path to the
+// resulting archive. The package is a few hundred bytes, so every caller sharing one build
+// costs less than a second in total; the directory is removed by TestMain after the run.
+//
+// Callers must treat the returned path as read-only: copy it into t.TempDir() first if a
+// test mutates or re-signs the package.
+func minimalPackage(t *testing.T) string {
+	t.Helper()
+
+	minimalPkgOnce.Do(func() {
+		minimalPkgDir, minimalPkgErr = os.MkdirTemp(os.Getenv("CARGOSHIP_E2E_TMPDIR"), "cargoship-e2e-minimal")
+		if minimalPkgErr != nil {
+			return
+		}
+		if _, _, minimalPkgErr = e2e.Cargoship(t, "create", minimalDistroDir, "-o", minimalPkgDir); minimalPkgErr != nil {
+			return
+		}
+		var matches []string
+		matches, minimalPkgErr = filepath.Glob(filepath.Join(minimalPkgDir, "*.tar.zst"))
+		if minimalPkgErr != nil {
+			return
+		}
+		if len(matches) != 1 {
+			t.Fatalf("expected exactly one package in %s, got %v", minimalPkgDir, matches)
+		}
+		minimalPkgPath = matches[0]
+	})
+	require.NoError(t, minimalPkgErr)
+
+	return minimalPkgPath
+}
+
+// copyPackage copies src into a fresh t.TempDir() and returns the new path, so a test can
+// sign or overwrite a package without disturbing the shared one from minimalPackage.
+func copyPackage(t *testing.T, src string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(src)
+	require.NoError(t, err)
+	dst := filepath.Join(t.TempDir(), filepath.Base(src))
+	require.NoError(t, os.WriteFile(dst, data, 0o600))
+
+	return dst
+}
+
+// cosignKeyPair generates an ephemeral cosign key pair in t.TempDir() and returns the
+// private and public key paths. Keys are generated per call rather than committed, so the
+// signing tests carry no key material in the repo and two calls yield unrelated keys --
+// which is what the "wrong key fails verification" cases rely on.
+func cosignKeyPair(t *testing.T) (privPath string, pubPath string) {
+	t.Helper()
+
+	keys, err := cosign.GenerateKeyPair(func(bool) ([]byte, error) { return []byte(cosignKeyPassword), nil })
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	privPath = filepath.Join(dir, "cosign.key")
+	pubPath = filepath.Join(dir, "cosign.pub")
+	require.NoError(t, os.WriteFile(privPath, keys.PrivateBytes, 0o600))
+	require.NoError(t, os.WriteFile(pubPath, keys.PublicBytes, 0o644))
+
+	return privPath, pubPath
+}

--- a/src/test/e2e/noncluster/main_test.go
+++ b/src/test/e2e/noncluster/main_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package noncluster holds the e2e tests that drive the built binary without a cluster:
+// the misc and package command groups. Nothing here starts a container or talks to a real
+// registry, so the suite needs only the binary under build/ and is cheap enough to gate
+// every pull request. The install group lives in the sibling cluster package.
+package noncluster
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/colonel-byte/cargoship/src/test"
+)
+
+var e2e test.CargoE2ETest //nolint:gochecknoglobals
+
+func TestMain(m *testing.M) {
+	var err error
+	e2e, _, err = test.Bootstrap()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	code := m.Run()
+
+	if minimalPkgDir != "" {
+		if err := os.RemoveAll(minimalPkgDir); err != nil {
+			log.Printf("failed to remove %s: %v", minimalPkgDir, err)
+		}
+	}
+	os.Exit(code)
+}

--- a/src/test/e2e/noncluster/testdata/minimal/distro.yaml
+++ b/src/test/e2e/noncluster/testdata/minimal/distro.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 colonel-byte
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A deliberately tiny distro definition for the e2e suite: no images and no files, so
+# "cargoship create" assembles it in milliseconds with no network access. Use it for
+# every package-group test that only needs *a* package; the real distros under example/
+# pull ~1.5GB of engine artifacts and images and belong in the heavy, non-short tests.
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/colonel-byte/cargoship/refs/heads/main/schema/zarf-v1alpha1-distro-package-schema.json
+apiVersion: zarf.dev/v1alpha1
+kind: ZarfDistro
+metadata:
+  name: e2e-minimal
+  version: 0.0.1
+  architecture: amd64
+spec:
+  type: rke2
+  version: 1.35.0-rke2r1
+  config:
+    engine:
+      config:
+        cluster-cidr: 10.42.0.0/16
+        cluster-domain: cluster.local

--- a/src/test/registry.go
+++ b/src/test/registry.go
@@ -16,6 +16,8 @@ package test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -25,13 +27,18 @@ import (
 	"time"
 
 	"github.com/colonel-byte/cargoship/src/config"
+	"github.com/colonel-byte/cargoship/src/pkg/utils"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/stretchr/testify/require"
 )
 
-// registryLogDir is the directory, relative to the cargoship cache, that the in-memory
+// registryLogDir is the directory, relative to the user cache directory, that the in-memory
 // registry writes its request logs into.
 const registryLogDir = "e2e-logs"
+
+// keepRegistryLogEnv, when set to a non-empty value, keeps the registry log of every test
+// rather than only the logs of tests that failed.
+const keepRegistryLogEnv = "CARGOSHIP_E2E_KEEP_REGISTRY_LOG"
 
 // SetupInMemoryRegistry starts a plain-HTTP, in-memory OCI registry on an auto-allocated
 // localhost port and returns its address (host:port). Use it against the built cargoship
@@ -66,31 +73,30 @@ func SetupInMemoryRegistry(t *testing.T) string {
 
 // registryLogFile opens the file the in-memory registry logs to. The registry writes a line
 // per request, which buries the output of the test actually being run, so it goes to a file
-// in the cargoship cache instead of stderr. A passing test removes its log on cleanup; a
+// under the user cache directory instead of stderr. A passing test removes its log on cleanup; a
 // failing one leaves it behind and reports the path, since those requests are usually what
-// explains why a publish or pull failed.
+// explains why a publish or pull failed. Set CARGOSHIP_E2E_KEEP_REGISTRY_LOG to keep the logs
+// of passing tests too.
 func registryLogFile(t *testing.T) *os.File {
 	t.Helper()
 
-	cachePath := config.CommonOptions.CachePath
-	if cachePath == "" {
-		// A test binary never loads the CLI config, so CommonOptions is zero-valued.
-		cachePath = config.DefaultCachePath
-	}
-	cacheDir, err := config.GetAbsHomePath(cachePath)
+	// Empty argument: resolve to the OS user cache directory (XDG_CACHE_HOME aware), rather
+	// than the CLI's own --cache-path, so the logs stay out of the content cache the binary
+	// under test reads and writes.
+	cacheDir, err := utils.ResolveCachePath("")
 	require.NoError(t, err)
 
 	logDir := filepath.Join(cacheDir, registryLogDir)
 	require.NoError(t, os.MkdirAll(logDir, 0o755))
 
-	f, err := os.CreateTemp(logDir, "registry-*.log")
+	f, err := createLog(logDir)
 	require.NoError(t, err)
 
 	// Registered before the server's cleanup, so it runs after it: the registry has stopped
 	// writing by the time the file is closed.
 	t.Cleanup(func() {
 		require.NoError(t, f.Close())
-		if t.Failed() {
+		if t.Failed() || os.Getenv(keepRegistryLogEnv) != "" {
 			t.Logf("in-memory registry log: %s", f.Name())
 			return
 		}
@@ -98,4 +104,23 @@ func registryLogFile(t *testing.T) *os.File {
 	})
 
 	return f
+}
+
+// createLog creates the log file for one registry in logDir, named the way the CLI names its
+// own log files in the cache: the prefix, then the time the file was created. Two registries
+// created within the same hundredth of a second get a counter appended rather than sharing a
+// file, since interleaved request logs from two registries are hard to read.
+func createLog(logDir string) (*os.File, error) {
+	base := fmt.Sprintf("registry-%s", time.Now().Format(config.TimeFormat))
+	for i := 0; ; i++ {
+		name := base
+		if i > 0 {
+			name = fmt.Sprintf("%s-%d", base, i)
+		}
+		f, err := os.OpenFile(filepath.Join(logDir, name+".log"), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return f, err
+	}
 }

--- a/src/test/registry.go
+++ b/src/test/registry.go
@@ -1,0 +1,101 @@
+// Copyright 2026 colonel-byte
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/colonel-byte/cargoship/src/config"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/stretchr/testify/require"
+)
+
+// registryLogDir is the directory, relative to the cargoship cache, that the in-memory
+// registry writes its request logs into.
+const registryLogDir = "e2e-logs"
+
+// SetupInMemoryRegistry starts a plain-HTTP, in-memory OCI registry on an auto-allocated
+// localhost port and returns its address (host:port). Use it against the built cargoship
+// binary with the "--plain-http" flag, e.g. as the destination for "cargoship publish"/"pull"
+// in e2e tests, without needing a real registry or network access. The registry is torn down
+// automatically via t.Cleanup.
+func SetupInMemoryRegistry(t *testing.T) string {
+	t.Helper()
+
+	logger := log.New(registryLogFile(t), "", log.LstdFlags|log.Lmicroseconds)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &http.Server{
+		Handler:  registry.New(registry.Logger(logger)),
+		ErrorLog: logger,
+	}
+	go func() {
+		//nolint:errcheck // returns http.ErrServerClosed once Shutdown is called below; nothing to do with the error
+		srv.Serve(ln)
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		//nolint:errcheck // best-effort shutdown during test cleanup
+		srv.Shutdown(shutdownCtx)
+	})
+
+	return ln.Addr().String()
+}
+
+// registryLogFile opens the file the in-memory registry logs to. The registry writes a line
+// per request, which buries the output of the test actually being run, so it goes to a file
+// in the cargoship cache instead of stderr. A passing test removes its log on cleanup; a
+// failing one leaves it behind and reports the path, since those requests are usually what
+// explains why a publish or pull failed.
+func registryLogFile(t *testing.T) *os.File {
+	t.Helper()
+
+	cachePath := config.CommonOptions.CachePath
+	if cachePath == "" {
+		// A test binary never loads the CLI config, so CommonOptions is zero-valued.
+		cachePath = config.DefaultCachePath
+	}
+	cacheDir, err := config.GetAbsHomePath(cachePath)
+	require.NoError(t, err)
+
+	logDir := filepath.Join(cacheDir, registryLogDir)
+	require.NoError(t, os.MkdirAll(logDir, 0o755))
+
+	f, err := os.CreateTemp(logDir, "registry-*.log")
+	require.NoError(t, err)
+
+	// Registered before the server's cleanup, so it runs after it: the registry has stopped
+	// writing by the time the file is closed.
+	t.Cleanup(func() {
+		require.NoError(t, f.Close())
+		if t.Failed() {
+			t.Logf("in-memory registry log: %s", f.Name())
+			return
+		}
+		require.NoError(t, os.Remove(f.Name()))
+	})
+
+	return f
+}

--- a/vendor/github.com/google/go-containerregistry/internal/httptest/httptest.go
+++ b/vendor/github.com/google/go-containerregistry/internal/httptest/httptest.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httptest provides a method for testing a TLS server a la net/http/httptest.
+package httptest
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// NewTLSServer returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain.
+// If you need a transport, Client().Transport is correctly configured.
+func NewTLSServer(domain string, handler http.Handler) (*httptest.Server, error) {
+	s := httptest.NewUnstartedServer(handler)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses: []net.IP{
+			net.IPv4(127, 0, 0, 1),
+			net.IPv6loopback,
+		},
+		DNSNames: []string{domain},
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := &bytes.Buffer{}
+	if err := pem.Encode(pc, &pem.Block{Type: "CERTIFICATE", Bytes: b}); err != nil {
+		return nil, err
+	}
+
+	ek, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pk := &bytes.Buffer{}
+	if err := pem.Encode(pk, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ek}); err != nil {
+		return nil, err
+	}
+
+	c, err := tls.X509KeyPair(pc.Bytes(), pk.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	s.TLS = &tls.Config{
+		Certificates: []tls.Certificate{c},
+	}
+	s.StartTLS()
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(s.Certificate())
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: certpool,
+		},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.Dial(s.Listener.Addr().Network(), s.Listener.Addr().String())
+		},
+	}
+	s.Client().Transport = t
+
+	return s, nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/README.md
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/README.md
@@ -1,0 +1,14 @@
+# `pkg/registry`
+
+This package implements a Docker v2 registry and the OCI distribution specification.
+
+It is designed to be used anywhere a low dependency container registry is needed, with an initial focus on tests.
+
+Its goal is to be standards compliant and its strictness will increase over time.
+
+This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it in production, please let us know how and send us PRs for integration tests.
+
+Before sending a PR, understand that the expectation of this package is that it remain free of extraneous dependencies.
+This means that we expect `pkg/registry` to only have dependencies on Go's standard library, and other packages in `go-containerregistry`.
+
+You may be asked to change your code to reduce dependencies, and your PR might be rejected if this is deemed impossible.

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/blobs.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/blobs.go
@@ -1,0 +1,540 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/internal/verify"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Returns whether this url should be handled by the blob handler
+// This is complicated because blob is indicated by the trailing path, not the leading path.
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-a-layer
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-a-layer
+func isBlob(req *http.Request) bool {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	if elem[len(elem)-1] == "" {
+		elem = elem[:len(elem)-1]
+	}
+	if len(elem) < 3 {
+		return false
+	}
+	return elem[len(elem)-2] == "blobs" || (elem[len(elem)-3] == "blobs" &&
+		elem[len(elem)-2] == "uploads")
+}
+
+// BlobHandler represents a minimal blob storage backend, capable of serving
+// blob contents.
+type BlobHandler interface {
+	// Get gets the blob contents, or errNotFound if the blob wasn't found.
+	Get(ctx context.Context, repo string, h v1.Hash) (io.ReadCloser, error)
+}
+
+// BlobStatHandler is an extension interface representing a blob storage
+// backend that can serve metadata about blobs.
+type BlobStatHandler interface {
+	// Stat returns the size of the blob, or errNotFound if the blob wasn't
+	// found, or RedirectError if the blob can be found elsewhere.
+	Stat(ctx context.Context, repo string, h v1.Hash) (int64, error)
+}
+
+// BlobPutHandler is an extension interface representing a blob storage backend
+// that can write blob contents.
+type BlobPutHandler interface {
+	// Put puts the blob contents.
+	//
+	// The contents will be verified against the expected size and digest
+	// as the contents are read, and an error will be returned if these
+	// don't match. Implementations should return that error, or a wrapper
+	// around that error, to return the correct error when these don't match.
+	Put(ctx context.Context, repo string, h v1.Hash, rc io.ReadCloser) error
+}
+
+// BlobDeleteHandler is an extension interface representing a blob storage
+// backend that can delete blob contents.
+type BlobDeleteHandler interface {
+	// Delete the blob contents.
+	Delete(ctx context.Context, repo string, h v1.Hash) error
+}
+
+// RedirectError represents a signal that the blob handler doesn't have the blob
+// contents, but that those contents are at another location which registry
+// clients should redirect to.
+type RedirectError struct {
+	// Location is the location to find the contents.
+	Location string
+
+	// Code is the HTTP redirect status code to return to clients.
+	Code int
+}
+
+type bytesCloser struct {
+	*bytes.Reader
+}
+
+func (r *bytesCloser) Close() error {
+	return nil
+}
+
+func (e RedirectError) Error() string { return fmt.Sprintf("redirecting (%d): %s", e.Code, e.Location) }
+
+// ErrNotFound represents an error locating the blob.
+var ErrNotFound = errors.New("not found")
+
+type memHandler struct {
+	m    map[string][]byte
+	lock sync.Mutex
+}
+
+func NewInMemoryBlobHandler() BlobHandler { return &memHandler{m: map[string][]byte{}} }
+
+func (m *memHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	b, found := m.m[h.String()]
+	if !found {
+		return 0, ErrNotFound
+	}
+	return int64(len(b)), nil
+}
+
+func (m *memHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	b, found := m.m[h.String()]
+	if !found {
+		return nil, ErrNotFound
+	}
+	return &bytesCloser{bytes.NewReader(b)}, nil
+}
+
+func (m *memHandler) Put(_ context.Context, _ string, h v1.Hash, rc io.ReadCloser) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	defer rc.Close()
+	all, err := io.ReadAll(rc)
+	if err != nil {
+		return err
+	}
+	m.m[h.String()] = all
+	return nil
+}
+
+func (m *memHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, found := m.m[h.String()]; !found {
+		return ErrNotFound
+	}
+
+	delete(m.m, h.String())
+	return nil
+}
+
+// blobs
+type blobs struct {
+	blobHandler BlobHandler
+
+	// Each upload gets a unique id that writes occur to until finalized.
+	uploads map[string][]byte
+	lock    sync.Mutex
+	log     *log.Logger
+}
+
+func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	if elem[len(elem)-1] == "" {
+		elem = elem[:len(elem)-1]
+	}
+	// Must have a path of form /v2/{name}/blobs/{upload,sha256:}
+	if len(elem) < 4 {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "NAME_INVALID",
+			Message: "blobs must be attached to a repo",
+		}
+	}
+	target := elem[len(elem)-1]
+	service := elem[len(elem)-2]
+	digest := req.URL.Query().Get("digest")
+	contentRange := req.Header.Get("Content-Range")
+	rangeHeader := req.Header.Get("Range")
+
+	repo := req.URL.Host + path.Join(elem[1:len(elem)-2]...)
+
+	switch req.Method {
+	case http.MethodHead:
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		var size int64
+		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
+			size, err = bsh.Stat(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+		} else {
+			rc, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+			defer rc.Close()
+			size, err = io.Copy(io.Discard, rc)
+			if err != nil {
+				return regErrInternal(err)
+			}
+		}
+
+		resp.Header().Set("Content-Length", fmt.Sprint(size))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusOK)
+		return nil
+
+	case http.MethodGet:
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		var size int64
+		var r io.Reader
+		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
+			size, err = bsh.Stat(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+
+			rc, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+
+				return regErrInternal(err)
+			}
+
+			defer rc.Close()
+			r = rc
+
+		} else {
+			tmp, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+
+				return regErrInternal(err)
+			}
+			defer tmp.Close()
+			var buf bytes.Buffer
+			io.Copy(&buf, tmp)
+			size = int64(buf.Len())
+			r = &buf
+		}
+
+		if rangeHeader != "" {
+			start, end := int64(0), int64(0)
+			if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UNKNOWN",
+					Message: "We don't understand your Range",
+				}
+			}
+
+			n := (end + 1) - start
+			if ra, ok := r.(io.ReaderAt); ok {
+				if end+1 > size {
+					return &regError{
+						Status:  http.StatusRequestedRangeNotSatisfiable,
+						Code:    "BLOB_UNKNOWN",
+						Message: fmt.Sprintf("range end %d > %d size", end+1, size),
+					}
+				}
+				r = io.NewSectionReader(ra, start, n)
+			} else {
+				if _, err := io.CopyN(io.Discard, r, start); err != nil {
+					return &regError{
+						Status:  http.StatusRequestedRangeNotSatisfiable,
+						Code:    "BLOB_UNKNOWN",
+						Message: fmt.Sprintf("Failed to discard %d bytes", start),
+					}
+				}
+
+				r = io.LimitReader(r, n)
+			}
+
+			resp.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
+			resp.Header().Set("Content-Length", fmt.Sprint(n))
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusPartialContent)
+		} else {
+			resp.Header().Set("Content-Length", fmt.Sprint(size))
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusOK)
+		}
+
+		io.Copy(resp, r)
+		return nil
+
+	case http.MethodPost:
+		bph, ok := b.blobHandler.(BlobPutHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		// It is weird that this is "target" instead of "service", but
+		// that's how the index math works out above.
+		if target != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("POST to /blobs must be followed by /uploads, got %s", target),
+			}
+		}
+
+		if digest != "" {
+			h, err := v1.NewHash(digest)
+			if err != nil {
+				return regErrDigestInvalid
+			}
+
+			vrc, err := verify.ReadCloser(req.Body, req.ContentLength, h)
+			if err != nil {
+				return regErrInternal(err)
+			}
+			defer vrc.Close()
+
+			if err = bph.Put(req.Context(), repo, h, vrc); err != nil {
+				if errors.As(err, &verify.Error{}) {
+					log.Printf("Digest mismatch: %v", err)
+					return regErrDigestMismatch
+				}
+				return regErrInternal(err)
+			}
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusCreated)
+			return nil
+		}
+
+		id := fmt.Sprint(rand.Int63())
+		resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-2]...), "blobs/uploads", id))
+		resp.Header().Set("Range", "0-0")
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	case http.MethodPatch:
+		if service != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("PATCH to /blobs must be followed by /uploads, got %s", service),
+			}
+		}
+
+		if contentRange != "" {
+			start, end := 0, 0
+			if _, err := fmt.Sscanf(contentRange, "%d-%d", &start, &end); err != nil {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UPLOAD_UNKNOWN",
+					Message: "We don't understand your Content-Range",
+				}
+			}
+			b.lock.Lock()
+			defer b.lock.Unlock()
+			if start != len(b.uploads[target]) {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UPLOAD_UNKNOWN",
+					Message: "Your content range doesn't match what we have",
+				}
+			}
+			l := bytes.NewBuffer(b.uploads[target])
+			io.Copy(l, req.Body)
+			b.uploads[target] = l.Bytes()
+			resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-3]...), "blobs/uploads", target))
+			resp.Header().Set("Range", fmt.Sprintf("0-%d", len(l.Bytes())-1))
+			// OCI Distribution spec §10.5 requires 202 Accepted for chunk uploads.
+			resp.WriteHeader(http.StatusAccepted)
+			return nil
+		}
+
+		b.lock.Lock()
+		defer b.lock.Unlock()
+		if _, ok := b.uploads[target]; ok {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "BLOB_UPLOAD_INVALID",
+				Message: "Stream uploads after first write are not allowed",
+			}
+		}
+
+		l := &bytes.Buffer{}
+		io.Copy(l, req.Body)
+
+		b.uploads[target] = l.Bytes()
+		resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-3]...), "blobs/uploads", target))
+		resp.Header().Set("Range", fmt.Sprintf("0-%d", len(l.Bytes())-1))
+		// OCI Distribution spec §10.5 requires 202 Accepted for chunk uploads.
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	case http.MethodPut:
+		bph, ok := b.blobHandler.(BlobPutHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		if service != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("PUT to /blobs must be followed by /uploads, got %s", service),
+			}
+		}
+
+		if digest == "" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "DIGEST_INVALID",
+				Message: "digest not specified",
+			}
+		}
+
+		b.lock.Lock()
+		defer b.lock.Unlock()
+
+		h, err := v1.NewHash(digest)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		defer req.Body.Close()
+		in := io.NopCloser(io.MultiReader(bytes.NewBuffer(b.uploads[target]), req.Body))
+
+		size := int64(verify.SizeUnknown)
+		if req.ContentLength > 0 {
+			size = int64(len(b.uploads[target])) + req.ContentLength
+		}
+
+		vrc, err := verify.ReadCloser(in, size, h)
+		if err != nil {
+			return regErrInternal(err)
+		}
+		defer vrc.Close()
+
+		if err := bph.Put(req.Context(), repo, h, vrc); err != nil {
+			if errors.As(err, &verify.Error{}) {
+				log.Printf("Digest mismatch: %v", err)
+				return regErrDigestMismatch
+			}
+			return regErrInternal(err)
+		}
+
+		delete(b.uploads, target)
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusCreated)
+		return nil
+
+	case http.MethodDelete:
+		bdh, ok := b.blobHandler.(BlobDeleteHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+		if err := bdh.Delete(req.Context(), repo, h); err != nil {
+			return regErrInternal(err)
+		}
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	default:
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/blobs_disk.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/blobs_disk.go
@@ -1,0 +1,84 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type diskHandler struct {
+	dir string
+}
+
+func NewDiskBlobHandler(dir string) BlobHandler { return &diskHandler{dir: dir} }
+
+func (m *diskHandler) blobHashPath(h v1.Hash) string {
+	return filepath.Join(m.dir, h.Algorithm, h.Hex)
+}
+
+func (m *diskHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
+	f, err := os.Open(m.blobHashPath(h))
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, ErrNotFound
+	} else if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	got, size, err := v1.SHA256(f)
+	if err != nil {
+		return 0, err
+	}
+	if got != h {
+		return 0, fmt.Errorf("%w: blob %s has digest %s", ErrNotFound, h, got)
+	}
+	return size, nil
+}
+
+func (m *diskHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
+	return os.Open(m.blobHashPath(h))
+}
+
+func (m *diskHandler) Put(_ context.Context, _ string, h v1.Hash, rc io.ReadCloser) error {
+	// Put the temp file in the same directory to avoid cross-device problems
+	// during the os.Rename.  The filenames cannot conflict.
+	f, err := os.CreateTemp(m.dir, "upload-*")
+	if err != nil {
+		return err
+	}
+
+	if err := func() error {
+		defer f.Close()
+		_, err := io.Copy(f, rc)
+		return err
+	}(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(m.dir, h.Algorithm), os.ModePerm); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), m.blobHashPath(h))
+}
+
+func (m *diskHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
+	return os.Remove(m.blobHashPath(h))
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/error.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/error.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type regError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (r *regError) Write(resp http.ResponseWriter) error {
+	resp.WriteHeader(r.Status)
+
+	type err struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	type wrap struct {
+		Errors []err `json:"errors"`
+	}
+	return json.NewEncoder(resp).Encode(wrap{
+		Errors: []err{
+			{
+				Code:    r.Code,
+				Message: r.Message,
+			},
+		},
+	})
+}
+
+// regErrInternal returns an internal server error.
+func regErrInternal(err error) *regError {
+	return &regError{
+		Status:  http.StatusInternalServerError,
+		Code:    "INTERNAL_SERVER_ERROR",
+		Message: err.Error(),
+	}
+}
+
+var regErrBlobUnknown = &regError{
+	Status:  http.StatusNotFound,
+	Code:    "BLOB_UNKNOWN",
+	Message: "Unknown blob",
+}
+
+var regErrUnsupported = &regError{
+	Status:  http.StatusMethodNotAllowed,
+	Code:    "UNSUPPORTED",
+	Message: "Unsupported operation",
+}
+
+var regErrDigestMismatch = &regError{
+	Status:  http.StatusBadRequest,
+	Code:    "DIGEST_INVALID",
+	Message: "digest does not match contents",
+}
+
+var regErrDigestInvalid = &regError{
+	Status:  http.StatusBadRequest,
+	Code:    "NAME_INVALID",
+	Message: "invalid digest",
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/manifest.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/manifest.go
@@ -1,0 +1,444 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type catalog struct {
+	Repos []string `json:"repositories"`
+}
+
+type listTags struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+type manifest struct {
+	contentType string
+	blob        []byte
+}
+
+type manifests struct {
+	// maps repo -> manifest tag/digest -> manifest
+	manifests map[string]map[string]manifest
+	lock      sync.RWMutex
+	log       *log.Logger
+}
+
+func isManifest(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "manifests"
+}
+
+func isTags(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "tags"
+}
+
+func isCatalog(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 2 {
+		return false
+	}
+
+	return elems[len(elems)-1] == "_catalog"
+}
+
+// Returns whether this url should be handled by the referrers handler
+func isReferrers(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "referrers"
+}
+
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-an-image-manifest
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-an-image
+func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	switch req.Method {
+	case http.MethodGet:
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		m, ok := c[target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.Header().Set("Content-Type", m.contentType)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader(m.blob))
+		return nil
+
+	case http.MethodHead:
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		if _, ok := m.manifests[repo]; !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		m, ok := m.manifests[repo][target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.Header().Set("Content-Type", m.contentType)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
+		resp.WriteHeader(http.StatusOK)
+		return nil
+
+	case http.MethodPut:
+		b := &bytes.Buffer{}
+		io.Copy(b, req.Body)
+		h, _, _ := v1.SHA256(bytes.NewReader(b.Bytes()))
+		digest := h.String()
+		mf := manifest{
+			blob:        b.Bytes(),
+			contentType: req.Header.Get("Content-Type"),
+		}
+
+		// If the manifest is a manifest list, check that the manifest
+		// list's constituent manifests are already uploaded.
+		// This isn't strictly required by the registry API, but some
+		// registries require this.
+		if types.MediaType(mf.contentType).IsIndex() {
+			if err := func() *regError {
+				m.lock.RLock()
+				defer m.lock.RUnlock()
+
+				im, err := v1.ParseIndexManifest(b)
+				if err != nil {
+					return &regError{
+						Status:  http.StatusBadRequest,
+						Code:    "MANIFEST_INVALID",
+						Message: err.Error(),
+					}
+				}
+				for _, desc := range im.Manifests {
+					if !desc.MediaType.IsDistributable() {
+						continue
+					}
+					if desc.MediaType.IsIndex() || desc.MediaType.IsImage() {
+						if _, found := m.manifests[repo][desc.Digest.String()]; !found {
+							return &regError{
+								Status:  http.StatusNotFound,
+								Code:    "MANIFEST_UNKNOWN",
+								Message: fmt.Sprintf("Sub-manifest %q not found", desc.Digest),
+							}
+						}
+					} else {
+						// TODO: Probably want to do an existence check for blobs.
+						m.log.Printf("TODO: Check blobs for %q", desc.Digest)
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
+		if _, ok := m.manifests[repo]; !ok {
+			m.manifests[repo] = make(map[string]manifest, 2)
+		}
+
+		// Allow future references by target (tag) and immutable digest.
+		// See https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier.
+		m.manifests[repo][digest] = mf
+		m.manifests[repo][target] = mf
+		resp.Header().Set("Docker-Content-Digest", digest)
+		resp.WriteHeader(http.StatusCreated)
+		return nil
+
+	case http.MethodDelete:
+		m.lock.Lock()
+		defer m.lock.Unlock()
+		if _, ok := m.manifests[repo]; !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+
+		_, ok := m.manifests[repo][target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		delete(m.manifests[repo], target)
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	default:
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+}
+
+func (m *manifests) handleTags(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	if req.Method == "GET" {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+
+		var tags []string
+		for tag := range c {
+			if !strings.Contains(tag, "sha256:") {
+				tags = append(tags, tag)
+			}
+		}
+		sort.Strings(tags)
+
+		// https://github.com/opencontainers/distribution-spec/blob/b505e9cc53ec499edbd9c1be32298388921bb705/detail.md#tags-paginated
+		// Offset using last query parameter.
+		if last := req.URL.Query().Get("last"); last != "" {
+			for i, t := range tags {
+				if t > last {
+					tags = tags[i:]
+					break
+				}
+			}
+		}
+
+		// Limit using n query parameter.
+		if ns := req.URL.Query().Get("n"); ns != "" {
+			if n, err := strconv.Atoi(ns); err != nil {
+				return &regError{
+					Status:  http.StatusBadRequest,
+					Code:    "BAD_REQUEST",
+					Message: fmt.Sprintf("parsing n: %v", err),
+				}
+			} else if n < len(tags) {
+				tags = tags[:n]
+			}
+		}
+
+		tagsToList := listTags{
+			Name: repo,
+			Tags: tags,
+		}
+
+		msg, _ := json.Marshal(tagsToList)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader([]byte(msg)))
+		return nil
+	}
+
+	return &regError{
+		Status:  http.StatusBadRequest,
+		Code:    "METHOD_UNKNOWN",
+		Message: "We don't understand your method + url",
+	}
+}
+
+func (m *manifests) handleCatalog(resp http.ResponseWriter, req *http.Request) *regError {
+	query := req.URL.Query()
+	nStr := query.Get("n")
+	n := 10000
+	if nStr != "" {
+		n, _ = strconv.Atoi(nStr)
+	}
+
+	if req.Method == "GET" {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		var repos []string
+		countRepos := 0
+		// TODO: implement pagination
+		for key := range m.manifests {
+			if countRepos >= n {
+				break
+			}
+			countRepos++
+
+			repos = append(repos, key)
+		}
+
+		repositoriesToList := catalog{
+			Repos: repos,
+		}
+
+		msg, _ := json.Marshal(repositoriesToList)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader([]byte(msg)))
+		return nil
+	}
+
+	return &regError{
+		Status:  http.StatusBadRequest,
+		Code:    "METHOD_UNKNOWN",
+		Message: "We don't understand your method + url",
+	}
+}
+
+// TODO: implement handling of artifactType querystring
+func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request) *regError {
+	// Ensure this is a GET request
+	if req.Method != "GET" {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	// Validate that incoming target is a valid digest
+	if _, err := v1.NewHash(target); err != nil {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "UNSUPPORTED",
+			Message: "Target must be a valid digest",
+		}
+	}
+
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	digestToManifestMap, repoExists := m.manifests[repo]
+	if !repoExists {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "NAME_UNKNOWN",
+			Message: "Unknown name",
+		}
+	}
+
+	im := v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
+		Manifests:     []v1.Descriptor{},
+	}
+	for digest, manifest := range digestToManifestMap {
+		h, err := v1.NewHash(digest)
+		if err != nil {
+			continue
+		}
+		var refPointer struct {
+			Subject *v1.Descriptor `json:"subject"`
+		}
+		json.Unmarshal(manifest.blob, &refPointer)
+		if refPointer.Subject == nil {
+			continue
+		}
+		referenceDigest := refPointer.Subject.Digest
+		if referenceDigest.String() != target {
+			continue
+		}
+		// At this point, we know the current digest references the target
+		var imageAsArtifact struct {
+			Config struct {
+				MediaType string `json:"mediaType"`
+			} `json:"config"`
+		}
+		json.Unmarshal(manifest.blob, &imageAsArtifact)
+		im.Manifests = append(im.Manifests, v1.Descriptor{
+			MediaType:    types.MediaType(manifest.contentType),
+			Size:         int64(len(manifest.blob)),
+			Digest:       h,
+			ArtifactType: imageAsArtifact.Config.MediaType,
+		})
+	}
+	msg, _ := json.Marshal(&im)
+	resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+	resp.Header().Set("Content-Type", string(types.OCIImageIndex))
+	resp.WriteHeader(http.StatusOK)
+	io.Copy(resp, bytes.NewReader([]byte(msg)))
+	return nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/registry.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/registry.go
@@ -1,0 +1,144 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registry implements a docker V2 registry and the OCI distribution specification.
+//
+// It is designed to be used anywhere a low dependency container registry is needed, with an
+// initial focus on tests.
+//
+// Its goal is to be standards compliant and its strictness will increase over time.
+//
+// This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it
+// in production, please let us know how and send us CL's for integration tests.
+package registry
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+)
+
+type registry struct {
+	log              *log.Logger
+	blobs            blobs
+	manifests        manifests
+	referrersEnabled bool
+	warnings         map[float64]string
+}
+
+// https://docs.docker.com/registry/spec/api/#api-version-check
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#api-version-check
+func (r *registry) v2(resp http.ResponseWriter, req *http.Request) *regError {
+	if r.warnings != nil {
+		rnd := rand.Float64()
+		for prob, msg := range r.warnings {
+			if prob > rnd {
+				resp.Header().Add("Warning", fmt.Sprintf(`299 - "%s"`, msg))
+			}
+		}
+	}
+
+	if isBlob(req) {
+		return r.blobs.handle(resp, req)
+	}
+	if isManifest(req) {
+		return r.manifests.handle(resp, req)
+	}
+	if isTags(req) {
+		return r.manifests.handleTags(resp, req)
+	}
+	if isCatalog(req) {
+		return r.manifests.handleCatalog(resp, req)
+	}
+	if r.referrersEnabled && isReferrers(req) {
+		return r.manifests.handleReferrers(resp, req)
+	}
+	resp.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+	if req.URL.Path != "/v2/" && req.URL.Path != "/v2" {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+	resp.WriteHeader(200)
+	return nil
+}
+
+func (r *registry) root(resp http.ResponseWriter, req *http.Request) {
+	if rerr := r.v2(resp, req); rerr != nil {
+		r.log.Printf("%s %s %d %s %s", req.Method, req.URL, rerr.Status, rerr.Code, rerr.Message)
+		rerr.Write(resp)
+		return
+	}
+	r.log.Printf("%s %s", req.Method, req.URL)
+}
+
+// New returns a handler which implements the docker registry protocol.
+// It should be registered at the site root.
+func New(opts ...Option) http.Handler {
+	r := &registry{
+		log: log.New(os.Stderr, "", log.LstdFlags),
+		blobs: blobs{
+			blobHandler: &memHandler{m: map[string][]byte{}},
+			uploads:     map[string][]byte{},
+			log:         log.New(os.Stderr, "", log.LstdFlags),
+		},
+		manifests: manifests{
+			manifests: map[string]map[string]manifest{},
+			log:       log.New(os.Stderr, "", log.LstdFlags),
+		},
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return http.HandlerFunc(r.root)
+}
+
+// Option describes the available options
+// for creating the registry.
+type Option func(r *registry)
+
+// Logger overrides the logger used to record requests to the registry.
+func Logger(l *log.Logger) Option {
+	return func(r *registry) {
+		r.log = l
+		r.manifests.log = l
+		r.blobs.log = l
+	}
+}
+
+// WithReferrersSupport enables the referrers API endpoint (OCI 1.1+)
+func WithReferrersSupport(enabled bool) Option {
+	return func(r *registry) {
+		r.referrersEnabled = enabled
+	}
+}
+
+func WithWarning(prob float64, msg string) Option {
+	return func(r *registry) {
+		if r.warnings == nil {
+			r.warnings = map[float64]string{}
+		}
+		r.warnings[prob] = msg
+	}
+}
+
+func WithBlobHandler(h BlobHandler) Option {
+	return func(r *registry) {
+		r.blobs.blobHandler = h
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/tls.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/tls.go
@@ -1,0 +1,29 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"net/http/httptest"
+
+	ggcrtest "github.com/google/go-containerregistry/internal/httptest"
+)
+
+// TLS returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain
+// which should correspond to the domain the image is stored in.
+// If you need a transport, Client().Transport is correctly configured.
+func TLS(domain string) (*httptest.Server, error) {
+	return ggcrtest.NewTLSServer(domain, New())
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1073,6 +1073,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/go-containerregistry/internal/and
 github.com/google/go-containerregistry/internal/compression
 github.com/google/go-containerregistry/internal/gzip
+github.com/google/go-containerregistry/internal/httptest
 github.com/google/go-containerregistry/internal/limit
 github.com/google/go-containerregistry/internal/redact
 github.com/google/go-containerregistry/internal/retry
@@ -1088,6 +1089,7 @@ github.com/google/go-containerregistry/pkg/legacy
 github.com/google/go-containerregistry/pkg/legacy/tarball
 github.com/google/go-containerregistry/pkg/logs
 github.com/google/go-containerregistry/pkg/name
+github.com/google/go-containerregistry/pkg/registry
 github.com/google/go-containerregistry/pkg/v1
 github.com/google/go-containerregistry/pkg/v1/daemon
 github.com/google/go-containerregistry/pkg/v1/empty


### PR DESCRIPTION
## Description

End-to-end coverage for every cargoship command that does not need a cluster: the misc group (`version`, `sha256sum`, `vault-encrypt`) and the package group (`create`, `publish`, `pull`, `sign`). Each test drives the built binary as a subprocess, the same way a user would.

This is the first half of the e2e work. The install group needs Docker, a nine-container bootloose cluster and a ~1.5 GB distro package, so it lives in a follow-up PR and is deliberately absent here. The suites are split by Go package rather than by test-name filters, so this one cannot accidentally pull in the cluster machinery:

```
src/test/e2e/noncluster/   misc + package groups, no Docker, no network
src/test/e2e/cluster/      install group (follow-up PR)
```

The whole suite in this PR runs in about six seconds and starts no containers, which is what makes it usable as a pull request gate.

### Coverage

| Command | Cases |
| --- | --- |
| `version` | plain output, `v` alias, `-o json` and `--output yaml` parsed and asserted (build version/commit/platform/go plus a non-empty dependency map), unsupported format errors |
| `sha256sum` | local file, `sum` alias, `http(s)` source via `httptest`, `--extract-path` and its `-e` shorthand, missing archive member, missing file, no args |
| `vault-encrypt` | argument and stdin input, `CARGOSHIP_VAULT_PASSWORD`, `ANSIBLE_VAULT_PASSWORD`, no password available, empty stdin, unreadable password file, missing required flag, too many args |
| `create` | package naming and metadata, `-o`, `--reproducible` producing byte-identical archives across runs, `--signing-key` producing `distro.bundle.sig` and `build.signed: true`, three `--registry-override` parse failures, nonexistent directory, too many args, and the real `example/rke2-cilium` build gated behind `-short` |
| `publish` | round trip against an in-process registry, destination missing the `oci://` prefix, missing source, argument count |
| `pull` | round trip byte-identical to the published package, `--shasum` matching and mismatching the manifest digest, unknown tag, `http(s)` source with matching, mismatching and absent shasum, argument count |
| `sign` | sign to `-o`, default in-place output, re-sign refused without `--overwrite`, `--verify=always` passing with the matching key and failing with an unrelated one, wrong key password, neither `--signing-key` nor `--keyless`, the two being mutually exclusive, missing source, argument count, and signing straight to an `oci://` destination followed by a verifying pull |

Verification is exercised in both directions: a package signed with one key verifies, and the same package fails against a second, unrelated key.

### Fixtures

Three choices keep the suite fast and hermetic:

- **`src/test/e2e/noncluster/testdata/minimal`** is a valid distro definition with no images and no files. `assemble.AssembleDistro` only reaches out to a registry when `config.imageConfig.images` or `config.files` are populated, so this builds in milliseconds into a 386-byte package. Every package-group test uses it; only `TestCargoshipCreateExample` builds a real example, and it is skipped under `-short`.
- **Signing keys are generated per test** with `cosign.GenerateKeyPair`, so no key material is committed and two calls naturally yield unrelated keys for the negative cases.
- **`test.SetupInMemoryRegistry`** starts an OCI registry in-process on a random localhost port, so publish and pull need no registry container and no network. `docs/agent/choice-in-memory-oci-registry.md` records why `google/go-containerregistry` was chosen over `distribution/distribution` for this. The registry logs one line per request, which buries the output of the test being run, so it writes to a file under the user cache directory instead (`~/.cache/cargoship/e2e-logs/registry-<timestamp>.log`, named the way the CLI names its own log files). The file is removed when the test passes and kept, with its path reported, when it fails; `CARGOSHIP_E2E_KEEP_REGISTRY_LOG=1` keeps it either way.

### Tooling

- `.github/workflows/e2e.yaml` gains an `e2e-noncluster` job that reuses the binary built by `build-e2e`, stages it where the suite expects it, and runs `go test -short ./src/test/e2e/noncluster/...`.
- `mage test:endToEndNonCluster` mirrors that job locally; `mage test:endToEnd` runs everything including the example packages. The mage test targets are split one per file with the shared helper in `magefiles/test-common.go`.
- `daggerBuildLocal` now picks `--progress=plain` when stdout is not a terminal, since the tty renderer errors out in CI.
- `docs/dev/e2e-tests.md` documents how to run the suite directly with `go test`, without the mage wrappers: building the binary the tests exec, running a single test or subtest, the environment variables, where the artifacts and logs land, and how to reproduce a failing case by hand. Linked from `docs/SUMMARY.md`.
- `src/pkg/utils/files.go` exports `TmpPathPrefix` (previously unexported) so the test harness can create temp directories with the same prefix the binary uses.

### Dependencies

`go mod tidy` promotes two modules from indirect to direct: `github.com/sigstore/cosign/v3` (key generation) and `github.com/google/go-containerregistry` (in-memory registry). Both were already in the module graph, so this adds nine vendored files and no new transitive dependencies. `go.sum` is unchanged.

### Findings, not fixed here

Writing these tests turned up four things worth a separate look. The tests pin current behavior rather than changing it:

- `publish` registers `--verify` and `-k` through `addVerifyFlags`, but its `distro.Load` call never sets `VerificationStrategy` or builds verify options, so both flags are silently ignored. Verification only actually happens on `pull` and `sign`.
- `create --skip-sbom` is a no-op: `distro.Create` hardcodes `SkipSBOM: true` and ignores the option.
- `--verify` is declared with a `NoOptDefVal`, so `--verify always` parses `always` as a positional argument and fails with `accepts 1 arg(s), received 2`. Only the attached form `--verify=always` works, which is worth checking against the docs and examples.
- `vault-encrypt` marks `--vault-password-file` as required, so the `CARGOSHIP_VAULT_PASSWORD` and `ANSIBLE_VAULT_PASSWORD` fallbacks are only reachable by passing the flag with an empty value.

Also worth noting: `install engine-config-sync` has no e2e coverage in either half, so it should not be assumed covered once the cluster PR lands.

### Unrelated one-line fix

`defaultLogFilePath` in `src/cmd/root.go` described its log file as "named to the second", but `config.TimeFormat` ends in fractional seconds, so the name is to the hundredth. Comment only, no behavior change.

### Verification

`go build ./...`, `go vet ./src/...` and `golangci-lint run ./src/...` are clean, and `go test -short ./src/test/e2e/noncluster/...` passes with all eleven suites green in about six seconds with Docker stopped.

## Related Issue

Relates to #18

## Checklist before merging

- [x] Test, docs, adr added or updated as needed

