### PR TITLE
fix!: make package signature verification actually run on publish and local sources

### DIFF
--- a/docs/commands/cargoship_publish.md
+++ b/docs/commands/cargoship_publish.md
@@ -41,7 +41,7 @@ $ cargoship publish ./build/cargoship-rancher-rke2-amd64-1.0.0.tar.zst oci://ghc
       --signing-key-pass string                 Password to the private key used for publishing packages
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Verify the Cargoship package signature (default if-possible)
+      --verify verifyMode                       Verify the Cargoship package signature (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/cargoship_pull.md
+++ b/docs/commands/cargoship_pull.md
@@ -42,7 +42,7 @@ $ cargoship pull oci://ghcr.io/my-org/my-package:1.0.0 --verify=always --certifi
       --shasum string                           Shasum of the package to pull
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Verify the Cargoship package signature (default if-possible)
+      --verify verifyMode                       Verify the Cargoship package signature (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/cargoship_sign.md
+++ b/docs/commands/cargoship_sign.md
@@ -59,7 +59,7 @@ $ cargoship sign cargoship-rancher-rke2-amd64-1.0.0.tar.zst --signing-key awskms
       --trusted-root string                     Path to a Sigstore TrustedRoot JSON. Falls back to the binary-embedded copy when omitted.
       --tsa-server-url string                   RFC3161 timestamp authority URL (e.g. https://timestamp.sigstore.dev/api/v1/timestamp). When set, a signed timestamp is embedded in the bundle as an alternative or complement to --tlog-upload for proving the signature was made while the Fulcio certificate was valid.
       --use-signed-timestamps                   Verify RFC3161 signed timestamps in the bundle. Auto-enabled when the bundle contains TSA timestamp data. Use when signing was done with --tsa-server-url and Rekor was not used.
-      --verify verifyMode[=always]              Verify the Cargoship package signature (default if-possible)
+      --verify verifyMode                       Verify the Cargoship package signature (default if-possible)
 ```
 
 ### Options inherited from parent commands

--- a/src/cmd/common_verify.go
+++ b/src/cmd/common_verify.go
@@ -160,7 +160,6 @@ func newVerifyFlagSet(v *viper.Viper, f *packageVerifyFlags) *pflag.FlagSet {
 	fs.StringVarP(&f.publicKeyPath, "key", "k", resolvedConfig.DistroOpts.PublicKey, zlang.CmdPackageFlagFlagPublicKey)
 	f.verify = verifyModeIfPossible
 	fs.VarP(&f.verify, "verify", "", lang.CmdPackageFlagVerify)
-	fs.Lookup("verify").NoOptDefVal = string(verifyModeAlways)
 
 	fs.AddFlagSet(newKeylessVerifyFlagSet(v, f))
 	annotateFlagGroup(fs, verifyFlagGroupTitle)

--- a/src/cmd/package_publish.go
+++ b/src/cmd/package_publish.go
@@ -59,7 +59,7 @@ func newPackagePublishCommand() *cobra.Command {
 		PreRunE: o.preRunE,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			return o.run(ctx, args)
+			return o.run(ctx, cmd, args)
 		},
 	}
 
@@ -76,7 +76,7 @@ func newPackagePublishCommand() *cobra.Command {
 	return cmd
 }
 
-func (o *packagePublishOptions) run(ctx context.Context, args []string) error {
+func (o *packagePublishOptions) run(ctx context.Context, cmd *cobra.Command, args []string) error {
 	l := logger.From(ctx)
 	distroSource := args[0]
 
@@ -101,9 +101,11 @@ func (o *packagePublishOptions) run(ctx context.Context, args []string) error {
 	}
 
 	loadOpts := distro.LoadOptions{
-		CachePath:    cachePath,
-		Architecture: config.CLIArch,
-		Output:       config.CommonOptions.TempDirectory,
+		CachePath:            cachePath,
+		Architecture:         config.CLIArch,
+		Output:               config.CommonOptions.TempDirectory,
+		VerificationStrategy: o.verify.toStrategy(),
+		VerifyBlobOptions:    o.buildVerifyBlobOptions(cmd, v),
 	}
 
 	distroLayout, err := distro.Load(ctx, distroSource, loadOpts)

--- a/src/cmd/package_sign.go
+++ b/src/cmd/package_sign.go
@@ -91,7 +91,6 @@ func newPackageSignCommand() *cobra.Command {
 	cmd.Flags().IntVar(&o.retries, "retries", resolvedConfig.DistroOpts.Retry, lang.CmdPackageFlagRetries)
 	o.verify = verifyModeIfPossible
 	cmd.Flags().VarP(&o.verify, "verify", "", lang.CmdPackageFlagVerify)
-	cmd.Flags().Lookup("verify").NoOptDefVal = string(verifyModeAlways)
 
 	cmd.Flags().BoolVar(&o.keyless, "keyless", false, zlang.CmdPackageSignFlagKeyless)
 	cmd.Flags().StringVar(&o.identityToken, "identity-token", "", zlang.CmdPackageSignFlagIdentityToken)

--- a/src/pkg/distro/load.go
+++ b/src/pkg/distro/load.go
@@ -110,7 +110,10 @@ func Load(ctx context.Context, source string, opts LoadOptions) (*layout.DistroL
 		return nil, err
 	}
 	logger.From(ctx).Debug(tmpPath)
-	distroLayout, err := layout.LoadFromTar(ctx, tmpPath, layout.DistroLayoutOptions{})
+	distroLayout, err := layout.LoadFromTar(ctx, tmpPath, layout.DistroLayoutOptions{
+		VerifyBlobOptions:    opts.VerifyBlobOptions,
+		VerificationStrategy: opts.VerificationStrategy,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/src/test/e2e/noncluster/11_cargoship_publish_pull_test.go
+++ b/src/test/e2e/noncluster/11_cargoship_publish_pull_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -83,6 +84,102 @@ func TestCargoshipPublish(t *testing.T) {
 	t.Run("one arg errors", func(t *testing.T) {
 		_, _, err := e2e.Cargoship(t, "publish", minimalPackage(t))
 		require.Error(t, err)
+	})
+}
+
+// TestCargoshipPublishVerify covers publish's verification flags. publish registers the
+// full verify flag set, but until the loader forwarded VerificationStrategy for local
+// package sources these flags were accepted and silently ignored, so an unverifiable
+// package published anyway.
+func TestCargoshipPublishVerify(t *testing.T) {
+	t.Run("verify always on an unsigned package errors before anything is published", func(t *testing.T) {
+		addr := test.SetupInMemoryRegistry(t)
+		dst, src := ociRefs(addr, "e2e-test")
+
+		_, stderr, err := e2e.Cargoship(t, "publish", minimalPackage(t), dst,
+			"--plain-http", "--confirm", "--verify=always")
+		require.Error(t, err)
+		require.Contains(t, stderr, "no verification material available")
+
+		// The failure must happen at load, before the package reaches the registry.
+		_, _, err = e2e.Cargoship(t, "pull", src, "--plain-http", "-o", t.TempDir())
+		require.Error(t, err, "nothing should have been pushed")
+	})
+
+	t.Run("unsigned package publishes when verification is not enforced", func(t *testing.T) {
+		addr := test.SetupInMemoryRegistry(t)
+		dst, _ := ociRefs(addr, "e2e-test")
+
+		_, _, err := e2e.Cargoship(t, "publish", minimalPackage(t), dst, "--plain-http", "--confirm")
+		require.NoError(t, err)
+	})
+
+	t.Run("verify always with the matching key publishes", func(t *testing.T) {
+		pkgPath, pubPath := signedPackage(t)
+		addr := test.SetupInMemoryRegistry(t)
+		dst, src := ociRefs(addr, "e2e-test")
+
+		_, _, err := e2e.Cargoship(t, "publish", pkgPath, dst,
+			"--plain-http", "--confirm", "--verify=always", "-k", pubPath)
+		require.NoError(t, err)
+
+		pullDir := t.TempDir()
+		_, _, err = e2e.Cargoship(t, "pull", src, "--plain-http", "-o", pullDir, "--verify=always", "-k", pubPath)
+		require.NoError(t, err)
+		requireSinglePackage(t, pullDir)
+	})
+
+	t.Run("verify always with an unrelated key errors", func(t *testing.T) {
+		pkgPath, _ := signedPackage(t)
+		_, otherPubPath := cosignKeyPair(t)
+		addr := test.SetupInMemoryRegistry(t)
+		dst, _ := ociRefs(addr, "e2e-test")
+
+		_, _, err := e2e.Cargoship(t, "publish", pkgPath, dst,
+			"--plain-http", "--confirm", "--verify=always", "-k", otherPubPath)
+		require.Error(t, err)
+	})
+
+	t.Run("verify never skips a signature that would not validate", func(t *testing.T) {
+		pkgPath, _ := signedPackage(t)
+		_, otherPubPath := cosignKeyPair(t)
+		addr := test.SetupInMemoryRegistry(t)
+		dst, _ := ociRefs(addr, "e2e-test")
+
+		_, _, err := e2e.Cargoship(t, "publish", pkgPath, dst,
+			"--plain-http", "--confirm", "--verify=never", "-k", otherPubPath)
+		require.NoError(t, err)
+	})
+}
+
+// TestCargoshipVerifyFlagParsing pins how --verify takes its value. It carried a
+// NoOptDefVal, which made the space-separated form parse the mode as a positional
+// argument and fail with an argument-count error.
+func TestCargoshipVerifyFlagParsing(t *testing.T) {
+	t.Run("space-separated value is accepted", func(t *testing.T) {
+		pkgPath, pubPath := signedPackage(t)
+		addr := test.SetupInMemoryRegistry(t)
+		dst, _ := ociRefs(addr, "e2e-test")
+
+		_, _, err := e2e.Cargoship(t, "publish", pkgPath, dst,
+			"--plain-http", "--confirm", "--verify", "always", "-k", pubPath)
+		require.NoError(t, err)
+	})
+
+	// Run directly rather than through e2e.Cargoship: that helper appends --no-color and
+	// --tmpdir, and a trailing --verify would consume the first of them as its value.
+	t.Run("without a value errors", func(t *testing.T) {
+		cmd := exec.CommandContext(t.Context(), e2e.CargoBinPath,
+			"pull", "oci://example.invalid/nope:0.0.1", "-o", t.TempDir(), "--no-color", "--verify")
+		out, err := cmd.CombinedOutput()
+		require.Error(t, err)
+		require.Contains(t, string(out), "flag needs an argument")
+	})
+
+	t.Run("an unknown mode errors", func(t *testing.T) {
+		_, stderr, err := e2e.Cargoship(t, "pull", "oci://example.invalid/nope:0.0.1", "-o", t.TempDir(), "--verify", "sometimes")
+		require.Error(t, err)
+		require.Contains(t, stderr, "must be never, if-possible, or always")
 	})
 }
 

--- a/src/test/e2e/noncluster/12_cargoship_sign_test.go
+++ b/src/test/e2e/noncluster/12_cargoship_sign_test.go
@@ -81,7 +81,6 @@ func TestCargoshipSign(t *testing.T) {
 
 		// --verify=always makes the CLI check the existing signature before re-signing, so
 		// this run only succeeds if the signature validates against the matching key.
-		// The flag takes an optional value, so it must be passed as --verify=always.
 		_, _, err = e2e.Cargoship(t, "sign", signed,
 			"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", t.TempDir(),
 			"--overwrite", "--verify=always", "-k", pubPath)

--- a/src/test/e2e/noncluster/helpers_test.go
+++ b/src/test/e2e/noncluster/helpers_test.go
@@ -84,6 +84,21 @@ func copyPackage(t *testing.T, src string) string {
 	return dst
 }
 
+// signedPackage signs the shared testdata package with a fresh key pair and returns the
+// path to the signed copy together with the public key that verifies it. The signed copy
+// lives in t.TempDir(), so callers may re-sign or overwrite it freely.
+func signedPackage(t *testing.T) (pkgPath string, pubPath string) {
+	t.Helper()
+
+	privPath, pubPath := cosignKeyPair(t)
+	outDir := t.TempDir()
+	_, _, err := e2e.Cargoship(t, "sign", minimalPackage(t),
+		"--signing-key", privPath, "--signing-key-pass", cosignKeyPassword, "-o", outDir)
+	require.NoError(t, err)
+
+	return requireSinglePackage(t, outDir), pubPath
+}
+
 // cosignKeyPair generates an ephemeral cosign key pair in t.TempDir() and returns the
 // private and public key paths. Keys are generated per call rather than committed, so the
 // signing tests carry no key material in the repo and two calls yield unrelated keys --


### PR DESCRIPTION
## Description

Signature verification was not enforced where the flags said it was. Two of these came out of the non-cluster e2e work (#234); the third was found while testing the fix for the first, and is the reason the first fix alone changed nothing.

### `distro.Load` dropped the verification options for every non-OCI source

`distro.Load` accepts `VerifyBlobOptions` and `VerificationStrategy`, forwards them in the `oci` branch, and then passes a bare `layout.DistroLayoutOptions{}` to `LoadFromTar` for the `tarball`, `http` and `https` branches. Both fields were discarded.

The zero value of `VerificationStrategy` is `VerifyIfPossible`, so a local package file was always loaded at if-possible regardless of what the caller asked for. `--verify=always` could not be enforced on a local package, and `sign`'s deliberate `VerifyNever` (it verifies separately, after checking `IsSigned`) was ignored too. Fixed by forwarding both fields.

### `publish` ignored `--verify` and `-k`

`publish` registers the full verification flag set through `addVerifyFlags`, but its `distro.Load` call set neither field, so all ten flags were accepted and silently discarded — a package published with `--verify=always --key ./public-key.pem` was never checked. It now sets the strategy and the blob options from the flags, and threads `cmd` into `run()` so `buildVerifyBlobOptions` can tell whether `--insecure-ignore-tlog` was explicitly changed, the same way `sign` does.

Verification was previously reachable only through `pull` and `sign`.

### `--verify always` did not parse

`--verify` carried a `NoOptDefVal` of `always`, so a bare `--verify` meant `--verify=always`. The cost is that pflag then refuses to consume a following argument, so the natural `--verify always` parsed `always` as a positional and failed with `accepts 1 arg(s), received 2`, which reads like a bug in the command line rather than in the flag.

The `NoOptDefVal` is dropped on both the shared verify flag set and `sign`'s own registration. `--verify always` and `--verify=always` both work now, and a bare `--verify` fails with pflag's own `flag needs an argument: --verify`. Every example and doc already used the attached form, so the only doc change is the usage string losing its `[=always]` suffix.

**Breaking:** `--verify` with no value is no longer accepted; it needs one of `never`, `if-possible`, `always`.

## Related Issue

Relates to #234

## Checklist before merging

- [x] Test, docs, adr added or updated as needed

## Verification

`go build ./src/...`, `go vet ./src/...`, `go test ./src/...` and `golangci-lint run ./src/...` are clean. Command docs regenerated with `mage generate:document`.

Checked against the built binary, using a minimal distro definition and two unrelated cosign key pairs:

- `publish --verify=always` on an unsigned package now fails at load with `signature verification failed: package is not signed - verification cannot be performed: no verification material available`, before any registry call. On `main` it published.
- `publish --verify=always -k` with the matching public key passes verification and proceeds; with the second, unrelated key it fails with `invalid signature when validating ASN.1 encoded signature`.
- `publish --verify=never` and the default `if-possible` are unchanged on both signed and unsigned packages.
- `sign` is unaffected: signing an unsigned package, re-signing with `--overwrite --verify=always` and the matching key, failing with the unrelated key, and refusing to re-sign without `--overwrite` all behave as before.
- `pull --verify always`, `--verify=always` and `--verify bogus` parse as expected; bare `--verify` reports `flag needs an argument: --verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)