### PR TITLE
fix: remove no-op --skip-sbom flag, unblock vault-encrypt env fallbacks

### DIFF
--- a/docs/commands/cargoship_create.md
+++ b/docs/commands/cargoship_create.md
@@ -23,8 +23,8 @@ $ cargoship create ./distro-defs --registry-override docker.io=mirror.example.co
 # Sign the package as it is built, without prompting for the key password
 $ cargoship create ./distro-defs --signing-key ./private-key.pem --confirm
 
-# Build a byte-identical package on every run, skipping SBOM generation
-$ cargoship create ./distro-defs --reproducible --skip-sbom
+# Build a byte-identical package on every run
+$ cargoship create ./distro-defs --reproducible
 ```
 
 ### Options
@@ -38,7 +38,6 @@ $ cargoship create ./distro-defs --reproducible --skip-sbom
       --reproducible                Pin the recorded package build time to a fixed value instead of the current time, so identical inputs produce a byte-identical package.
       --signing-key string          Private key for signing packages. Accepts either a local file path or a Cosign-supported key provider
       --signing-key-pass string     Password to the private key used for signing packages
-      --skip-sbom                   Skip generating SBOM for this package
 ```
 
 ### Options inherited from parent commands

--- a/schema/zarf-config-distro-schema.json
+++ b/schema/zarf-config-distro-schema.json
@@ -19,10 +19,6 @@
         "registry_override": {
           "$ref": "#/$defs/RegistryOverrideMap",
           "description": "maps a source registry to the registry cargoship uses instead\nwhen pulling images, for example {\"docker.io\": \"mirror.example.com\"}"
-        },
-        "skip_sbom": {
-          "description": "whether we will scan the images or files",
-          "type": "boolean"
         }
       },
       "type": "object"

--- a/src/cmd/misc_vault_encrypt.go
+++ b/src/cmd/misc_vault_encrypt.go
@@ -46,8 +46,10 @@ func newVaultEncryptCommand() *cobra.Command {
 		RunE:    o.run,
 	}
 
+	// Not marked required: ResolveVaultPassword falls back to CARGOSHIP_VAULT_PASSWORD
+	// and ANSIBLE_VAULT_PASSWORD, which are unreachable if cobra rejects the command
+	// before RunE. run() errors when no password is found by any means.
 	cmd.Flags().StringVar(&o.vaultPasswordFile, MiscVaultPasswordFile, "", lang.CmdVaultEncryptFlagPasswordFile)
-	cmd.MarkFlagRequired(MiscVaultPasswordFile)
 
 	return cmd
 }

--- a/src/cmd/package_create.go
+++ b/src/cmd/package_create.go
@@ -49,7 +49,6 @@ type packageCreateOptions struct {
 	registryOverrides  []string
 	ociConcurrency     int
 	confirm            bool
-	skipSBOM           bool
 	reproducible       bool
 	signingKeyPath     string
 	signingKeyPassword string
@@ -84,7 +83,6 @@ func newPackageCreateCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&o.confirm, "confirm", "c", false, zlang.CmdPackagePublishFlagConfirm)
 	cmd.Flags().StringVarP(&o.output, "output", "o", output, lang.CmdPackageCreateFlagOutput)
 	cmd.Flags().StringSliceVar(&o.registryOverrides, "registry-override", registryOverrideDefaults, zlang.CmdPackageCreateFlagRegistryOverride)
-	cmd.Flags().BoolVar(&o.skipSBOM, "skip-sbom", resolvedConfig.DistroOpts.CreateOpts.SkipSBOM, zlang.CmdPackageCreateFlagSkipSbom)
 	cmd.Flags().BoolVar(&o.reproducible, "reproducible", false, lang.CmdPackageCreateFlagReproducible)
 	cmd.Flags().StringVar(&o.signingKeyPath, "signing-key", resolvedConfig.DistroOpts.PublishOpts.SigningKey, zlang.CmdPackageCreateFlagSigningKey)
 	cmd.Flags().StringVar(&o.signingKeyPassword, "signing-key-pass", resolvedConfig.DistroOpts.PublishOpts.SigningKeyPassword, zlang.CmdPackageCreateFlagSigningKeyPassword)

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -180,7 +180,6 @@ func setDefaults() {
 	v.SetDefault(configPath("LogFile"), false)
 
 	v.SetDefault(configPath("DistroOpts", "OCIConcurrency"), 6)
-	v.SetDefault(configPath("DistroOpts", "CreateOpts", "SkipSBOM"), false)
 	v.SetDefault(configPath("DistroOpts", "Concurrency"), 30)
 	v.SetDefault(configPath("DistroOpts", "HostUpdate"), false)
 	v.SetDefault(configPath("DistroOpts", "FirewallUpdate"), false)

--- a/src/config/lang/eng-examples.go
+++ b/src/config/lang/eng-examples.go
@@ -99,8 +99,8 @@ $ cargoship create ./distro-defs --registry-override docker.io=mirror.example.co
 # Sign the package as it is built, without prompting for the key password
 $ cargoship create ./distro-defs --signing-key ./private-key.pem --confirm
 
-# Build a byte-identical package on every run, skipping SBOM generation
-$ cargoship create ./distro-defs --reproducible --skip-sbom`
+# Build a byte-identical package on every run
+$ cargoship create ./distro-defs --reproducible`
 
 	// CmdDistroPublishExample publish example
 	CmdDistroPublishExample = `# Publish a package to an OCI registry

--- a/src/pkg/distro/create.go
+++ b/src/pkg/distro/create.go
@@ -39,7 +39,6 @@ type CreateOptions struct {
 	OCIConcurrency int
 	CachePath      string
 	IsInteractive  bool
-	SkipSBOM       bool
 	// Reproducible pins Build.Timestamp to config.Timestamp instead of the
 	// current time, and is recorded on Build.Reproducible, so identical package
 	// inputs produce byte-identical output.

--- a/src/test/e2e/noncluster/02_cargoship_vault_test.go
+++ b/src/test/e2e/noncluster/02_cargoship_vault_test.go
@@ -63,13 +63,11 @@ func TestCargoshipVaultEncrypt(t *testing.T) {
 		require.Equal(t, value, decrypted)
 	})
 
-	t.Run("CARGOSHIP_VAULT_PASSWORD is used when the password file is empty", func(t *testing.T) {
+	t.Run("CARGOSHIP_VAULT_PASSWORD is used when the password file is omitted", func(t *testing.T) {
 		const value = "env-password-secret"
 		t.Setenv("CARGOSHIP_VAULT_PASSWORD", password)
 
-		// The flag is marked required, so it still has to be present -- an empty value
-		// hands ResolveVaultPassword the fall-through to the environment.
-		stdout, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", "", value)
+		stdout, _, err := e2e.Cargoship(t, "vault-encrypt", value)
 		require.NoError(t, err)
 
 		decrypted, err := vault.Decrypt(strings.TrimSpace(stdout), password)
@@ -81,6 +79,21 @@ func TestCargoshipVaultEncrypt(t *testing.T) {
 		const value = "ansible-env-password-secret"
 		t.Setenv("CARGOSHIP_VAULT_PASSWORD", "")
 		t.Setenv("ANSIBLE_VAULT_PASSWORD", password)
+
+		stdout, _, err := e2e.Cargoship(t, "vault-encrypt", value)
+		require.NoError(t, err)
+
+		decrypted, err := vault.Decrypt(strings.TrimSpace(stdout), password)
+		require.NoError(t, err)
+		require.Equal(t, value, decrypted)
+	})
+
+	// Passing the flag with an empty value was the only way to reach the environment
+	// while --vault-password-file was still marked required. It has to keep working so
+	// scripts written against that behavior do not break.
+	t.Run("an empty password file flag still falls through to the environment", func(t *testing.T) {
+		const value = "empty-flag-secret"
+		t.Setenv("CARGOSHIP_VAULT_PASSWORD", password)
 
 		stdout, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", "", value)
 		require.NoError(t, err)
@@ -94,8 +107,9 @@ func TestCargoshipVaultEncrypt(t *testing.T) {
 		t.Setenv("CARGOSHIP_VAULT_PASSWORD", "")
 		t.Setenv("ANSIBLE_VAULT_PASSWORD", "")
 
-		_, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", "", "value")
+		_, stderr, err := e2e.Cargoship(t, "vault-encrypt", "value")
 		require.Error(t, err)
+		require.Contains(t, stderr, "no vault password found")
 	})
 
 	t.Run("empty stdin errors", func(t *testing.T) {
@@ -106,15 +120,6 @@ func TestCargoshipVaultEncrypt(t *testing.T) {
 
 	t.Run("missing password file errors", func(t *testing.T) {
 		_, _, err := e2e.Cargoship(t, "vault-encrypt", "--vault-password-file", filepath.Join(t.TempDir(), "does-not-exist"), "value")
-		require.Error(t, err)
-	})
-
-	// --vault-password-file is marked required, so omitting it fails in cobra before
-	// ResolveVaultPassword ever consults the environment.
-	t.Run("missing password flag errors even with the env var set", func(t *testing.T) {
-		t.Setenv("CARGOSHIP_VAULT_PASSWORD", password)
-
-		_, _, err := e2e.Cargoship(t, "vault-encrypt", "value")
 		require.Error(t, err)
 	})
 

--- a/src/test/e2e/noncluster/10_cargoship_create_test.go
+++ b/src/test/e2e/noncluster/10_cargoship_create_test.go
@@ -105,6 +105,14 @@ func TestCargoshipCreate(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// --skip-sbom was removed because distro.Create hardcoded SkipSBOM and never read
+	// the flag. Assert it is gone rather than silently accepted again.
+	t.Run("skip-sbom is not a flag", func(t *testing.T) {
+		_, stderr, err := e2e.Cargoship(t, "create", minimalDistroDir, "-o", t.TempDir(), "--skip-sbom")
+		require.Error(t, err)
+		require.Contains(t, stderr, "unknown flag: --skip-sbom")
+	})
+
 	t.Run("nonexistent directory errors", func(t *testing.T) {
 		_, _, err := e2e.Cargoship(t, "create", filepath.Join(t.TempDir(), "nope"), "-o", t.TempDir())
 		require.Error(t, err)

--- a/src/types/config.go
+++ b/src/types/config.go
@@ -112,8 +112,6 @@ type DistroOptions struct {
 
 // DistroCreateOptions holds the values for the `.distro.create` section of the config file
 type DistroCreateOptions struct {
-	// SkipSBOM whether we will scan the images or files
-	SkipSBOM bool `json:"skip_sbom,omitempty" mapstructure:"skip_sbom"`
 	// RegistryOverride maps a source registry to the registry cargoship uses instead
 	// when pulling images, for example {"docker.io": "mirror.example.com"}
 	RegistryOverride RegistryOverrideMap `json:"registry_override,omitempty" mapstructure:"-"` // mapstructure:"-": viper always splits a map key on "." when merging its settings tree, so a domain key like "docker.io" gets silently corrupted into a nested map; read directly from the config file instead (see initViper in cmd/viper.go)


### PR DESCRIPTION
## Description

Two CLI flags found while writing the non-cluster e2e suite (#234) that do not do what they claim. Both are fixed here; neither change touches package output.

### `create --skip-sbom` is removed

The flag was wired from the CLI through `distro.CreateOptions`, but `distro.Create` hardcodes `SkipSBOM: true` on the assemble options and never reads the value. Passing `--skip-sbom`, or setting `distro.create.skip_sbom` in the config file, did nothing — SBOM generation is not implemented yet, so every package is already built without one.

Rather than leave a switch that advertises behavior the binary does not have, this removes the flag, the `distro.CreateOptions.SkipSBOM` field, the `distro.create.skip_sbom` config key and its schema entry, and the example line that used it. `assemble.AssembleOptions` keeps its `SkipSBOM` field and `distro.Create` keeps setting it to `true`, so the hook for the eventual implementation is still there.

**Breaking:** a command line or config file that sets either one now errors instead of being silently ignored.

### `vault-encrypt --vault-password-file` is no longer required

The flag was marked required, so cobra rejected the command before `RunE` ran. That made the `CARGOSHIP_VAULT_PASSWORD` and `ANSIBLE_VAULT_PASSWORD` fallbacks in `ResolveVaultPassword` unreachable unless you passed the flag with an empty value. Dropping the required marking makes the documented env vars work on their own; `run()` already errors when no password is found by any means, and that message names the flag and both variables.

## Related Issue

Relates to #234

## Checklist before merging

- [x] Test, docs, adr added or updated as needed

## Verification

`go build ./src/...`, `go vet ./src/...`, `go test ./src/...` and `golangci-lint run ./src/...` are clean. Schema and command docs regenerated with `mage generate:schema` and `mage generate:document`.

Checked against the built binary:

- `cargoship create --help` no longer lists `--skip-sbom`, and a package still builds.
- `CARGOSHIP_VAULT_PASSWORD=... cargoship vault-encrypt` with no flag encrypts successfully.
- With neither the flag nor either env var set, it still fails with `no vault password found: set --vault-password-file or the CARGOSHIP_VAULT_PASSWORD/ANSIBLE_VAULT_PASSWORD environment variable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)