### PR TITLE
fix: add logging into debug on config

### DIFF
--- a/src/pkg/packager/assemble/assemble.go
+++ b/src/pkg/packager/assemble/assemble.go
@@ -74,15 +74,15 @@ type AssembleOptions struct {
 	types.RemoteOptions
 }
 
-// warnUnknownEngineConfig warns about engine config keys the distro version being packaged
-// does not recognize, so a typo is caught here rather than on every node at install time.
+// logUnknownEngineConfig logs engine config keys the distro version being packaged does not
+// recognize, so a typo is visible here rather than only on every node at install time.
 //
-// This only ever warns. The generated schemas cover the versions whose source has been pulled
-// into this build, which is not necessarily the version a package targets, and a package that
-// carries a key this binary has never heard of is still a package worth building. Install
+// This only ever logs, at debug. The generated schemas cover the versions whose source has been
+// pulled into this build, which is not necessarily the version a package targets, and a package
+// that carries a key this binary has never heard of is still a package worth building. Install
 // time keeps the authoritative check, where the key is narrowed to the role the node actually
 // plays and an unrecognized one is dropped from the config it writes.
-func warnUnknownEngineConfig(ctx context.Context, d distro.ZarfDistro) {
+func logUnknownEngineConfig(ctx context.Context, d distro.ZarfDistro) {
 	cfg := engineConfigKeys(d.Spec.Config.Engine[config.EngineConfig])
 	if len(cfg) == 0 {
 		return
@@ -103,7 +103,7 @@ func warnUnknownEngineConfig(ctx context.Context, d distro.ZarfDistro) {
 
 	for _, k := range slices.Sorted(maps.Keys(cfg)) {
 		if _, ok := valid[k]; !ok {
-			l.Warn("engine config key not recognized for this distro/version, it will be dropped at install time",
+			l.Debug("engine config key not recognized for this distro/version, it will be dropped at install time",
 				"distro", d.Spec.Type, "version", d.Spec.Version, "key", k)
 		}
 	}
@@ -125,7 +125,7 @@ func engineConfigKeys(v any) map[string]any {
 func AssembleDistro(ctx context.Context, d distro.ZarfDistro, distroPath string, opts AssembleOptions) (*layout.DistroLayout, error) {
 	l := logger.From(ctx)
 	l.Info("assembling distro", "path", distroPath)
-	warnUnknownEngineConfig(ctx, d)
+	logUnknownEngineConfig(ctx, d)
 
 	buildPath, err := utils.MakeTempDir(config.CommonOptions.TempDirectory)
 	if err != nil {

--- a/src/pkg/packager/assemble/assemble_test.go
+++ b/src/pkg/packager/assemble/assemble_test.go
@@ -123,9 +123,9 @@ func TestReproducibleAssemblyIsDeterministic(t *testing.T) {
 	}
 }
 
-// warnEngineConfigContext gives warnUnknownEngineConfig a logger whose output can be read
-// back, since warning is the whole of what it does.
-func warnEngineConfigContext() (context.Context, *bytes.Buffer) {
+// engineConfigLogContext gives logUnknownEngineConfig a logger whose output can be read
+// back, since logging is the whole of what it does.
+func engineConfigLogContext() (context.Context, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
 	l := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	return logger.WithContext(context.Background(), l), buf
@@ -139,11 +139,11 @@ func engineConfigDistro(version string, cfg dig.Mapping) distro.ZarfDistro {
 	return d
 }
 
-func TestWarnUnknownEngineConfigWarnsOnlyUnknownKeys(t *testing.T) {
-	ctx, buf := warnEngineConfigContext()
+func TestLogUnknownEngineConfigLogsOnlyUnknownKeys(t *testing.T) {
+	ctx, buf := engineConfigLogContext()
 
 	// cluster-cidr is a server-only key, so it also covers the check reading both roles.
-	warnUnknownEngineConfig(ctx, engineConfigDistro("1.36.4-rke2r1", dig.Mapping{
+	logUnknownEngineConfig(ctx, engineConfigDistro("1.36.4-rke2r1", dig.Mapping{
 		"cluster-cidr":  []string{"10.42.0.0/16"},
 		"server":        "https://localhost:9345",
 		"totally-typod": "value",
@@ -151,31 +151,34 @@ func TestWarnUnknownEngineConfigWarnsOnlyUnknownKeys(t *testing.T) {
 
 	out := buf.String()
 	if !strings.Contains(out, "key=totally-typod") {
-		t.Fatalf("warnUnknownEngineConfig did not warn about the unknown key: %s", out)
+		t.Fatalf("logUnknownEngineConfig did not log the unknown key: %s", out)
 	}
 	if strings.Contains(out, "key=cluster-cidr") || strings.Contains(out, "key=server") {
-		t.Fatalf("warnUnknownEngineConfig warned about a known key: %s", out)
+		t.Fatalf("logUnknownEngineConfig logged a known key: %s", out)
+	}
+	if strings.Contains(out, "level=WARN") {
+		t.Fatalf("logUnknownEngineConfig logged above debug: %s", out)
 	}
 }
 
-func TestWarnUnknownEngineConfigUnknownVersionWarnsNothing(t *testing.T) {
-	ctx, buf := warnEngineConfigContext()
+func TestLogUnknownEngineConfigUnknownVersionLogsNoKeys(t *testing.T) {
+	ctx, buf := engineConfigLogContext()
 
-	warnUnknownEngineConfig(ctx, engineConfigDistro("1.99.0-rke2r1", dig.Mapping{
+	logUnknownEngineConfig(ctx, engineConfigDistro("1.99.0-rke2r1", dig.Mapping{
 		"totally-typod": "value",
 	}))
 
-	if out := buf.String(); strings.Contains(out, "level=WARN") {
-		t.Fatalf("warnUnknownEngineConfig warned for a version it has no schema for: %s", out)
+	if out := buf.String(); strings.Contains(out, "key=totally-typod") {
+		t.Fatalf("logUnknownEngineConfig flagged a key for a version it has no schema for: %s", out)
 	}
 }
 
-func TestWarnUnknownEngineConfigEmptyConfigWarnsNothing(t *testing.T) {
-	ctx, buf := warnEngineConfigContext()
+func TestLogUnknownEngineConfigEmptyConfigLogsNothing(t *testing.T) {
+	ctx, buf := engineConfigLogContext()
 
-	warnUnknownEngineConfig(ctx, distro.ZarfDistro{})
+	logUnknownEngineConfig(ctx, distro.ZarfDistro{})
 
 	if out := buf.String(); out != "" {
-		t.Fatalf("warnUnknownEngineConfig logged for a distro with no engine config: %s", out)
+		t.Fatalf("logUnknownEngineConfig logged for a distro with no engine config: %s", out)
 	}
 }

--- a/src/types/distrocfg/rancher_common.go
+++ b/src/types/distrocfg/rancher_common.go
@@ -200,7 +200,7 @@ func (d *RancherCommon) ConfigureEngine(ctx context.Context, host cluster.ZarfHo
 
 // validateEngineConfig drops any config.yaml keys that aren't part of the flag set
 // mage generate:engineConfig extracted for this distro at the given engine version's minor
-// release (see src/pkg/engineconfig/gen), warning about each one removed. If no generated
+// release (see src/pkg/engineconfig/gen), logging each one removed at debug. If no generated
 // config exists for this distro/version -- e.g. a version nobody has pulled/generated yet --
 // there's nothing to check against, so it warns once and leaves cfg untouched, falling back to
 // writing it exactly as before this check existed.
@@ -219,7 +219,7 @@ func (d *RancherCommon) validateEngineConfig(ctx context.Context, version string
 	valid := gen.Keys(target)
 	for k := range cfg {
 		if _, ok := valid[k]; !ok {
-			logger.From(ctx).Warn("engine config key not recognized for this distro/version, dropping it from config.yaml", "distro", d.ID, "version", version, "key", k)
+			logger.From(ctx).Debug("engine config key not recognized for this distro/version, dropping it from config.yaml", "distro", d.ID, "version", version, "key", k)
 			delete(cfg, k)
 		}
 	}

--- a/src/types/distrocfg/rancher_common_test.go
+++ b/src/types/distrocfg/rancher_common_test.go
@@ -39,7 +39,7 @@ import (
 
 func testLoggerContext() (context.Context, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
-	l := slog.New(slog.NewTextHandler(buf, nil))
+	l := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	return logger.WithContext(context.Background(), l), buf
 }
 
@@ -64,6 +64,7 @@ func TestValidateEngineConfigKnownVersionDropsUnknownKeys(t *testing.T) {
 	require.NotContains(t, out, `key=node-name`)
 	require.Contains(t, out, "engine config key not recognized")
 	require.Contains(t, out, `key=totally-typod`)
+	require.NotContains(t, out, "level=WARN")
 }
 
 func TestValidateEngineConfigUnknownVersionBlindlyKeepsAllKeys(t *testing.T) {


### PR DESCRIPTION
## Description

Unrecognized engine config keys are now reported at debug rather than warn, on both sides of the check.

The keys a package carries are frequently valid for the distro version it actually targets while being absent from the schemas generated into this binary, so the warning fired on healthy packages and healthy clusters and taught people to ignore it. The information is still useful when chasing down a key that silently went missing, so it is kept — just at a level that has to be asked for.

Two call sites change:

- `assemble`: `warnUnknownEngineConfig` is renamed `logUnknownEngineConfig` and logs each unknown key at debug. Build time was always advisory; a package carrying a key this binary has never heard of is still worth building.
- `distrocfg`: `RancherCommon.validateEngineConfig`, the path both `apply` and `engine-config-sync` run through, logs each dropped key at debug. The drop itself is unchanged — the key is still removed from the config.yaml written to the node.

The one warn left in place is `no generated engine config schema for this distro/version, skipping config key validation`, which fires once per node and means validation did not run at all.

Tests are updated to assert the messages land at debug and no longer at warn.

## Related Issue

Relates to N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
