### PR TITLE
ci: add commit into mage build

### DIFF
--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -20,7 +20,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/colonel-byte/cargoship/src/config"
 	"github.com/colonel-byte/cargoship/src/pkg/utils/build"
 	"github.com/magefile/mage/sh"
 	"golang.org/x/term"
@@ -71,7 +73,7 @@ func hostBuildLocal(oper string, arch string) error {
 	env["CGO_ENABLED"] = "0"
 
 	gc := build.GCFLags()
-	ld := build.LDFlags("0.0.0", "")
+	ld := build.LDFlags(config.UnsetCLIVersion, gitCommit())
 
 	goBuild := fmt.Sprintf(`go build -a -trimpath -gcflags=all="%s" -ldflags "%s" -o %s ./main.go`, gc, ld, bin)
 
@@ -83,6 +85,28 @@ func hostBuildLocal(oper string, arch string) error {
 		"-c",
 		goBuild,
 	)
+}
+
+// gitCommit returns the short commit of the checkout being built, suffixed with "-dirty" when
+// the working tree has uncommitted changes. When the commit cannot be resolved, for example in a
+// source tree with no .git directory or on a machine without git, it returns
+// config.UnsetCLICommit so a local build always stamps something rather than an empty string.
+func gitCommit() string {
+	commit, err := sh.Output("git", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return config.UnsetCLICommit
+	}
+
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return config.UnsetCLICommit
+	}
+
+	if dirty, err := sh.Output("git", "status", "--porcelain"); err == nil && strings.TrimSpace(dirty) != "" {
+		commit += "-dirty"
+	}
+
+	return commit
 }
 
 func clean() error {


### PR DESCRIPTION
## Description

Local `mage` builds now stamp the version and commit the same way release builds do.

`hostBuildLocal` passed `build.LDFlags("0.0.0", "")`, so a locally built binary reported a made-up version and an empty commit. It now passes `config.UnsetCLIVersion` for the version and the actual checkout commit for the build hash.

The new `gitCommit` helper resolves the short `HEAD` commit, appends `-dirty` when the working tree has uncommitted changes, and falls back to `config.UnsetCLICommit` when the commit cannot be resolved at all (a source tree with no `.git` directory, or a machine without `git`), so a local build always stamps something rather than an empty string.

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
